### PR TITLE
Use a smaller slice size for ESRI scraping

### DIFF
--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -293,7 +293,7 @@ class EsriRestDownloadTask(DownloadTask):
                 f.write('{\n"type": "FeatureCollection",\n"features": [\n')
                 oid_iter = iter(oids)
                 while True:
-                    oid_chunk = tuple(itertools.islice(oid_iter, 250))
+                    oid_chunk = tuple(itertools.islice(oid_iter, 100))
 
                     if not oid_chunk:
                         break


### PR DESCRIPTION
The 250 slice width was causing problems on some servers.