### PR TITLE
Pin unicodecsv version to 0.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ if sys.version_info[0] == 2:
         'future >= 0.14.3',
         
         # https://github.com/jdunck/python-unicodecsv
-        'unicodecsv >= 0.9.4',
+        # 0.11.1 has a bug https://github.com/jdunck/python-unicodecsv/issues/54
+        'unicodecsv == 0.11.0',
     ]
 
 setup(


### PR DESCRIPTION
Version 0.11.1 has a bug that breaks our Japanese sources;
it doesn't write non-ascii headers correctly. When that's
fixed it should be OK to update to latest again.

https://github.com/jdunck/python-unicodecsv/issues/54