### PR TITLE
[WIP] Communicate directly with EC2

### DIFF
--- a/chef/sources/recipes/default.rb
+++ b/chef/sources/recipes/default.rb
@@ -1,3 +1,5 @@
+package 'git'
+
 git '/var/opt/openaddresses' do
   repository 'https://github.com/openaddresses/openaddresses.git'
   reference 'master'

--- a/openaddr/run.py
+++ b/openaddr/run.py
@@ -122,7 +122,9 @@ parser.add_argument('--bigspender', dest='bid_strategy',
 def main():
     args = parser.parse_args()
     jobs.setup_logger(None)
-    
+    run_ec2(args)
+
+def run_ec2(args):
     tempdir = mkdtemp(prefix='oa-')
     tarball = prepare_tarball(tempdir, args.repository, args.branch)
     

--- a/openaddr/run.py
+++ b/openaddr/run.py
@@ -66,17 +66,17 @@ parser = ArgumentParser(description='Run some source files.')
 parser.add_argument('bucketname',
                     help='Required S3 bucket name.')
 
+parser.add_argument('-r', '--repository', default='https://github.com/openaddresses/machine',
+                    help='Optional git repository to clone. Defaults to "https://github.com/openaddresses/machine".')
+
+parser.add_argument('-b', '--branch', default=__version__,
+                    help='Optional git branch to clone. Defaults to OpenAddresses-Machine version, "{}".'.format(__version__))
+
 parser.add_argument('-a', '--access-key', default=environ.get('AWS_ACCESS_KEY_ID', None),
                     help='Optional AWS access key name for writing to S3. Defaults to value of AWS_ACCESS_KEY_ID environment variable.')
 
 parser.add_argument('-s', '--secret-key', default=environ.get('AWS_SECRET_ACCESS_KEY', None),
                     help='Optional AWS secret key name for writing to S3. Defaults to value of AWS_SECRET_ACCESS_KEY environment variable.')
-
-parser.add_argument('-b', '--branch', default=__version__,
-                    help='Optional git repository to clone. Defaults to OpenAddresses-Machine version, "{}".'.format(__version__))
-
-parser.add_argument('-r', '--repository', default='https://github.com/openaddresses/machine',
-                    help='Optional code branch to clone. Defaults to "https://github.com/openaddresses/machine".')
 
 parser.add_argument('--ec2-access-key',
                     help='Optional AWS access key name for setting up EC2; distinct from access key for populating S3 bucket. Defaults to value of EC2_ACCESS_KEY_ID environment variable or S3 access key.')

--- a/openaddr/run.py
+++ b/openaddr/run.py
@@ -100,16 +100,16 @@ parser.add_argument('--ec2-access-key',
 parser.add_argument('--ec2-secret-key',
                     help='Optional AWS secret key name for setting up EC2; distinct from secret key for populating S3 bucket. Defaults to value of EC2_SECRET_ACCESS_KEY environment variable or S3 secret key.')
 
-parser.add_argument('--instance-type', default='m3.xlarge',
+parser.add_argument('--ec2-instance-type', '--instance-type', default='m3.xlarge',
                     help='EC2 instance type, defaults to m3.xlarge.')
 
-parser.add_argument('--ssh-keypair', default='oa-keypair',
+parser.add_argument('--ec2-ssh-keypair', '--ssh-keypair', default='oa-keypair',
                     help='EC2 SSH key pair name, defaults to "oa-keypair".')
 
-parser.add_argument('--security-group', default='default',
+parser.add_argument('--ec2-security-group', '--security-group', default='default',
                     help='EC2 security group name, defaults to "default".')
 
-parser.add_argument('--machine-image', default='ami-4ae27e22',
+parser.add_argument('--ec2-machine-image', '--machine-image', default='ami-4ae27e22',
                     help='AMI identifier, defaults to Alestic Ubuntu 14.04 (ami-4ae27e22).')
 
 parser.add_argument('--cheapskate', dest='bid_strategy',
@@ -146,8 +146,8 @@ def run_ec2(args):
     ec2_secret_key = args.ec2_secret_key or environ.get('EC2_SECRET_ACCESS_KEY', args.secret_key)
     ec2 = EC2Connection(ec2_access_key, ec2_secret_key)
     
-    bid = get_bid_amount(ec2, args.instance_type, args.bid_strategy)
-    _L.info('Bidding ${:.4f}/hour for {} instance'.format(bid, args.instance_type))
+    bid = get_bid_amount(ec2, args.ec2_instance_type, args.bid_strategy)
+    _L.info('Bidding ${:.4f}/hour for {} instance'.format(bid, args.ec2_instance_type))
     
     #
     # Request a spot instance with 200GB storage.
@@ -155,11 +155,11 @@ def run_ec2(args):
     device_sda1 = BlockDeviceType(size=200, delete_on_termination=True)
     device_map = BlockDeviceMapping(); device_map['/dev/sda1'] = device_sda1
     
-    spot_args = dict(instance_type=args.instance_type, user_data=user_data,
-                     key_name=args.ssh_keypair, block_device_map=device_map,
-                     security_groups=[args.security_group])
+    spot_args = dict(instance_type=args.ec2_instance_type, user_data=user_data,
+                     key_name=args.ec2_ssh_keypair, block_device_map=device_map,
+                     security_groups=[args.ec2_security_group])
 
-    spot_req = ec2.request_spot_instances(bid, args.machine_image, **spot_args)[0]
+    spot_req = ec2.request_spot_instances(bid, args.ec2_machine_image, **spot_args)[0]
 
     _L.info('https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#SpotInstances:search={}'.format(spot_req.id))
     

--- a/openaddr/run.py
+++ b/openaddr/run.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function
 import logging; _L = logging.getLogger('openaddr.run')
 
 from os import environ
@@ -180,13 +181,13 @@ def run_ec2(args):
             client.open_sftp().get('/var/log/cloud-init-output.log', logfile)
             
             with open(logfile) as file:
-                print file.read()
+                _L.info('/var/log/cloud-init-output.log contents:\n\n{}\n'.format(file.read()))
 
     finally:
         spot_req = ec2.get_all_spot_instance_requests(spot_req.id)[0]
         
         if spot_req.instance_id:
-            print 'Shutting down instance {} early'.format(spot_req.instance_id)
+            print('Shutting down instance {} early'.format(spot_req.instance_id))
             ec2.terminate_instances(spot_req.instance_id)
         
         spot_req.cancel()

--- a/openaddr/run.py
+++ b/openaddr/run.py
@@ -7,7 +7,7 @@ from operator import attrgetter
 from itertools import groupby
 from time import time, sleep
 
-from . import jobs
+from . import jobs, __version__
 from boto.ec2 import EC2Connection
 from boto.ec2.blockdevicemapping import BlockDeviceMapping, BlockDeviceType
 
@@ -56,6 +56,12 @@ parser.add_argument('-a', '--access-key', default=environ.get('AWS_ACCESS_KEY_ID
 parser.add_argument('-s', '--secret-key', default=environ.get('AWS_SECRET_ACCESS_KEY', None),
                     help='Optional AWS secret key name for writing to S3. Defaults to value of AWS_SECRET_ACCESS_KEY environment variable.')
 
+parser.add_argument('-b', '--branch', default=__version__,
+                    help='Optional git repository to clone. Defaults to OpenAddresses-Machine version, "{}".'.format(__version__))
+
+parser.add_argument('-r', '--repository', default='https://github.com/openaddresses/machine',
+                    help='Optional code branch to clone. Defaults to "https://github.com/openaddresses/machine".')
+
 parser.add_argument('--ec2-access-key',
                     help='Optional AWS access key name for setting up EC2; distinct from access key for populating S3 bucket. Defaults to value of EC2_ACCESS_KEY_ID environment variable or S3 access key.')
 
@@ -89,13 +95,10 @@ def main():
     #
     # Prepare init script for new EC2 instance to run.
     #
-    with open(join(dirname(__file__), 'VERSION')) as file:
-        version = file.read().strip()
-    
     with open(join(dirname(__file__), 'templates', 'user-data.sh')) as file:
-        user_data = file.read().format(version=version, **args.__dict__)
+        user_data = file.read().format(**args.__dict__)
     
-    _L.info('Prepared {} bytes of instance user data for tag {}'.format(len(user_data), version))
+    _L.info('Prepared {} bytes of instance user data for tag {}'.format(len(user_data), args.branch))
 
     #
     # Figure out how much we're willing to bid on a spot instance.

--- a/openaddr/templates/user-data.sh
+++ b/openaddr/templates/user-data.sh
@@ -1,16 +1,17 @@
 #!/bin/sh -ex
 apt-get update -y
-apt-get install -y git
+while [ ! -f /tmp/machine.tar.gz ]; do sleep 10; done
 
-echo 'cloning' > /var/www/html/state.txt
-git clone -b {branch} {repository} /tmp/machine
+echo 'extracting' > /var/run/machine-state.txt
+mkdir /tmp/machine
+tar -C /tmp/machine -xzf /tmp/machine.tar.gz
 
-echo 'installing' > /var/www/html/state.txt
+echo 'installing' > /var/run/machine-state.txt
 /tmp/machine/ec2/swap.sh
 /tmp/machine/chef/run.sh batchmode
 
-echo 'processing' > /var/www/html/state.txt
+echo 'processing' > /var/run/machine-state.txt
 openaddr-process -a {access_key} -s {secret_key} -l log.txt /var/opt/openaddresses/sources {bucketname}
 
-echo 'terminating' > /var/www/html/state.txt
+echo 'terminating' > /var/run/machine-state.txt
 shutdown -h now

--- a/openaddr/templates/user-data.sh
+++ b/openaddr/templates/user-data.sh
@@ -3,7 +3,7 @@ apt-get update -y
 apt-get install -y git
 
 echo 'cloning' > /var/www/html/state.txt
-git clone -b {version} https://github.com/openaddresses/machine /tmp/machine
+git clone -b {branch} {repository} /tmp/machine
 
 echo 'installing' > /var/www/html/state.txt
 /tmp/machine/ec2/swap.sh

--- a/openaddr/templates/user-data.sh
+++ b/openaddr/templates/user-data.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 apt-get update -y
-apt-get install -y git apache2
+apt-get install -y git
 
 echo 'cloning' > /var/www/html/state.txt
 git clone -b {version} https://github.com/openaddresses/machine /tmp/machine

--- a/openaddr/tests/run.py
+++ b/openaddr/tests/run.py
@@ -1,0 +1,46 @@
+import unittest
+from mock import patch, call, Mock
+
+def not_implemented(*args, **kwargs):
+    raise NotImplementedError()
+
+class TestEC2 (unittest.TestCase):
+
+    @patch('shutil.rmtree')
+    @patch('tempfile.mkdtemp')
+    @patch('subprocess.check_call')
+    @patch('boto.ec2.EC2Connection')
+    @patch('boto.ec2.blockdevicemapping.BlockDeviceType')
+    @patch('boto.ec2.blockdevicemapping.BlockDeviceMapping')
+    def test_main(self, BlockDeviceMapping, BlockDeviceType, EC2Connection, check_call, mkdtemp, rmtree):
+        '''
+        '''
+        ec2_connection = Mock()
+        ec2_connection.get_spot_price_history.return_value = []
+        ec2_connection.request_spot_instances.side_effect = not_implemented
+    
+        EC2Connection.return_value = ec2_connection
+        BlockDeviceMapping.return_value = dict()
+        BlockDeviceType.return_value = 'fake device type'
+        mkdtemp.return_value = '/temp'
+    
+        from ..run import run_ec2, parser
+        
+        with self.assertRaises(NotImplementedError) as e:
+            argv = '-r', 'http://github/openaddresses/machine', '-b', 'master', 'bucket-name'
+            run_ec2(parser.parse_args(argv))
+    
+        check_call.assert_has_calls([
+            call(('git', 'clone', '-q', '-b', 'master', '--bare', 'http://github/openaddresses/machine', '/temp/repo')),
+            call(('git', '--git-dir', '/temp/repo', 'archive', 'master', '-o', '/temp/archive.tar')),
+            call(('gzip', '/temp/archive.tar')),
+            ])
+    
+        rmtree.assert_called_with('/temp/repo')
+    
+        ec2_connection.request_spot_instances.assert_called_with(
+            1.01, 'ami-4ae27e22', key_name='oa-keypair',
+            block_device_map={'/dev/sda1': 'fake device type'},
+            security_groups=['default'], instance_type='m3.xlarge',
+            user_data="#!/bin/sh -ex\napt-get update -y\nwhile [ ! -f /tmp/machine.tar.gz ]; do sleep 10; done\n\necho 'extracting' > /var/run/machine-state.txt\nmkdir /tmp/machine\ntar -C /tmp/machine -xzf /tmp/machine.tar.gz\n\necho 'installing' > /var/run/machine-state.txt\n/tmp/machine/ec2/swap.sh\n/tmp/machine/chef/run.sh batchmode\n\necho 'processing' > /var/run/machine-state.txt\nopenaddr-process -a None -s None -l log.txt /var/opt/openaddresses/sources bucket-name\n\necho 'terminating' > /var/run/machine-state.txt\nshutdown -h now\n"
+            )

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,9 @@ setup(
         # http://initd.org/psycopg/
         'psycopg2 == 2.6',
         
+        # http://www.paramiko.org
+        'paramiko == 1.15.2',
+        
         # https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991/comments/10
         'requests == 2.2.1',
 

--- a/test.py
+++ b/test.py
@@ -23,6 +23,7 @@ from openaddr.tests.expand import TestExpand
 from openaddr.tests.render import TestRender
 from openaddr.tests.util import TestEsri2GeoJSON
 from openaddr.tests.ci import TestHook
+from openaddr.tests.run import TestEC2
 
 if __name__ == '__main__':
     # Allow the user to turn on logging with -l or --logall


### PR DESCRIPTION
Allowed connections to EC2 instance by specifying a key in `openaddr-ec2-run`, and pushing machine code up as a tarball.

* [x] Read back content of `/var/log/cloud-init-output.log`.

Closes #108.