### PR TITLE
Fix incorrect file selection for non-shapefiles

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -255,7 +255,8 @@ def elaborate_filenames(filename):
     if filename is None:
         return []
     
-    base, original_ext = splitext(filename.lower())
+    filename = filename.lower()
+    base, original_ext = splitext(filename)
     
     if original_ext == '.shp':
         return [base + ext for ext in (original_ext, '.shx', '.dbf', '.prj')]


### PR DESCRIPTION
I didn't notice elaborate_filenames only converted to lowercase for shapefiles. This fixes the regression I introduced.

4 sources should be affected by this
```
# grep '"file": ".*[A-Z]\+' *.json  | grep -v .shp                                                                                                                  
au-queensland.json:        "file": "DP_PROP_LOCATION_INDEXQLD/WholeOfState_20140530.txt",
fi-uusimaa.json:        "file": "Paakaupunkiseudun_osoiteluettelo/PKS_avoin_osoiteluettelo.csv",
is.json:        "file": "STADFANG.dsv",
us-va.json:        "file": "VA_SiteAddress.txt",
```
