### PR TITLE
Remove hard-coded list of keys in conform_smash_case

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -647,9 +647,9 @@ def conform_smash_case(source_definition):
     "Convert all named fields in source_definition object to lowercase. Returns new object."
     new_sd = copy.deepcopy(source_definition)
     conform = new_sd["conform"]
-    for k in ("split", "lat", "lon", "street", "number"):
-        if k in conform:
-            conform[k] = conform[k].lower()
+    for k, v in conform.items():
+        if v not in (X_FIELDNAME, Y_FIELDNAME) and getattr(v, 'lower', None):
+            conform[k] = v.lower()
     if "merge" in conform:
         conform["merge"] = [s.lower() for s in conform["merge"]]
     if "advanced_merge" in conform:
@@ -659,8 +659,7 @@ def conform_smash_case(source_definition):
 
 def row_smash_case(sd, input):
     "Convert all field names to lowercase. Slow, but necessary for imprecise conform specs."
-    output = { k.lower(): v for (k, v) in input.items() if k not in (X_FIELDNAME, Y_FIELDNAME) }
-    output.update({ k: v for (k, v) in input.items() if k in (X_FIELDNAME, Y_FIELDNAME) })
+    output = { k if k in (X_FIELDNAME, Y_FIELDNAME) else k.lower() : v for (k, v) in input.items() }
     return output
 
 def row_merge_street(sd, row):


### PR DESCRIPTION
OK, here am I with another case sensitivity fix. :-)

Any postcode stored in a mixed case key isn't making it into the output because postcode was never added to the hardcoded list in conform_smash_case. Same thing for the keys to be added in #106.

I think it's safe to remove this hardcoded list and just lowercase everything except OA:x/OA:y as row_smash_case does. This will lowercase some extra keys like file and type but it looks like those aren't accessed after conform_smash_case is called anyway.