### PR TITLE
Completed openaddr.ci.worker for EC2

### DIFF
--- a/chef/apache-worker/recipes/default.rb
+++ b/chef/apache-worker/recipes/default.rb
@@ -1,0 +1,1 @@
+package 'apache2'

--- a/chef/apache-worker/recipes/default.rb
+++ b/chef/apache-worker/recipes/default.rb
@@ -1,1 +1,6 @@
 package 'apache2'
+
+directory '/var/www/html/oa-runone' do
+  owner node[:username]
+  mode '0755'
+end

--- a/chef/ec2-hostname/recipes/default.rb
+++ b/chef/ec2-hostname/recipes/default.rb
@@ -1,3 +1,5 @@
+package 'curl'
+
 bash 'hostname' do
   code <<-CODE
     # What is our public DNS name?

--- a/chef/ec2-hostname/recipes/default.rb
+++ b/chef/ec2-hostname/recipes/default.rb
@@ -1,0 +1,17 @@
+bash 'hostname' do
+  code <<-CODE
+    # What is our public DNS name?
+    ipaddr=$(ifconfig eth0 | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{{ print $1}}')
+    fullname=`curl -s http://169.254.169.254/latest/meta-data/public-hostname --connect-timeout 5`
+    shortname=`echo $fullname | cut -d. -f1`
+
+    # Configure host name for Ubuntu.
+    sed -i '/ '$fullname'/ d' /etc/hosts
+    echo "$ipaddr $fullname $shortname" >> /etc/hosts
+    echo $shortname > /etc/hostname
+    hostname -F /etc/hostname
+  CODE
+  
+  # Stop as soon as an error is encountered.
+  flags '-e'
+end

--- a/chef/role-worker.json
+++ b/chef/role-worker.json
@@ -9,6 +9,7 @@
     [
         "openaddr",
         "account",
-        "worker"
+        "worker",
+        "apache-worker"
     ]
 }

--- a/chef/role-worker.json
+++ b/chef/role-worker.json
@@ -9,8 +9,8 @@
     [
         "openaddr",
         "account",
-        "worker",
         "ec2-hostname",
-        "apache-worker"
+        "apache-worker",
+        "worker"
     ]
 }

--- a/chef/role-worker.json
+++ b/chef/role-worker.json
@@ -10,6 +10,7 @@
         "openaddr",
         "account",
         "worker",
+        "ec2-hostname",
         "apache-worker"
     ]
 }

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -124,7 +124,7 @@ def get_touched_branch_files(payload, github_auth):
     return touched
 
 def process_payload_files(payload, github_auth):
-    ''' Return a dictionary of file paths and raw JSON contents.
+    ''' Return a dictionary of file paths to raw JSON contents and file IDs.
     '''
     files = dict()
 
@@ -160,7 +160,7 @@ def process_payload_files(payload, github_auth):
         current_app.logger.debug('Contents SHA {}'.format(contents['sha']))
         
         if encoding == 'base64':
-            files[filename] = b64decode(content).decode('utf8')
+            files[filename] = b64decode(content).decode('utf8'), contents['sha']
         else:
             raise ValueError('Unrecognized encoding "{}"'.format(encoding))
     
@@ -254,8 +254,9 @@ def add_files_to_queue(queue, job_id, job_url, files):
     '''
     tasks = {}
     
-    for (name, content) in files.items():
-        task = queue.put(dict(id=job_id, url=job_url, name=name, content=content))
+    for (name, (content, file_id)) in files.items():
+        task = queue.put(dict(id=job_id, url=job_url, name=name,
+                              content=content, file_id=file_id))
         
         tasks[str(task)] = name
     

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -250,7 +250,7 @@ def create_queued_job(queue, files, job_url_template, status_url):
     file_results = {name: None for name in filenames}
 
     job_id = calculate_job_id(files)
-    job_url = expand(job_url_template, dict(id=job_id))
+    job_url = job_url_template and expand(job_url_template, dict(id=job_id))
     job_status = None
 
     with queue as db:
@@ -344,6 +344,9 @@ def pop_task_from_donequeue(queue, github_auth):
             job_status = True
         
         write_job(db, job_id, job_status, task_files, file_states, file_results, status_url)
+        
+        if not status_url:
+            return
         
         if job_status is False:
             bad_files = [name for (name, state) in file_states.items() if state is False]

--- a/openaddr/ci/run_dequeue.py
+++ b/openaddr/ci/run_dequeue.py
@@ -3,7 +3,7 @@ from time import sleep
 from traceback import print_exc
 
 from . import (
-    db_connect, db_queue, pop_finished_task_from_queue, DONE_QUEUE, load_config
+    db_connect, db_queue, pop_task_from_donequeue, DONE_QUEUE, load_config
     )
 
 def main():
@@ -15,7 +15,7 @@ def main():
         try:
             with db_connect(config['DATABASE_URL']) as conn:
                 queue = db_queue(conn, DONE_QUEUE)
-                pop_finished_task_from_queue(queue, config['GITHUB_AUTH'])
+                pop_task_from_donequeue(queue, config['GITHUB_AUTH'])
         except:
             print >> stderr, '-' * 40
             print_exc(file=stderr)

--- a/openaddr/ci/worker.py
+++ b/openaddr/ci/worker.py
@@ -32,15 +32,20 @@ def do_work(job_id, job_contents):
     os.mkdir(oa_dir)
 
     # Invoke the job to do
-    result_code = subprocess.call(('openaddr-process-one',
-                                   '-l', '%s/logfile.txt' % out_dir,
-                                   out_fn,
-                                   oa_dir))
+    cmd = 'openaddr-process-one', '-l', '%s/logfile.txt' % out_dir, out_fn, oa_dir
+    try:
+        result_stdout = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        message = 'Something went wrong in {0}'.format(*cmd)
+        result_code, result_stdout = e.returncode, None
+    else:
+        result_code, message = 0, MAGIC_OK_MESSAGE
 
     # Prepare return parameters
     r = { 'result_code': result_code,
+          'result_stdout': result_stdout,
           'output_url': urlparse.urljoin(_web_base_url, job_id),
-          'message': MAGIC_OK_MESSAGE }
+          'message': message }
 
     return r
 

--- a/openaddr/ci/worker.py
+++ b/openaddr/ci/worker.py
@@ -12,36 +12,37 @@ from . import db_connect, db_queue, db_queue, MAGIC_OK_MESSAGE, DONE_QUEUE
 
 # File path and URL path for result directory. Should be S3.
 _web_output_dir = '/var/www/html/oa-runone'
-_web_base_url = 'http://{host}/oa-runone/'.format(host=socket.getfqdn())
 
-def do_work(job_id, job_contents):
+def do_work(job_id, job_contents, output_dir):
     "Do the actual work of running a source file in job_contents"
 
     # Make a directory to run the whole job
     assert '/' not in job_id
-    out_dir = '%s/%s' % (_web_output_dir, job_id)
+    out_dir = '%s/%s' % (output_dir, job_id)
     os.mkdir(out_dir)
 
     # Write the user input to a file
-    out_fn = '%s/user_input.txt' % out_dir
+    out_fn = os.path.join(out_dir, 'user_input.txt')
     with file(out_fn, 'wb') as out_fp:
         out_fp.write(job_contents)
 
     # Make a directory in which to run openaddr
-    oa_dir = '%s/%s' % (out_dir, 'out')
+    oa_dir = os.path.join(out_dir, 'out')
     os.mkdir(oa_dir)
 
     # Invoke the job to do
-    cmd = 'openaddr-process-one', '-l', '%s/logfile.txt' % out_dir, out_fn, oa_dir
+    cmd = 'openaddr-process-one', '-l', os.path.join(out_dir, 'logfile.txt'), out_fn, oa_dir
     try:
         result_stdout = subprocess.check_output(cmd)
     except subprocess.CalledProcessError as e:
         message = 'Something went wrong in {0}'.format(*cmd)
-        result_code, result_stdout, output_url = e.returncode, None, None
+        result_code, result_stdout, output_url = e.returncode, e.output, None
     else:
         result_code, message = 0, MAGIC_OK_MESSAGE
-        state_path = os.path.relpath(result_stdout.strip(), _web_output_dir)
-        output_url = urlparse.urljoin(_web_base_url, state_path)
+
+        output_base = 'http://{host}/oa-runone/'.format(host=socket.getfqdn())
+        state_path = os.path.relpath(result_stdout.strip(), output_dir)
+        output_url = urlparse.urljoin(output_base, state_path)
 
     # Prepare return parameters
     r = { 'result_code': result_code,
@@ -51,7 +52,7 @@ def do_work(job_id, job_contents):
 
     return r
 
-def run(task_data):
+def run(task_data, output_dir):
     "Run a task posted to the queue. Handles the JSON for task and result objects."
 
     print "Got job %s" % task_data
@@ -63,7 +64,7 @@ def run(task_data):
     name = task_data['name']
 
     # Run the task
-    result = do_work(job_id, content)
+    result = do_work(job_id, content, output_dir)
 
     # Prepare a result object
     r = { 'id' : job_id,
@@ -85,7 +86,7 @@ def main():
         task = input_queue.get()
         # PQ will return NULL after 1 second timeout if not ask
         if task:
-            task_output_data = run(task.data)
+            task_output_data = run(task.data, _web_output_dir)
             output_queue.put(task_output_data)
 
 

--- a/openaddr/ci/worker.py
+++ b/openaddr/ci/worker.py
@@ -6,13 +6,13 @@ Jobs get enqueued to a PQ task queue by some other system.
 This program pops jobs and runs them one at a time, then
 enqueues a new message on a separate PQ queue when the work is done."""
 
-import time, os, subprocess, psycopg2
+import time, os, subprocess, psycopg2, urlparse, socket
 
 from . import db_connect, db_queue, db_queue, MAGIC_OK_MESSAGE, DONE_QUEUE
 
 # File path and URL path for result directory. Should be S3.
 _web_output_dir = '/var/www/html/oa-runone'
-_web_base_url = 'http://minar.us.to/oa-runone'
+_web_base_url = 'http://{host}/oa-runone/'.format(host=socket.getfqdn())
 
 def do_work(job_id, job_contents):
     "Do the actual work of running a source file in job_contents"
@@ -39,7 +39,7 @@ def do_work(job_id, job_contents):
 
     # Prepare return parameters
     r = { 'result_code': result_code,
-          'output_url': '%s/%s' % (_web_base_url, job_id),
+          'output_url': urlparse.urljoin(_web_base_url, job_id),
           'message': MAGIC_OK_MESSAGE }
 
     return r

--- a/openaddr/ci/worker.py
+++ b/openaddr/ci/worker.py
@@ -34,17 +34,19 @@ def do_work(job_id, job_contents):
     # Invoke the job to do
     cmd = 'openaddr-process-one', '-l', '%s/logfile.txt' % out_dir, out_fn, oa_dir
     try:
-        result_stdout = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        result_stdout = subprocess.check_output(cmd)
     except subprocess.CalledProcessError as e:
         message = 'Something went wrong in {0}'.format(*cmd)
-        result_code, result_stdout = e.returncode, None
+        result_code, result_stdout, output_url = e.returncode, None, None
     else:
         result_code, message = 0, MAGIC_OK_MESSAGE
+        state_path = os.path.relpath(result_stdout.strip(), _web_output_dir)
+        output_url = urlparse.urljoin(_web_base_url, state_path)
 
     # Prepare return parameters
     r = { 'result_code': result_code,
           'result_stdout': result_stdout,
-          'output_url': urlparse.urljoin(_web_base_url, job_id),
+          'output_url': output_url,
           'message': message }
 
     return r

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -12,7 +12,7 @@ os.environ['GITHUB_TOKEN'] = ''
 os.environ['DATABASE_URL'] = environ.get('DATABASE_URL', 'postgres:///hooked_on_sources')
 
 from ..ci import (
-    app, db_connect, db_cursor, db_queue, pop_finished_task_from_queue,
+    app, db_connect, db_cursor, db_queue, pop_task_from_donequeue,
     TASK_QUEUE, DONE_QUEUE, MAGIC_OK_MESSAGE
     )
 
@@ -40,7 +40,7 @@ class TestHook (unittest.TestCase):
         '''
         return
         
-        with db_connect(app) as conn:
+        with db_connect(self.database_url) as conn:
             with db_cursor(conn) as db:
                 db.execute('TRUNCATE jobs')
                 db.execute('TRUNCATE queue')
@@ -132,7 +132,7 @@ class TestHook (unittest.TestCase):
         
             # Handle completion task and check with Github.
             with HTTMock(self.response_content):
-                pop_finished_task_from_queue(db_queue(conn, DONE_QUEUE), self.github_auth)
+                pop_task_from_donequeue(db_queue(conn, DONE_QUEUE), self.github_auth)
         
             # Check that Github knows the job to have been completed successfully.
             self.assertEqual(self.last_status_state, 'success')
@@ -170,7 +170,7 @@ class TestHook (unittest.TestCase):
         
                 # Handle completion tasks and check with Github.
                 with HTTMock(self.response_content):
-                    pop_finished_task_from_queue(db_queue(conn, DONE_QUEUE), self.github_auth)
+                    pop_task_from_donequeue(db_queue(conn, DONE_QUEUE), self.github_auth)
                 
                 # Check that Github already knows the job to have been completed unsuccessfully.
                 self.assertEqual(self.last_status_state, 'failure')
@@ -209,7 +209,7 @@ class TestHook (unittest.TestCase):
         
                 # Handle completion tasks and check with Github.
                 with HTTMock(self.response_content):
-                    pop_finished_task_from_queue(db_queue(conn, DONE_QUEUE), self.github_auth)
+                    pop_task_from_donequeue(db_queue(conn, DONE_QUEUE), self.github_auth)
                 
                 if index == 0:
                     # Check that Github still thinks it's pending.

--- a/test.py
+++ b/test.py
@@ -22,7 +22,7 @@ from openaddr.tests.conform import TestConformCli, TestConformTransforms, TestCo
 from openaddr.tests.expand import TestExpand
 from openaddr.tests.render import TestRender
 from openaddr.tests.util import TestEsri2GeoJSON
-from openaddr.tests.ci import TestHook
+from openaddr.tests.ci import TestHook, TestWorker
 from openaddr.tests.run import TestEC2
 
 if __name__ == '__main__':


### PR DESCRIPTION
Setup for EC2 usage of openaddr workers, including URLs of output data and chef setup for public hostnames. Reports errors from `openaddr-process-one` and tracks source file IDs for future use in `runs` table.