### PR TITLE
Reduce repeated runs

### DIFF
--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -473,7 +473,7 @@ class TestRuns (unittest.TestCase):
     @patch('openaddr.ci.DUETASK_DELAY', new=timedelta(seconds=1))
     @patch('openaddr.ci.worker.do_work')
     def test_working_run(self, do_work):
-        '''
+        ''' Test a boring successful run.
         '''
         source = b'''{
             "coverage": { "US Census": {"geoid": "0653000", "place": "Oakland city", "state": "California"} },
@@ -524,7 +524,7 @@ class TestRuns (unittest.TestCase):
     @patch('openaddr.ci.DUETASK_DELAY', new=timedelta(seconds=1))
     @patch('openaddr.compat.check_output')
     def test_failing_run(self, check_output):
-        '''
+        ''' Test a run that fails.
         '''
         def raises_unexpected_error(cmd, timeout=None):
             raise NotImplementedError('Everything is ruined.')
@@ -588,7 +588,7 @@ class TestRuns (unittest.TestCase):
     @patch('openaddr.ci.DUETASK_DELAY', new=timedelta(seconds=1))
     @patch('openaddr.ci.worker.do_work')
     def test_overdue_run(self, do_work):
-        '''
+        ''' Test a run that succeeds past its due date.
         '''
         def returns_plausible_result(s3, run_id, source_name, content, output_dir):
             return dict(message=MAGIC_OK_MESSAGE, output={"source": "user_input.txt"})
@@ -647,7 +647,7 @@ class TestRuns (unittest.TestCase):
     @patch('openaddr.ci.DUETASK_DELAY', new=timedelta(seconds=1))
     @patch('openaddr.ci.worker.do_work')
     def test_double_run(self, do_work):
-        '''
+        ''' Test repeated run that's fast enough to take advantage of reuse.
         '''
         source = b'''{
             "coverage": { "US Census": {"geoid": "0653000", "place": "Oakland city", "state": "California"} },
@@ -660,7 +660,7 @@ class TestRuns (unittest.TestCase):
             return dict(message=MAGIC_OK_MESSAGE, output={"source": "user_input.txt"}, result_code=0, result_stdout='...')
         
         def raises_an_error(s3, run_id, source_name, content, output_dir):
-            raise Exception('Nope')
+            raise Exception('Worker did not know to re-use previous run')
         
         # Do the work.
         with db_connect(self.database_url) as conn, HTTMock(self.response_content):
@@ -687,7 +687,7 @@ class TestRuns (unittest.TestCase):
                 self.assertEqual(db_source_id, source_id)
                 self.assertTrue(de64(bytes(db_source_data)).startswith('{'))
      
-            do_work.side_effect = raises_an_error
+            do_work.side_effect = raises_an_error # won't be called anyway
             self.last_status_state = None
 
             create_queued_job(task_Q, files, self.fake_job_template_url, self.fake_status_url)

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -642,7 +642,62 @@ class TestRuns (unittest.TestCase):
                 self.assertEqual(db_source_path, source_path)
                 self.assertEqual(db_source_id, source_id)
                 self.assertTrue(de64(bytes(db_source_data)).startswith('{'))
+
+    @patch('openaddr.jobs.JOB_TIMEOUT', new=timedelta(seconds=1))
+    @patch('openaddr.ci.DUETASK_DELAY', new=timedelta(seconds=1))
+    @patch('openaddr.ci.worker.do_work')
+    def test_double_run(self, do_work):
+        '''
+        '''
+        source = b'''{
+            "coverage": { "US Census": {"geoid": "0653000", "place": "Oakland city", "state": "California"} },
+            "data": "http://data.openoakland.org/sites/default/files/OakParcelsGeo2013_0.zip"
+            }'''
+        
+        source_id, source_path = '0xDEADBEEF', 'sources/us-ca-oakland.json'
+        
+        def returns_plausible_result(s3, run_id, source_name, content, output_dir):
+            return dict(message=MAGIC_OK_MESSAGE, output={"source": "user_input.txt"})
+        
+        def raises_an_error(s3, run_id, source_name, content, output_dir):
+            raise Exception('Nope')
+        
+        # Do the work.
+        with db_connect(self.database_url) as conn, HTTMock(self.response_content):
+            task_Q = db_queue(conn, TASK_QUEUE)
+            done_Q = db_queue(conn, DONE_QUEUE)
+            due_Q = db_queue(conn, DUE_QUEUE)
+
+            do_work.side_effect = returns_plausible_result
+
+            files = {source_path: (en64(source), source_id)}
+            create_queued_job(task_Q, files, self.fake_job_template_url, self.fake_status_url)
+            pop_task_from_taskqueue(self.s3, task_Q, done_Q, due_Q, self.output_dir)
+            self.assertEqual(self.last_status_state, None, 'Should be nothing yet')
+            
+            # Work done!
+            pop_task_from_donequeue(done_Q, self.github_auth)
+            self.assertEqual(self.last_status_state, 'success', 'Should be "success" now')
+            
+            # Find a record of this run.
+            with done_Q as db:
+                db.execute('SELECT source_path, source_id, source_data FROM runs')
+                ((db_source_path, db_source_id, db_source_data), ) = db.fetchall()
+                self.assertEqual(db_source_path, source_path)
+                self.assertEqual(db_source_id, source_id)
+                self.assertTrue(de64(bytes(db_source_data)).startswith('{'))
      
+            do_work.side_effect = raises_an_error
+            self.last_status_state = None
+
+            create_queued_job(task_Q, files, self.fake_job_template_url, self.fake_status_url)
+            pop_task_from_taskqueue(self.s3, task_Q, done_Q, due_Q, self.output_dir)
+            self.assertEqual(self.last_status_state, None, 'Should be nothing still')
+            
+            # Work done again!
+            pop_task_from_donequeue(done_Q, self.github_auth)
+            self.assertEqual(self.last_status_state, 'success', 'Should be "success" again')
+
 class TestWorker (unittest.TestCase):
 
     def setUp(self):

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -657,7 +657,7 @@ class TestRuns (unittest.TestCase):
         source_id, source_path = '0xDEADBEEF', 'sources/us-ca-oakland.json'
         
         def returns_plausible_result(s3, run_id, source_name, content, output_dir):
-            return dict(message=MAGIC_OK_MESSAGE, output={"source": "user_input.txt"})
+            return dict(message=MAGIC_OK_MESSAGE, output={"source": "user_input.txt"}, result_code=0, result_stdout='...')
         
         def raises_an_error(s3, run_id, source_name, content, output_dir):
             raise Exception('Nope')
@@ -697,6 +697,12 @@ class TestRuns (unittest.TestCase):
             # Work done again!
             pop_task_from_donequeue(done_Q, self.github_auth)
             self.assertEqual(self.last_status_state, 'success', 'Should be "success" again')
+            
+            # Ensure that no new run was created
+            with done_Q as db:
+                db.execute('SELECT count(id) FROM runs')
+                (count, ) = db.fetchone()
+                self.assertEqual(count, 1, 'There should still be just one run')
 
 class TestWorker (unittest.TestCase):
 


### PR DESCRIPTION
Uses a five-day time limit to prevent re-runs of identical sources.

Closes #133.