### PR TITLE
Re-use correct run status

### DIFF
--- a/openaddr/ci/schema.pgsql
+++ b/openaddr/ci/schema.pgsql
@@ -8,7 +8,8 @@ CREATE TABLE runs
     source_data         BYTEA,
     datetime            TIMESTAMP,
     -- commit_id?
-    state               JSON
+    state               JSON,
+    status              BOOLEAN
 );
 
 DROP TABLE IF EXISTS jobs;


### PR DESCRIPTION
Copy runs when reusing them, and ensure that status is handled correctly.

Added `status` boolean column to `runs` table.

Closes #137.