### PR TITLE
Mark run copies

### DIFF
--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -491,8 +491,8 @@ def copy_run(db, run_id):
     ''' Duplicate a previous run and return its new ID.
     '''
     db.execute('''INSERT INTO runs
-                  (source_path, source_id, source_data, state, status, datetime)
-                  SELECT source_path, source_id, source_data, state, status,
+                  (copy_of, source_path, source_id, source_data, state, status, datetime)
+                  SELECT id, source_path, source_id, source_data, state, status,
                          NOW() AT TIME ZONE 'UTC'
                   FROM runs
                   WHERE id = %s''',

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -504,6 +504,21 @@ def copy_run(db, run_id):
     
     return run_id
 
+def get_previously_completed_run(db, file_id):
+    ''' Look for an existing run on this file ID within the reuse timeout limit.
+    '''
+    interval = '{} seconds'.format(RUN_REUSE_TIMEOUT.seconds + RUN_REUSE_TIMEOUT.days * 86400)
+    
+    db.execute('''SELECT id, state, status FROM runs
+                  WHERE source_id = %s
+                    AND datetime > (NOW() AT TIME ZONE 'UTC') - INTERVAL %s
+                    AND status IS NOT NULL
+                    AND copy_of IS NULL
+                  ORDER BY id DESC LIMIT 1''',
+               (file_id, interval))
+    
+    return db.fetchone()
+
 def update_job_status(db, job_id, job_url, filenames, task_files, file_states, file_results, status_url, github_auth):
     '''
     '''
@@ -544,18 +559,7 @@ def pop_task_from_taskqueue(s3, task_queue, done_queue, due_queue, output_dir):
         _L.info('Got job {job_id} from task queue'.format(**task.data))
         passed_on_keys = 'job_id', 'file_id', 'name', 'url', 'content_b64'
         passed_on_kwargs = {k: task.data.get(k) for k in passed_on_keys}
-        
-        # Look for an existing run on this file ID within the reuse timeout limit.
-        interval = '{} seconds'.format(RUN_REUSE_TIMEOUT.seconds + RUN_REUSE_TIMEOUT.days * 86400)
-        
-        db.execute('''SELECT id, state, status FROM runs
-                      WHERE source_id = %s
-                        AND datetime > (NOW() AT TIME ZONE 'UTC') - INTERVAL %s
-                        AND status IS NOT NULL
-                      ORDER BY datetime DESC LIMIT 1''',
-                   (passed_on_kwargs['file_id'], interval))
-        
-        previous_run = db.fetchone()
+        previous_run = get_previously_completed_run(db, task.data.get('file_id'))
     
         if previous_run:
             # Make a copy of the previous run.

--- a/openaddr/ci/schema.pgsql
+++ b/openaddr/ci/schema.pgsql
@@ -9,7 +9,8 @@ CREATE TABLE runs
     datetime            TIMESTAMP,
     -- commit_id?
     state               JSON,
-    status              BOOLEAN
+    status              BOOLEAN,
+    copy_of             INTEGER REFERENCES runs(id) NULL
 );
 
 DROP TABLE IF EXISTS jobs;

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -180,7 +180,7 @@ class TestHook (unittest.TestCase):
             pop_task_from_taskqueue(self.s3, task_q, done_q, due_q, self.output_dir)
             pop_task_from_donequeue(done_q, self.github_auth)
             
-        self.assertEquals(self.last_status_state, 'failure', 'Bad JSON should lead to failure')
+        self.assertEqual(self.last_status_state, 'failure', 'Bad JSON should lead to failure')
 
     def test_webhook_badutf8_content(self):
         ''' Push a single commit with bad UTF8 source directly to master.
@@ -562,7 +562,7 @@ class TestRuns (unittest.TestCase):
             # Check for result
             with db_cursor(conn) as db:
                 job_status, _, _, _, _ = read_job(db, job_id)
-                self.assertEquals(job_status, None, 'Status should be null at this early stage')
+                self.assertEqual(job_status, None, 'Status should be null at this early stage')
 
             sleep(2.1)
             
@@ -575,7 +575,7 @@ class TestRuns (unittest.TestCase):
             # Check for result
             with db_cursor(conn) as db:
                 job_status, _, _, _, _ = read_job(db, job_id)
-                self.assertEquals(job_status, False, 'Status should be false after unexpected error')
+                self.assertEqual(job_status, False, 'Status should be false after unexpected error')
             
             # Find a record of this run.
             with done_Q as db:
@@ -625,7 +625,7 @@ class TestRuns (unittest.TestCase):
             # Check for result
             with db_cursor(conn) as db:
                 job_status, _, _, _, _ = read_job(db, job_id)
-                self.assertEquals(job_status, False, 'Status should be false since it took so long')
+                self.assertEqual(job_status, False, 'Status should be false since it took so long')
 
             # The job eventually completes, but it's too late
             pop_task_from_donequeue(done_Q, None)
@@ -634,7 +634,7 @@ class TestRuns (unittest.TestCase):
             # Check for result
             with db_cursor(conn) as db:
                 job_status, _, _, _, _ = read_job(db, job_id)
-                self.assertEquals(job_status, False, 'Status should still be false no matter what')
+                self.assertEqual(job_status, False, 'Status should still be false no matter what')
             
             # Find a record of this run.
             with done_Q as db:

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -683,11 +683,12 @@ class TestRuns (unittest.TestCase):
             
             # Find a record of this run.
             with done_Q as db:
-                db.execute("SELECT id, state->>'nonce', source_path, source_id, source_data FROM runs")
-                ((first_run_id, first_nonce, db_source_path, db_source_id, db_source_data), ) = db.fetchall()
+                db.execute("SELECT id, copy_of, state->>'nonce', source_path, source_id, source_data FROM runs")
+                ((first_run_id, first_copyof, first_nonce, db_source_path, db_source_id, db_source_data), ) = db.fetchall()
                 self.assertEqual(db_source_path, source_path)
                 self.assertEqual(db_source_id, source_id)
                 self.assertTrue(de64(bytes(db_source_data)).startswith('{'))
+                self.assertTrue(first_copyof is None)
      
             do_work.side_effect = raises_an_error # won't be called anyway
             self.last_status_state = None
@@ -706,12 +707,13 @@ class TestRuns (unittest.TestCase):
                 (count, ) = db.fetchone()
                 self.assertEqual(count, 2, 'There should have been two runs')
 
-                db.execute('''SELECT id, state->>'nonce', source_path, source_id, source_data FROM runs
+                db.execute('''SELECT id, copy_of, state->>'nonce', source_path, source_id, source_data FROM runs
                               ORDER BY datetime DESC LIMIT 1''')
 
-                ((second_run_id, second_nonce, db_source_path, db_source_id, db_source_data), ) = db.fetchall()
+                ((second_run_id, second_copyof, second_nonce, db_source_path, db_source_id, db_source_data), ) = db.fetchall()
                 self.assertNotEqual(second_run_id, first_run_id, 'The two runs should be distinct')
                 self.assertEqual(second_nonce, first_nonce, 'The two runs should share the same nonce')
+                self.assertEqual(second_copyof, first_run_id, 'The second run should be a copy of the first')
                 self.assertEqual(db_source_path, source_path)
                 self.assertEqual(db_source_id, source_id)
                 self.assertTrue(de64(bytes(db_source_data)).startswith('{'))


### PR DESCRIPTION
Track which runs are copies, and only use originals to determine repeats.

Closes #141.