### PR TITLE
Move DB queries down to ci.objects module

### DIFF
--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -101,6 +101,24 @@ def add_set(db, owner, repository):
 
     return read_set(db, set_id)
 
+def complete_set(db, set_id, commit_sha):
+    '''
+    '''
+    _L.info(u'Updating set {} in sets table'.format(set_id))
+
+    db.execute('''UPDATE sets
+                  SET datetime_end = NOW(), commit_sha = %s
+                  WHERE id = %s''',
+               (commit_sha, set_id))
+
+def update_set_renders(db, set_id, render_world, render_usa, render_europe):
+    '''
+    '''
+    db.execute('''UPDATE sets
+                  SET render_world = %s, render_usa = %s, render_europe = %s
+                  WHERE id = %s''',
+               (render_world, render_usa, render_europe, set_id))
+
 def read_set(db, set_id):
     '''
     '''

--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -121,7 +121,9 @@ def read_sets(db, past_id):
     
         Returns list of Sets.
     '''
-    db.execute('''SELECT id, commit_sha, datetime_start, datetime_end
+    db.execute('''SELECT id, commit_sha, datetime_start, datetime_end,
+                         render_world, render_europe, render_usa,
+                         owner, repository
                   FROM sets WHERE id < COALESCE(%s, 2^64)
                   ORDER BY id DESC LIMIT 25''',
                (past_id, ))

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -25,12 +25,13 @@ from ..ci import (
     db_connect, db_cursor, db_queue, recreate_db, worker,
     pop_task_from_donequeue, pop_task_from_taskqueue, pop_task_from_duequeue,
     create_queued_job, TASK_QUEUE, DONE_QUEUE, DUE_QUEUE, MAGIC_OK_MESSAGE,
-    enqueue_sources, find_batch_sources, add_run, set_run, render_set_maps
+    enqueue_sources, find_batch_sources, render_set_maps
     )
 
 from ..ci.objects import (
     add_job, write_job, read_job, read_jobs,
-    Set, add_set, complete_set, update_set_renders, read_set, read_sets
+    Set, add_set, complete_set, update_set_renders, read_set, read_sets,
+    add_run, set_run
     )
 
 from ..jobs import JOB_TIMEOUT

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -29,7 +29,8 @@ from ..ci import (
     )
 
 from ..ci.objects import (
-    add_job, write_job, read_job, read_jobs, add_set, read_set, read_sets, Set
+    add_job, write_job, read_job, read_jobs,
+    Set, add_set, complete_set, update_set_renders, read_set, read_sets
     )
 
 from ..jobs import JOB_TIMEOUT
@@ -135,6 +136,28 @@ class TestObjects (unittest.TestCase):
                ])
         
         read_set.assert_called_with(self.db, 123)
+
+    def test_complete_set(self):
+        ''' Check behavior of objects.complete_set()
+        '''
+        complete_set(self.db, 123, 'abc')
+
+        self.db.execute.assert_called_once_with(
+               '''UPDATE sets
+                  SET datetime_end = NOW(), commit_sha = %s
+                  WHERE id = %s''',
+                  ('abc', 123))
+
+    def test_update_set_renders(self):
+        ''' Check behavior of objects.update_set_renders()
+        '''
+        update_set_renders(self.db, 123, 'http://w', 'http://usa', 'http://eu')
+
+        self.db.execute.assert_called_once_with(
+               '''UPDATE sets
+                  SET render_world = %s, render_usa = %s, render_europe = %s
+                  WHERE id = %s''',
+                  ('http://w', 'http://usa', 'http://eu', 123))
 
     def test_read_set(self):
         ''' Check behavior of objects.read_set()

--- a/test.py
+++ b/test.py
@@ -22,7 +22,7 @@ from openaddr.tests.conform import TestConformCli, TestConformTransforms, TestCo
 from openaddr.tests.expand import TestExpand
 from openaddr.tests.render import TestRender
 from openaddr.tests.util import TestEsri2GeoJSON
-from openaddr.tests.ci import TestHook, TestRuns, TestWorker, TestBatch
+from openaddr.tests.ci import TestHook, TestRuns, TestWorker, TestBatch, TestObjects
 from openaddr.tests.run import TestEC2
 
 if __name__ == '__main__':


### PR DESCRIPTION
This should make it easier to create a `Run` class and determine what DB indexes might be needed.

Closes #172.