### PR TITLE
Add new merge behavior [WIP]

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -27,7 +27,7 @@ ogr.UseExceptions()
 # Field names for use in cached CSV files.
 # We add columns to the extracted CSV with our own data with these names.
 GEOM_FIELDNAME = 'OA:geom'
-X_FIELDNAME, Y_FIELDNAME = 'OA:x', 'OA:y'
+X_FIELDNAME, Y_FIELDNAME, STREET_FIELDNAME = 'OA:x', 'OA:y', 'OA:street'
 
 geometry_types = {
     ogr.wkbPoint: 'Point',
@@ -672,7 +672,7 @@ def row_merge_street(sd, row):
         row['auto_street'] = ' '.join(merge_data)
     else:
         merge_data = [row[field] for field in sd["conform"]["street"]]
-        row['OA:STREET'] = ' '.join(merge_data)
+        row[STREET_FIELDNAME] = ' '.join(merge_data)
     return row
 
 def row_advanced_merge(sd, row):
@@ -717,7 +717,7 @@ def row_convert_to_out(sd, row):
     "Convert a row from the source schema to OpenAddresses output schema"
     # note: sd["conform"]["lat"] and lon were already applied in the extraction from source
     if type(sd['conform']["street"]) is list:
-        street_key = 'OA:STREET'
+        street_key = STREET_FIELDNAME
     else:
         street_key = sd['conform']["street"]
     city_key = sd['conform'].get('city', False)

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -633,7 +633,7 @@ def row_transform_and_convert(sd, row):
     row = row_smash_case(sd, row)
 
     c = sd["conform"]
-    if "merge" in c:
+    if "merge" in c or type(c["street"]) is list:
         row = row_merge_street(sd, row)
     if "advanced_merge" in c:
         row = row_advanced_merge(sd, row)
@@ -651,6 +651,8 @@ def conform_smash_case(source_definition):
     for k, v in conform.items():
         if v not in (X_FIELDNAME, Y_FIELDNAME) and getattr(v, 'lower', None):
             conform[k] = v.lower()
+    if type(conform["street"]) is list:
+        conform["street"] = [s.lower() for s in conform["street"]]
     if "merge" in conform:
         conform["merge"] = [s.lower() for s in conform["merge"]]
     if "advanced_merge" in conform:
@@ -665,8 +667,12 @@ def row_smash_case(sd, input):
 
 def row_merge_street(sd, row):
     "Merge multiple columns like 'Maple','St' to 'Maple St'"
-    merge_data = [row[field] for field in sd["conform"]["merge"]]
-    row['auto_street'] = ' '.join(merge_data)
+    if "merge" in sd["conform"]:
+        merge_data = [row[field] for field in sd["conform"]["merge"]]
+        row['auto_street'] = ' '.join(merge_data)
+    else:
+        merge_data = [row[field] for field in sd["conform"]["street"]]
+        row['OA:STREET'] = ' '.join(merge_data)
     return row
 
 def row_advanced_merge(sd, row):
@@ -710,6 +716,10 @@ def row_round_lat_lon(sd, row):
 def row_convert_to_out(sd, row):
     "Convert a row from the source schema to OpenAddresses output schema"
     # note: sd["conform"]["lat"] and lon were already applied in the extraction from source
+    if type(sd['conform']["street"]) is list:
+        street_key = 'OA:STREET'
+    else:
+        street_key = sd['conform']["street"]
     city_key = sd['conform'].get('city', False)
     district_key = sd['conform'].get('district', False)
     region_key = sd['conform'].get('region', False)
@@ -719,7 +729,7 @@ def row_convert_to_out(sd, row):
         "LON": row.get(X_FIELDNAME, None),
         "LAT": row.get(Y_FIELDNAME, None),
         "NUMBER": row.get(sd["conform"]["number"], None),
-        "STREET": row.get(sd["conform"]["street"], None),
+        "STREET": row.get(street_key, None) if street_key else None,
         "CITY": row.get(city_key, None) if city_key else None,
         "DISTRICT": row.get(district_key, None) if district_key else None,
         "REGION": row.get(region_key, None) if region_key else None,

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -56,7 +56,7 @@ class TestConformTransforms (unittest.TestCase):
 
         d = { "conform": { "street": [ "n", "t" ] } }
         r = row_merge_street(d, {"n": "MAPLE", "t": "ST", "x": "foo"})
-        self.assertEqual({"OA:STREET": "MAPLE ST", "x": "foo", "t": "ST", "n": "MAPLE"}, r)
+        self.assertEqual({"OA:street": "MAPLE ST", "x": "foo", "t": "ST", "n": "MAPLE"}, r)
 
     def test_row_advanced_merge(self):
         c = { "conform": { "advanced_merge": {

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -36,6 +36,13 @@ class TestConformTransforms (unittest.TestCase):
                            "advanced_merge": { "auto_street": { "fields": ["mixed", "upper"] } } } },
                          r)
 
+        d = { "conform": { "street": [ "U", "l", "MiXeD" ], "number": "U", "split": "U", "lat": "Y", "lon": "x",
+                           "advanced_merge": { "auto_street": { "fields": ["MiXeD", "UPPER"] } } } }
+        r = conform_smash_case(d)
+        self.assertEqual({ "conform": { "street": [ "u", "l", "mixed" ], "number": "u", "split": "u", "lat": "y", "lon": "x",
+                           "advanced_merge": { "auto_street": { "fields": ["mixed", "upper"] } } } },
+                         r)
+
     def test_row_convert_to_out(self):
         d = { "conform": { "street": "s", "number": "n" } }
         r = row_convert_to_out(d, {"s": "MAPLE LN", "n": "123", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3"})
@@ -46,6 +53,10 @@ class TestConformTransforms (unittest.TestCase):
         d = { "conform": { "merge": [ "n", "t" ] } }
         r = row_merge_street(d, {"n": "MAPLE", "t": "ST", "x": "foo"})
         self.assertEqual({"auto_street": "MAPLE ST", "x": "foo", "t": "ST", "n": "MAPLE"}, r)
+
+        d = { "conform": { "street": [ "n", "t" ] } }
+        r = row_merge_street(d, {"n": "MAPLE", "t": "ST", "x": "foo"})
+        self.assertEqual({"OA:STREET": "MAPLE ST", "x": "foo", "t": "ST", "n": "MAPLE"}, r)
 
     def test_row_advanced_merge(self):
         c = { "conform": { "advanced_merge": {
@@ -71,6 +82,11 @@ class TestConformTransforms (unittest.TestCase):
 
     def test_transform_and_convert(self):
         d = { "conform": { "street": "auto_street", "number": "n", "merge": ["s1", "s2"], "lon": "y", "lat": "x" } }
+        r = row_transform_and_convert(d, { "n": "123", "s1": "MAPLE", "s2": "ST", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3" })
+        self.assertEqual({"STREET": "Maple Street", "NUMBER": "123", "LON": "-119.2", "LAT": "39.3",
+                          "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None}, r)
+
+        d = { "conform": { "street": ["s1", "s2"], "number": "n", "lon": "y", "lat": "x" } }
         r = row_transform_and_convert(d, { "n": "123", "s1": "MAPLE", "s2": "ST", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3" })
         self.assertEqual({"STREET": "Maple Street", "NUMBER": "123", "LON": "-119.2", "LAT": "39.3",
                           "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None}, r)

--- a/openaddr/tests/conforms/lake-man-merge-postcode.json
+++ b/openaddr/tests/conforms/lake-man-merge-postcode.json
@@ -4,13 +4,12 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "merge": [
+        "street": [
             "ST_NAME",
             "ST_TYPE"
         ],
         "lon": "X",
         "lat": "Y",
-        "street": "auto_street",
         "number": "HOUSE_NUM",
         "type": "shapefile",
         "postcode": "ZIPCODE"

--- a/openaddr/tests/sources/pl-dolnoslaskie.json
+++ b/openaddr/tests/sources/pl-dolnoslaskie.json
@@ -13,11 +13,7 @@
     "conform": {
         "srs": "EPSG:2180",
         "lon": "X",
-        "merge": [
-            "ulc_nazwa",
-            "mjs_nazwa"
-        ],
-        "street": "auto_street",
+        "street": ["ulc_nazwa", "mjs_nazwa"],
         "number": "pad_numer_porzadkowy",
         "lat": "Y",
         "file": "punkty_adr_v2/dolnoslaskie.gml",

--- a/openaddr/tests/sources/us-ut.json
+++ b/openaddr/tests/sources/us-ut.json
@@ -8,7 +8,7 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "merge": [
+        "street": [
             "StreetName",
             "StreetType"
         ],
@@ -17,7 +17,6 @@
         "lon": "x",
         "lat": "y",
         "number": "AddNum",
-        "street": "auto_street",
         "postcode": "zipcode"
     }
 }


### PR DESCRIPTION
At the moment we have several internal machine functions whose output is forced upon the user.

The one I run into the most is the merge function. The user is forced to relate `merge: ['',''] => street: 'auto_street'`. 

This PR changes this behavior merging arrays automatically. 

so `{ merge: {'PRE','STR'}, street: 'auto_street'} `.  becomes `{ street: ['PRE','STR'] }`

cc/ @migurski (successor to #179 )