### PR TITLE
Betterfxn

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -397,6 +397,14 @@ class ConvertToCsvTask(object):
         # Conversion must have failed
         return None, 0
 
+def convert_regexp_replace(replace):
+    ''' Convert regular expression replace string from $ syntax to slash-syntax.
+    '''
+    if re.search(r'\$\d\b', replace):
+        return re.sub(r'\$(\d)\b', r'\\1', replace)
+    
+    return replace    
+
 def ogr_source_to_csv(source_definition, source_path, dest_path):
     "Convert a single shapefile or GeoJSON in source_path and put it in dest_path"
     in_datasource = ogr.Open(source_path, 0)

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -94,7 +94,6 @@ class ConformResult:
 class DecompressionError(Exception):
     pass
 
-
 class DecompressionTask(object):
     @classmethod
     def from_type_string(clz, type_string):
@@ -674,8 +673,14 @@ def conform_smash_case(source_definition):
     for k, v in conform.items():
         if v not in (X_FIELDNAME, Y_FIELDNAME) and getattr(v, 'lower', None):
             conform[k] = v.lower()
-        if type(k) is list and k in conform:
+        if type(conform[k]) is list:
            conform[k] = [s.lower() for s in conform[k]] 
+        if type(conform[k]) is dict:
+            if "field" in conform[k]:
+                conform[k]["field"] = conform[k]["field"]
+            elif "fields" in conform[k]:
+                conform[k]["fields"] = [s.lower() for s in conform[k]["fields"]]
+    
     if "advanced_merge" in conform:
         for new_col, spec in conform["advanced_merge"].items():
             spec["fields"] = [s.lower() for s in spec["fields"]]

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -656,9 +656,9 @@ def row_transform_and_convert(sd, row):
 
     ### Deprecated ###
     if "advanced_merge" in c:
-        row = row_fxn_merge(sd, row)
+        row = row_fxn_merge(sd, row, False)
     if "split" in c:
-        row = row_fxn_split(sd, row)
+        row = row_fxn_split(sd, row, False)
     ##################
     
     row2 = row_convert_to_out(sd, row)

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -27,7 +27,15 @@ ogr.UseExceptions()
 # Field names for use in cached CSV files.
 # We add columns to the extracted CSV with our own data with these names.
 GEOM_FIELDNAME = 'OA:geom'
-X_FIELDNAME, Y_FIELDNAME, STREET_FIELDNAME = 'OA:x', 'OA:y', 'OA:street'
+X_FIELDNAME, Y_FIELDNAME = 'OA:x', 'OA:y'
+attrib_types = { 
+    'street':   'OA:street',
+    'number':   'OA:number',
+    'city':     'OA:city',
+    'postcode': 'OA:postcode',
+    'district': 'OA:district',
+    'region':   'OA:region'
+}
 
 geometry_types = {
     ogr.wkbPoint: 'Point',
@@ -633,8 +641,15 @@ def row_transform_and_convert(sd, row):
     row = row_smash_case(sd, row)
 
     c = sd["conform"]
-    if "merge" in c or type(c["street"]) is list:
-        row = row_merge_street(sd, row)
+    
+    "Attribute tags can utilize processing fxns"
+    for k, v in c.items():
+        if k in attrib_types and type(c[k]) is list:
+            "Lists are a concat shortcut to concat fields with spaces"
+            row = row_merge(sd, row, k)
+        if k in attrib_types and type(c[k]) is dict:
+            "Dicts are custom processing functions"
+
     if "advanced_merge" in c:
         row = row_advanced_merge(sd, row)
     if "split" in c:
@@ -651,10 +666,8 @@ def conform_smash_case(source_definition):
     for k, v in conform.items():
         if v not in (X_FIELDNAME, Y_FIELDNAME) and getattr(v, 'lower', None):
             conform[k] = v.lower()
-    if type(conform["street"]) is list:
-        conform["street"] = [s.lower() for s in conform["street"]]
-    if "merge" in conform:
-        conform["merge"] = [s.lower() for s in conform["merge"]]
+        if type(k) is list and k in conform:
+           conform[k] = [s.lower() for s in conform[k]] 
     if "advanced_merge" in conform:
         for new_col, spec in conform["advanced_merge"].items():
             spec["fields"] = [s.lower() for s in spec["fields"]]
@@ -665,14 +678,10 @@ def row_smash_case(sd, input):
     output = { k if k in (X_FIELDNAME, Y_FIELDNAME) else k.lower() : v for (k, v) in input.items() }
     return output
 
-def row_merge_street(sd, row):
+def row_merge(sd, row, key):
     "Merge multiple columns like 'Maple','St' to 'Maple St'"
-    if "merge" in sd["conform"]:
-        merge_data = [row[field] for field in sd["conform"]["merge"]]
-        row['auto_street'] = ' '.join(merge_data)
-    else:
-        merge_data = [row[field] for field in sd["conform"]["street"]]
-        row[STREET_FIELDNAME] = ' '.join(merge_data)
+    merge_data = [row[field] for field in sd["conform"][key]]
+    row[attrib_types[key]] = ' '.join(merge_data)
     return row
 
 def row_advanced_merge(sd, row):
@@ -716,24 +725,23 @@ def row_round_lat_lon(sd, row):
 def row_convert_to_out(sd, row):
     "Convert a row from the source schema to OpenAddresses output schema"
     # note: sd["conform"]["lat"] and lon were already applied in the extraction from source
-    if type(sd['conform']["street"]) is list:
-        street_key = STREET_FIELDNAME
-    else:
-        street_key = sd['conform']["street"]
-    city_key = sd['conform'].get('city', False)
-    district_key = sd['conform'].get('district', False)
-    region_key = sd['conform'].get('region', False)
-    postcode_key = sd['conform'].get('postcode', False)
     
+    keys = {}
+    for k, v in attrib_types.items():
+        if attrib_types[k] in row:
+            keys[k] = attrib_types[k]
+        else:
+            keys[k] = sd['conform'].get(k, False)
+
     return {
         "LON": row.get(X_FIELDNAME, None),
         "LAT": row.get(Y_FIELDNAME, None),
-        "NUMBER": row.get(sd["conform"]["number"], None),
-        "STREET": row.get(street_key, None) if street_key else None,
-        "CITY": row.get(city_key, None) if city_key else None,
-        "DISTRICT": row.get(district_key, None) if district_key else None,
-        "REGION": row.get(region_key, None) if region_key else None,
-        "POSTCODE": row.get(postcode_key, None) if postcode_key else None,
+        "NUMBER": row.get(keys['number'], None) if keys['number'] else None,
+        "STREET": row.get(keys['street'], None) if keys['street'] else None,
+        "CITY": row.get(keys['city'], None) if keys['city'] else None,
+        "DISTRICT": row.get(keys['district'], None) if keys['district'] else None,
+        "REGION": row.get(keys['region'], None) if keys['region'] else None,
+        "POSTCODE": row.get(keys['postcode'], None) if keys['postcode'] else None,
     }
 
 ### File-level conform code. Inputs and outputs are filenames.

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -677,7 +677,7 @@ def conform_smash_case(source_definition):
            conform[k] = [s.lower() for s in conform[k]] 
         if type(conform[k]) is dict:
             if "field" in conform[k]:
-                conform[k]["field"] = conform[k]["field"]
+                conform[k]["field"] = conform[k]["field"].lower()
             elif "fields" in conform[k]:
                 conform[k]["fields"] = [s.lower() for s in conform[k]["fields"]]
     

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -399,9 +399,32 @@ class ConvertToCsvTask(object):
 
 def convert_regexp_replace(replace):
     ''' Convert regular expression replace string from $ syntax to slash-syntax.
+        
+        Replace one kind of replacement, then call self recursively to find others.
     '''
     if re.search(r'\$\d\b', replace):
-        return re.sub(r'\$(\d)\b', r'\\1', replace)
+        # $d back-reference followed by a word break.
+        return convert_regexp_replace(re.sub(r'\$(\d)\b', r'\\\g<1>', replace))
+    
+    if re.search(r'\$\d\D', replace):
+        # $d back-reference followed by an non-digit character.
+        return convert_regexp_replace(re.sub(r'\$(\d)(\D)', r'\\\g<1>\g<2>', replace))
+    
+    if re.search(r'\$\d+\b', replace):
+        # $dd* back-reference followed by a word break.
+        return convert_regexp_replace(re.sub(r'\$(\d+)\b', r'\\\g<1>', replace))
+    
+    if re.search(r'\$\{\d\}', replace):
+        # ${d} back-reference.
+        return convert_regexp_replace(re.sub(r'\$\{(\d)\}', r'\\g<\g<1>>', replace))
+    
+    if re.search(r'\$\d+\D', replace):
+        # $dd* back-reference followed by an non-digit character.
+        return convert_regexp_replace(re.sub(r'\$(\d+)(\D)', r'\\\g<1>\g<2>', replace))
+    
+    if re.search(r'\$\{\d+\}', replace):
+        # ${dd*} back-reference.
+        return convert_regexp_replace(re.sub(r'\$\{(\d+)\}', r'\\g<\g<1>>', replace))
     
     return replace    
 

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -724,8 +724,12 @@ def row_fxn_split(sd, row, key):
         row['auto_street'] = cols[1] if len(cols) > 1 else ''
     else: ## New Behavior
         fxn = sd["conform"][key]
-        regex = re.compile(fxn.get("regex", ""))
-        row[attrib_types[key]] = regex.match(row[fxn["field"]]).group()
+        regex = re.compile(fxn.get("regex", False))
+        match = regex.match(row[fxn["field"]])
+        if match: 
+            row[attrib_types[key]] = match.group()
+        else:
+            row[attrib_types[key]] = ""
     return row
 
 def row_canonicalize_street_and_number(sd, row):

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -649,16 +649,16 @@ def row_transform_and_convert(sd, row):
             row = row_merge(sd, row, k)
         if k in attrib_types and type(c[k]) is dict:
             "Dicts are custom processing functions"
-            if c[k]["function"] == "merge":
-                row = row_fxn_merge(sd, row, k) 
-            elif c[k]["function"] == "split":
-                row = row_fxn_split(sd, row, k)
+            if c[k]["function"] == "join":
+                row = row_fxn_join(sd, row, k) 
+            elif c[k]["function"] == "extract":
+                row = row_fxn_extract(sd, row, k)
 
     ### Deprecated ###
     if "advanced_merge" in c:
-        row = row_fxn_merge(sd, row, False)
+        row = row_fxn_join(sd, row, False)
     if "split" in c:
-        row = row_fxn_split(sd, row, False)
+        row = row_fxn_extract(sd, row, False)
     ##################
     
     row2 = row_convert_to_out(sd, row)
@@ -697,7 +697,7 @@ def row_merge(sd, row, key):
     row[attrib_types[key]] = ' '.join(merge_data)
     return row
 
-def row_fxn_merge(sd, row, key):
+def row_fxn_join(sd, row, key):
     "Create new columns by merging arbitrary other columns with a separator"
     if not key: ## Deprecated Behavior
         advanced_merge = sd["conform"]["advanced_merge"]
@@ -716,7 +716,7 @@ def row_fxn_merge(sd, row, key):
             _L.debug("Failure to merge row %r %s", e, row)
     return row
 
-def row_fxn_split(sd, row, key):
+def row_fxn_extract(sd, row, key):
     "Split addresses like '123 Maple St' into '123' and 'Maple St'"
     if not key: ## Deprecated Behavior
         cols = row[sd["conform"]["split"]].split(' ', 1)  # maxsplit

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -725,7 +725,7 @@ def row_fxn_extract(sd, row, key):
     else: ## New Behavior
         fxn = sd["conform"][key]
         regex = re.compile(fxn.get("regex", False))
-        match = regex.match(row[fxn["field"]])
+        match = regex.search(row[fxn["field"]])
         if match: 
             row[attrib_types[key]] = match.group()
         else:

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -727,7 +727,7 @@ def row_fxn_extract(sd, row, key):
         regex = re.compile(fxn.get("regex", False))
         match = regex.search(row[fxn["field"]])
         if match: 
-            row[attrib_types[key]] = match.group()
+            row[attrib_types[key]] = ''.join(match.groups())
         else:
             row[attrib_types[key]] = ""
     return row

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -746,7 +746,7 @@ def row_fxn_regexp(sd, row, key):
         pattern = re.compile(fxn.get("pattern", False))
         replace = fxn.get('replace', False)
         if replace:
-            match = re.sub(pattern, replace, row[fxn["field"]])
+            match = re.sub(pattern, convert_regexp_replace(replace), row[fxn["field"]])
             row[attrib_types[key]] = match;
         else:
             match = pattern.search(row[fxn["field"]])

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -649,9 +649,9 @@ def row_transform_and_convert(sd, row):
             row = row_merge(sd, row, k)
         if k in attrib_types and type(c[k]) is dict:
             "Dicts are custom processing functions"
-            if c[k]["fxn"] == "merge":
+            if c[k]["function"] == "merge":
                 row = row_fxn_merge(sd, row, k) 
-            elif c[k]["fxn"] == "split":
+            elif c[k]["function"] == "split":
                 row = row_fxn_split(sd, row, k)
 
     ### Deprecated ###

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -402,21 +402,9 @@ def convert_regexp_replace(replace):
         
         Replace one kind of replacement, then call self recursively to find others.
     '''
-    if re.search(r'\$\d\b', replace):
-        # $d back-reference followed by a word break.
-        return convert_regexp_replace(re.sub(r'\$(\d)\b', r'\\\g<1>', replace))
-    
-    if re.search(r'\$\d\D', replace):
-        # $d back-reference followed by an non-digit character.
-        return convert_regexp_replace(re.sub(r'\$(\d)(\D)', r'\\\g<1>\g<2>', replace))
-    
     if re.search(r'\$\d+\b', replace):
         # $dd* back-reference followed by a word break.
         return convert_regexp_replace(re.sub(r'\$(\d+)\b', r'\\\g<1>', replace))
-    
-    if re.search(r'\$\{\d\}', replace):
-        # ${d} back-reference.
-        return convert_regexp_replace(re.sub(r'\$\{(\d)\}', r'\\g<\g<1>>', replace))
     
     if re.search(r'\$\d+\D', replace):
         # $dd* back-reference followed by an non-digit character.

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -227,6 +227,10 @@ class TestOA (unittest.TestCase):
         
         with csvopen(output_path, encoding='utf8') as input:
             rows = list(csvDictReader(input, encoding='utf8'))
+            self.assertEqual(rows[1]['NUMBER'], '2147')
+            self.assertEqual(rows[10]['NUMBER'], '605')
+            self.assertEqual(rows[100]['NUMBER'], '167')
+            self.assertEqual(rows[1000]['NUMBER'], '322')
             self.assertEqual(rows[1]['STREET'], 'Broadway')
             self.assertEqual(rows[10]['STREET'], 'Hillsborough Street')
             self.assertEqual(rows[100]['STREET'], '8th Street')
@@ -474,6 +478,9 @@ class TestOA (unittest.TestCase):
         
         with csvopen(output_path, encoding='utf8') as input:
             rows = list(csvDictReader(input, encoding='utf8'))
+            self.assertEqual(rows[1]['NUMBER'], u'5')
+            self.assertEqual(rows[10]['NUMBER'], u'8')
+            self.assertEqual(rows[100]['NUMBER'], u'5a')
             self.assertEqual(rows[1]['STREET'], u'Ulica Dolnych Wa\u0142\xf3w  Gliwice')
             self.assertEqual(rows[10]['STREET'], u'Ulica Dolnych Wa\u0142\xf3w  Gliwice')
             self.assertEqual(rows[100]['STREET'], u'Plac Place Inwalid\xf3w Wojennych  Gliwice')

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -12,7 +12,7 @@ All logging is suppressed unless --logall or -l specified
 
 
 from __future__ import absolute_import, division, print_function
-from ..compat import standard_library, csvDictReader
+from ..compat import standard_library, csvopen, csvDictReader
 
 import unittest
 import shutil
@@ -222,6 +222,15 @@ class TestOA (unittest.TestCase):
         self.assertTrue('ZIPCODE' in sample_data[0])
         self.assertTrue('OAKLAND' in sample_data[1])
         self.assertTrue('94612' in sample_data[1])
+        
+        output_path = join(dirname(state_path), state['processed'])
+        
+        with csvopen(output_path, encoding='utf8') as input:
+            rows = list(csvDictReader(input, encoding='utf8'))
+            self.assertEqual(rows[1]['STREET'], 'Broadway')
+            self.assertEqual(rows[10]['STREET'], 'Hillsborough Street')
+            self.assertEqual(rows[100]['STREET'], '8th Street')
+            self.assertEqual(rows[1000]['STREET'], 'Hanover Avenue')
 
     def test_single_car(self):
         ''' Test complete process_one.process on Carson sample data.

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -232,6 +232,42 @@ class TestOA (unittest.TestCase):
             self.assertEqual(rows[100]['STREET'], '8th Street')
             self.assertEqual(rows[1000]['STREET'], 'Hanover Avenue')
 
+    def test_single_sf(self):
+        ''' Test complete process_one.process on San Francisco sample data.
+        '''
+        source = join(self.src_dir, 'us-ca-san_francisco.json')
+        
+        with HTTMock(self.response_content):
+            state_path = process_one.process(source, self.testdir)
+        
+        with open(state_path) as file:
+            state = dict(zip(*json.load(file)))
+        
+        self.assertTrue(state['cache'] is not None)
+        self.assertTrue(state['processed'] is not None)
+        self.assertTrue(state['sample'] is not None)
+        self.assertEqual(state['geometry type'], 'Point')
+        
+        with open(join(dirname(state_path), state['sample'])) as file:
+            sample_data = json.load(file)
+        
+        self.assertEqual(len(sample_data), 6)
+        self.assertTrue('ZIPCODE' in sample_data[0])
+        self.assertTrue('94102' in sample_data[1])
+        
+        output_path = join(dirname(state_path), state['processed'])
+        
+        with csvopen(output_path, encoding='utf8') as input:
+            rows = list(csvDictReader(input, encoding='utf8'))
+            self.assertEqual(rows[1]['NUMBER'], '27')
+            self.assertEqual(rows[10]['NUMBER'], '42')
+            self.assertEqual(rows[100]['NUMBER'], '209')
+            self.assertEqual(rows[1000]['NUMBER'], '1415')
+            self.assertEqual(rows[1]['STREET'], 'Octavia Street')
+            self.assertEqual(rows[10]['STREET'], 'Golden Gate Avenue')
+            self.assertEqual(rows[100]['STREET'], 'Octavia Street')
+            self.assertEqual(rows[1000]['STREET'], 'Folsom Street')
+
     def test_single_car(self):
         ''' Test complete process_one.process on Carson sample data.
         '''

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -433,6 +433,14 @@ class TestOA (unittest.TestCase):
         self.assertTrue('pad_numer_porzadkowy' in sample_data[0])
         self.assertTrue(u'Gliwice' in sample_data[1])
         self.assertTrue(u'Ulica Dworcowa ' in sample_data[1])
+        
+        output_path = join(dirname(state_path), state['processed'])
+        
+        with csvopen(output_path, encoding='utf8') as input:
+            rows = list(csvDictReader(input, encoding='utf8'))
+            self.assertEqual(rows[1]['STREET'], u'Ulica Dolnych Wa\u0142\xf3w  Gliwice')
+            self.assertEqual(rows[10]['STREET'], u'Ulica Dolnych Wa\u0142\xf3w  Gliwice')
+            self.assertEqual(rows[100]['STREET'], u'Plac Place Inwalid\xf3w Wojennych  Gliwice')
 
     def test_single_jp_f(self):
         ''' Test complete process_one.process on Japanese sample data.

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -28,13 +28,13 @@ class TestConformTransforms (unittest.TestCase):
 
     def test_conform_smash_case(self):
         d = { "conform": { "street": [ "U", "l", "MiXeD" ], "number": "U", "split": "U", "lat": "Y", "lon": "x",
-                           "city": { "fxn": "merge", "fields": ["ThIs","FiELd"], "separator": "-" },
-                           "district": { "fxn": "split", "field": "ThaT", "regex": ""},
+                           "city": { "function": "merge", "fields": ["ThIs","FiELd"], "separator": "-" },
+                           "district": { "function": "split", "field": "ThaT", "regex": ""},
                            "advanced_merge": { "auto_street": { "fields": ["MiXeD", "UPPER"] } } } }
         r = conform_smash_case(d)
         self.assertEqual({ "conform": { "street": [ "u", "l", "mixed" ], "number": "u", "split": "u", "lat": "y", "lon": "x",
-                           "city": {"fields": ["this", "field"], "fxn": "merge", "separator": "-"},
-                           "district": { "field": "that", "fxn": "split", "regex": ""},
+                           "city": {"fields": ["this", "field"], "function": "merge", "separator": "-"},
+                           "district": { "field": "that", "function": "split", "regex": ""},
                            "advanced_merge": { "auto_street": { "fields": ["mixed", "upper"] } } } },
                          r)
 
@@ -68,11 +68,11 @@ class TestConformTransforms (unittest.TestCase):
         "New fxn merge"
         c = { "conform": {
             "number": {
-                "fxn": "merge",
+                "function": "merge",
                 "fields": ["a1"]
             },
             "street": {
-                "fxn": "merge",
+                "function": "merge",
                 "fields": ["b1","b2"],
                 "separator": "-"
             }
@@ -99,12 +99,12 @@ class TestConformTransforms (unittest.TestCase):
         "New fxn split"
         c = { "conform": { 
             "number": {
-                "fxn": "split",
+                "function": "split",
                 "field": "ADDRESS",
                 "regex": "^[0-9]+"
             },
             "street": {
-                "fxn": "split",
+                "function": "split",
                 "field": "ADDRESS",
                 "regex": "fake"
             }

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import copy
 import json
+import re
 
 import unittest
 import tempfile
@@ -444,7 +445,57 @@ class TestConformMisc(unittest.TestCase):
     def test_convert_regexp_replace(self):
         '''
         '''
-        self.assertEqual(convert_regexp_replace('$1'), r'\1')
+        crr = convert_regexp_replace
+        
+        self.assertEqual(crr('$1'), r'\1')
+        self.assertEqual(crr('$9'), r'\9')
+        self.assertEqual(crr('$b'), '$b')
+        self.assertEqual(crr('$1yo$1'), r'\1yo\1')
+        self.assertEqual(crr('$9yo$9'), r'\9yo\9')
+        self.assertEqual(crr('$byo$b'), '$byo$b')
+        self.assertEqual(crr('$1 yo $1'), r'\1 yo \1')
+        self.assertEqual(crr('$9 yo $9'), r'\9 yo \9')
+        self.assertEqual(crr('$b yo $b'), '$b yo $b')
+
+        self.assertEqual(crr('$11'), r'\11')
+        self.assertEqual(crr('$99'), r'\99')
+        self.assertEqual(crr('$bb'), '$bb')
+        self.assertEqual(crr('$11yo$11'), r'\11yo\11')
+        self.assertEqual(crr('$99yo$99'), r'\99yo\99')
+        self.assertEqual(crr('$bbyo$bb'), '$bbyo$bb')
+        self.assertEqual(crr('$11 yo $11'), r'\11 yo \11')
+        self.assertEqual(crr('$99 yo $99'), r'\99 yo \99')
+        self.assertEqual(crr('$bb yo $bb'), '$bb yo $bb')
+
+        self.assertEqual(crr('${1}1'), r'\g<1>1')
+        self.assertEqual(crr('${9}9'), r'\g<9>9')
+        self.assertEqual(crr('${9}b'), r'\g<9>b')
+        self.assertEqual(crr('${b}b'), '${b}b')
+        self.assertEqual(crr('${1}1yo${1}1'), r'\g<1>1yo\g<1>1')
+        self.assertEqual(crr('${9}9yo${9}9'), r'\g<9>9yo\g<9>9')
+        self.assertEqual(crr('${9}byo${9}b'), r'\g<9>byo\g<9>b')
+        self.assertEqual(crr('${b}byo${b}b'), '${b}byo${b}b')
+        self.assertEqual(crr('${1}1 yo ${1}1'), r'\g<1>1 yo \g<1>1')
+        self.assertEqual(crr('${9}9 yo ${9}9'), r'\g<9>9 yo \g<9>9')
+        self.assertEqual(crr('${9}b yo ${9}b'), r'\g<9>b yo \g<9>b')
+        self.assertEqual(crr('${b}b yo ${b}b'), '${b}b yo ${b}b')
+
+        self.assertEqual(crr('${11}1'), r'\g<11>1')
+        self.assertEqual(crr('${99}9'), r'\g<99>9')
+        self.assertEqual(crr('${99}b'), r'\g<99>b')
+        self.assertEqual(crr('${bb}b'), '${bb}b')
+        self.assertEqual(crr('${11}1yo${11}1'), r'\g<11>1yo\g<11>1')
+        self.assertEqual(crr('${99}9yo${99}9'), r'\g<99>9yo\g<99>9')
+        self.assertEqual(crr('${99}byo${99}b'), r'\g<99>byo\g<99>b')
+        self.assertEqual(crr('${bb}byo${bb}b'), '${bb}byo${bb}b')
+        self.assertEqual(crr('${11}1yo${11}1'), r'\g<11>1yo\g<11>1')
+        self.assertEqual(crr('${99}9 yo ${99}9'), r'\g<99>9 yo \g<99>9')
+        self.assertEqual(crr('${99}b yo ${99}b'), r'\g<99>b yo \g<99>b')
+        self.assertEqual(crr('${bb}b yo ${bb}b'), '${bb}b yo ${bb}b')
+        
+        self.assertEqual(re.sub(r'hello (world)', crr('goodbye $1'), 'hello world'), 'goodbye world')
+        self.assertEqual(re.sub(r'(hello) (world)', crr('goodbye $2'), 'hello world'), 'goodbye world')
+        self.assertEqual(re.sub(r'he(ll)o', crr('he$1$1o'), 'hello'), 'hellllo')
 
     def test_find_shapefile_source_path(self):
         shp_conform = {"conform": { "type": "shapefile" } }

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -96,17 +96,38 @@ class TestConformTransforms (unittest.TestCase):
         self.assertEqual(r["auto_number"], "")
         self.assertEqual(r["auto_street"], "")
 
+        "Regex split"
+        c = { "conform": {
+            "number": {
+                "function": "extract",
+                "field": "ADDRESS",
+                "regex": "^([0-9]+)"
+            },
+            "street": {
+                "function": "extract",
+                "field": "ADDRESS",
+                "regex": "(?:[0-9]+ )(.*)"
+            }
+        } }
+        d = { "ADDRESS": "123 MAPLE ST" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:number": "123", "OA:street": "MAPLE ST" })
+        
+        d = row_fxn_extract(c, d, "number")
+        d = row_fxn_extract(c, d, "street")
+        self.assertEqual(e, d)
+
         "New fxn extract"
         c = { "conform": { 
             "number": {
                 "function": "extract",
                 "field": "ADDRESS",
-                "regex": "^[0-9]+"
+                "regex": "^([0-9]+)"
             },
             "street": {
                 "function": "extract",
                 "field": "ADDRESS",
-                "regex": "fake"
+                "regex": "(fake)"
             }
         } }
         d = { "ADDRESS": "123 MAPLE ST" }

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -28,9 +28,13 @@ class TestConformTransforms (unittest.TestCase):
 
     def test_conform_smash_case(self):
         d = { "conform": { "street": [ "U", "l", "MiXeD" ], "number": "U", "split": "U", "lat": "Y", "lon": "x",
+                           "city": { "fxn": "merge", "fields": ["ThIs","FiELd"], "separator": "-" },
+                           "district": { "fxn": "split", "field": "ThaT", "regex": ""},
                            "advanced_merge": { "auto_street": { "fields": ["MiXeD", "UPPER"] } } } }
         r = conform_smash_case(d)
         self.assertEqual({ "conform": { "street": [ "u", "l", "mixed" ], "number": "u", "split": "u", "lat": "y", "lon": "x",
+                           "city": {"fields": ["this", "field"], "fxn": "merge", "separator": "-"},
+                           "district": { "field": "that", "fxn": "split", "regex": ""},
                            "advanced_merge": { "auto_street": { "fields": ["mixed", "upper"] } } } },
                          r)
 

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -42,7 +42,7 @@ class TestConformTransforms (unittest.TestCase):
 
     def test_row_merge(self):
         d = { "conform": { "street": [ "n", "t" ] } }
-        r = row_merge(d, {"n": "MAPLE", "t": "ST", "x": "foo"})
+        r = row_merge(d, {"n": "MAPLE", "t": "ST", "x": "foo"}, 'street')
         self.assertEqual({"OA:street": "MAPLE ST", "x": "foo", "t": "ST", "n": "MAPLE"}, r)
 
     def test_row_fxn_merge(self):
@@ -51,19 +51,19 @@ class TestConformTransforms (unittest.TestCase):
                 "new_b": { "fields": ["b1", "b2"] },
                 "new_c": { "separator": "-", "fields": ["c1", "c2"] } } } }
         d = { "a1": "va1", "b1": "vb1", "b2": "vb2", "c1": "vc1", "c2": "vc2" }
-        r = row_fxn_merge(c, d)
+        r = row_fxn_merge(c, d, False)
         e = copy.deepcopy(d)
         e.update({ "new_a": "va1", "new_b": "vb1 vb2", "new_c": "vc1-vc2"})
         self.assertEqual(e, d)
 
     def test_row_fxn_split(self):
         d = { "conform": { "split": "ADDRESS" } }
-        r = row_fxn_split(d, { "ADDRESS": "123 MAPLE ST" })
+        r = row_fxn_split(d, { "ADDRESS": "123 MAPLE ST" }, False)
         self.assertEqual({"ADDRESS": "123 MAPLE ST", "auto_street": "MAPLE ST", "auto_number": "123"}, r)
-        r = row_fxn_split(d, { "ADDRESS": "265" })
+        r = row_fxn_split(d, { "ADDRESS": "265" }, False)
         self.assertEqual(r["auto_number"], "265")
         self.assertEqual(r["auto_street"], "")
-        r = row_fxn_split(d, { "ADDRESS": "" })
+        r = row_fxn_split(d, { "ADDRESS": "" }, False)
         self.assertEqual(r["auto_number"], "")
         self.assertEqual(r["auto_street"], "")
 

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -103,13 +103,13 @@ class TestConformTransforms (unittest.TestCase):
                 "function": "regexp",
                 "field": "ADDRESS",
                 "pattern": "^([0-9]+)(?:.*)",
-                "replace": "\\1"
+                "replace": "$1"
             },
             "street": {
                 "function": "regexp",
                 "field": "ADDRESS",
                 "pattern": "(?:[0-9]+ )(.*)",
-                "replace": "\\1"
+                "replace": "$1"
             }
         } }
         d = { "ADDRESS": "123 MAPLE ST" }

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -16,7 +16,7 @@ from ..conform import (
     row_fxn_regexp, row_smash_case, row_round_lat_lon, row_merge,
     row_extract_and_reproject, row_convert_to_out, row_fxn_join,
     row_canonicalize_street_and_number, conform_smash_case, conform_cli,
-    csvopen, csvDictReader
+    csvopen, csvDictReader, convert_regexp_replace
     )
 
 class TestConformTransforms (unittest.TestCase):
@@ -440,6 +440,12 @@ class TestConformCli (unittest.TestCase):
 
 
 class TestConformMisc(unittest.TestCase):
+
+    def test_convert_regexp_replace(self):
+        '''
+        '''
+        self.assertEqual(convert_regexp_replace('$1'), r'\1')
+
     def test_find_shapefile_source_path(self):
         shp_conform = {"conform": { "type": "shapefile" } }
         self.assertEqual("foo.shp", find_source_path(shp_conform, ["foo.shp"]))

--- a/openaddr/tests/conforms/lake-man-merge-postcode2.json
+++ b/openaddr/tests/conforms/lake-man-merge-postcode2.json
@@ -4,14 +4,13 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "merge": [
+        "street": [
             "FEANME",
             "FEATYP"
         ],
         "lon": "X",
         "lat": "Y",
         "number": "ST_NUM",
-        "street": "auto_street",
         "type": "shapefile",
         "postcode": "ZIPCODE"
     }

--- a/openaddr/tests/sources/pl-lodzkie.json
+++ b/openaddr/tests/sources/pl-lodzkie.json
@@ -13,11 +13,7 @@
     "conform": {
         "srs": "EPSG:2180",
         "lon": "X",
-        "merge": [
-            "ulc_nazwa",
-            "mjs_nazwa"
-        ],
-        "street": "auto_street",
+        "street": ["ulc_nazwa", "mjs_nazwa"],
         "number": "pad_numer_porzadkowy",
         "lat": "Y",
         "file": "punkty_adr_v2/lodzkie.gml",

--- a/openaddr/tests/sources/us-ca-alameda_county.json
+++ b/openaddr/tests/sources/us-ca-alameda_county.json
@@ -15,14 +15,10 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "merge": [
-            "FEANME",
-            "FEATYP"
-        ],
         "lon": "X",
         "lat": "Y",
         "number": "ST_NUM",
-        "street": "auto_street",
+        "street": ["FEANME", "FEATYP"],
         "type": "shapefile"
     }
 }

--- a/openaddr/tests/sources/us-ca-san_francisco.json
+++ b/openaddr/tests/sources/us-ca-san_francisco.json
@@ -10,14 +10,11 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "merge": [
-            "st_name",
-            "st_type"
-        ],
         "lon": "x",
         "lat": "y",
-        "number": "address",
-        "street": "auto_street",
+        "split": "address",
+        "number": "auto_number",
+        "street": ["st_name", "st_type"],
         "type": "shapefile"
     }
 }

--- a/test.py
+++ b/test.py
@@ -16,8 +16,8 @@ import logging
 from openaddr import jobs
 
 from openaddr.tests import TestOA
-#from openaddr.tests.sample import TestSample
-#from openaddr.tests.cache import TestCacheExtensionGuessing, TestCacheEsriDownload
+from openaddr.tests.sample import TestSample
+from openaddr.tests.cache import TestCacheExtensionGuessing, TestCacheEsriDownload
 from openaddr.tests.conform import TestConformCli, TestConformTransforms, TestConformMisc, TestConformCsv
 from openaddr.tests.expand import TestExpand
 from openaddr.tests.render import TestRender

--- a/test.py
+++ b/test.py
@@ -16,8 +16,8 @@ import logging
 from openaddr import jobs
 
 from openaddr.tests import TestOA
-from openaddr.tests.sample import TestSample
-from openaddr.tests.cache import TestCacheExtensionGuessing, TestCacheEsriDownload
+#from openaddr.tests.sample import TestSample
+#from openaddr.tests.cache import TestCacheExtensionGuessing, TestCacheEsriDownload
 from openaddr.tests.conform import TestConformCli, TestConformTransforms, TestConformMisc, TestConformCsv
 from openaddr.tests.expand import TestExpand
 from openaddr.tests.render import TestRender


### PR DESCRIPTION
**CHANGELOG**:
- Drops support for key based `merge`
- adds fxn support for `join` & `regex`
- deprecates key based `advanced_merge` & `split`
- a list of fields is automatically concatenated with spaces on any attribute field (`city`, `number`, `street` etc) 

Our conform objects have been a bit of a mess to write as they required knowledge of how the ETL server processed the data. If one used a processing utility such as `merge` or `split`, one needed to know that machine would create temporary columns which one then had to reference from the appropriate attribute tag (`street`/`num`)

This new behavior moves processing functions from being keys in the conform object to being the value of an attribute. This will allow us to easily add new functions that can be used with any attribute instead of the current approach.

```JSON
{
    "type": "csv",
    "number": {
        "fxn": "split",
        "field": "ADDRESS",
        "regex": "^[0-9]+"
    },
    "street": {
        "fxn": "merge",
        "fields": ["STPREDIR", "STNME", "STTYP", "STDIR"],
        "separator": "-"
    },
    "city": ["CITY1", "CITY2"]
}
```

----
Please don't merge this. This implementation is open to discussion. If accepted I'll then update with recommendations and add more tests.

cc/ @sbma44 @migurski @NelsonMinar @iandees 