### PR TITLE
Quickly update setup.py + conform.py

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -320,7 +320,7 @@ def find_source_path(source_definition, source_paths):
         candidates = []
         for fn in source_paths:
             basename, ext = os.path.splitext(fn)
-            if ext.lower() == ".json":
+            if ext.lower() in (".json", ".geojson"):
                 candidates.append(fn)
         if len(candidates) == 0:
             _L.warning("No JSON found in %s", source_paths)

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -20,6 +20,7 @@ import tempfile
 import json
 import re
 import pickle
+import sys
 from os import close, environ, mkdir, remove
 from io import BytesIO
 from csv import DictReader
@@ -27,7 +28,8 @@ from zipfile import ZipFile
 from mimetypes import guess_type
 from urllib.parse import urlparse, parse_qs
 from os.path import dirname, join, basename, exists, splitext
-from fcntl import lockf, LOCK_EX, LOCK_UN
+if sys.platform !="win32":
+    from fcntl import lockf, LOCK_EX, LOCK_UN
 from contextlib import contextmanager
 from subprocess import Popen, PIPE
 from threading import Lock
@@ -497,6 +499,8 @@ def locked_open(filename):
     ''' Open and lock a file, for use with threads and processes.
     '''
     with open(filename, 'r+b') as file:
+        if sys.platform == "win32":
+            yield file
         lockf(file, LOCK_EX)
         yield file
         lockf(file, LOCK_UN)

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'pq == 1.3',
         
         # http://initd.org/psycopg/
-        'psycopg2 == 2.6',
+        'psycopg2 >= 2.6',
         
         # https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991/comments/10
         'requests == 2.2.1',


### PR DESCRIPTION
* allows existing >2.6 installs of psycopg2 to work without trying to reinstall 2.6 (which fails on Windows w/o MSVS 2010)
* updated tests\__init__.py to work around fcntl only existing on Unix
* updated conform.py to add ".geojson" file extensions