### PR TITLE
Recognize IDs

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -35,7 +35,8 @@ attrib_types = {
     'city':     'OA:city',
     'postcode': 'OA:postcode',
     'district': 'OA:district',
-    'region':   'OA:region'
+    'region':   'OA:region',
+    'id':       'OA:id'
 }
 
 geometry_types = {
@@ -796,6 +797,7 @@ def row_convert_to_out(sd, row):
         "DISTRICT": row.get(keys['district'], None) if keys['district'] else None,
         "REGION": row.get(keys['region'], None) if keys['region'] else None,
         "POSTCODE": row.get(keys['postcode'], None) if keys['postcode'] else None,
+        "ID": row.get(keys['id'], None) if keys['id'] else None,
     }
 
 ### File-level conform code. Inputs and outputs are filenames.
@@ -824,7 +826,7 @@ def extract_to_source_csv(source_definition, source_path, extract_path):
         raise Exception("Unsupported source type %s" % source_definition["conform"]["type"])
 
 # The canonical output schema for conform
-_openaddr_csv_schema = ["LON", "LAT", "NUMBER", "STREET", "CITY", "DISTRICT", "REGION", "POSTCODE"]
+_openaddr_csv_schema = ["LON", "LAT", "NUMBER", "STREET", "CITY", "DISTRICT", "REGION", "POSTCODE", "ID"]
 
 def transform_to_out_csv(source_definition, extract_path, dest_path):
     ''' Transform an extracted source CSV to the OpenAddresses output CSV by applying conform rules.

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -157,6 +157,10 @@ class TestOA (unittest.TestCase):
         
         with csvopen(output_path, encoding='utf8') as input:
             rows = list(csvDictReader(input, encoding='utf8'))
+            self.assertEqual(rows[1]['ID'], '')
+            self.assertEqual(rows[10]['ID'], '')
+            self.assertEqual(rows[100]['ID'], '')
+            self.assertEqual(rows[1000]['ID'], '')
             self.assertEqual(rows[1]['NUMBER'], '2147')
             self.assertEqual(rows[10]['NUMBER'], '605')
             self.assertEqual(rows[100]['NUMBER'], '167')
@@ -195,6 +199,10 @@ class TestOA (unittest.TestCase):
         
         with csvopen(output_path, encoding='utf8') as input:
             rows = list(csvDictReader(input, encoding='utf8'))
+            self.assertEqual(rows[1]['ID'], '')
+            self.assertEqual(rows[10]['ID'], '')
+            self.assertEqual(rows[100]['ID'], '')
+            self.assertEqual(rows[1000]['ID'], '')
             self.assertEqual(rows[1]['NUMBER'], '27')
             self.assertEqual(rows[10]['NUMBER'], '42')
             self.assertEqual(rows[100]['NUMBER'], '209')
@@ -238,6 +246,7 @@ class TestOA (unittest.TestCase):
             self.assertEqual(rows[0]['POSTCODE'], '90745')
             self.assertEqual(rows[0]['DISTRICT'], '')
             self.assertEqual(rows[0]['REGION'], '')
+            self.assertEqual(rows[0]['ID'], '')
 
     def test_single_car_cached(self):
         ''' Test complete process_one.process on Carson sample data.
@@ -386,6 +395,9 @@ class TestOA (unittest.TestCase):
         
         with csvopen(output_path, encoding='utf8') as input:
             rows = list(csvDictReader(input, encoding='utf8'))
+            self.assertEqual(rows[1]['ID'], '055 188300600')
+            self.assertEqual(rows[10]['ID'], '055 189504000')
+            self.assertEqual(rows[100]['ID'], '055 188700100')
             self.assertEqual(rows[1]['NUMBER'], '2418')
             self.assertEqual(rows[10]['NUMBER'], '2029')
             self.assertEqual(rows[100]['NUMBER'], '2298')

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -366,6 +366,33 @@ class TestOA (unittest.TestCase):
         self.assertTrue(state['cache'] is None)
         self.assertTrue(state['processed'] is None)
         
+    def test_single_berk_apn(self):
+        ''' Test complete process_one.process on Berkeley sample data.
+        '''
+        source = join(self.src_dir, 'us-ca-berkeley-apn.json')
+        
+        with HTTMock(self.response_content):
+            state_path = process_one.process(source, self.testdir)
+        
+        with open(state_path) as file:
+            state = dict(zip(*json.load(file)))
+        
+        self.assertIsNotNone(state['cache'])
+        self.assertIsNotNone(state['processed'])
+        self.assertEqual(state['website'], 'http://www.ci.berkeley.ca.us/datacatalog/')
+        self.assertIsNone(state['license'])
+        
+        output_path = join(dirname(state_path), state['processed'])
+        
+        with csvopen(output_path, encoding='utf8') as input:
+            rows = list(csvDictReader(input, encoding='utf8'))
+            self.assertEqual(rows[1]['NUMBER'], '2418')
+            self.assertEqual(rows[10]['NUMBER'], '2029')
+            self.assertEqual(rows[100]['NUMBER'], '2298')
+            self.assertEqual(rows[1]['STREET'], 'Dana Street')
+            self.assertEqual(rows[10]['STREET'], 'Channing Way')
+            self.assertEqual(rows[100]['STREET'], 'Durant Avenue')
+
     def test_single_pl_ds(self):
         ''' Test complete process_one.process on Polish sample data.
         '''

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -43,7 +43,7 @@ class TestConformTransforms (unittest.TestCase):
         d = { "conform": { "street": "s", "number": "n" } }
         r = row_convert_to_out(d, {"s": "MAPLE LN", "n": "123", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3"})
         self.assertEqual({"LON": "-119.2", "LAT": "39.3", "NUMBER": "123", "STREET": "MAPLE LN",
-                          "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None}, r)
+                          "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None, "ID": None}, r)
 
     def test_row_merge(self):
         d = { "conform": { "street": [ "n", "t" ] } }
@@ -166,17 +166,17 @@ class TestConformTransforms (unittest.TestCase):
         d = { "conform": { "street": ["s1", "s2"], "number": "n", "lon": "y", "lat": "x" } }
         r = row_transform_and_convert(d, { "n": "123", "s1": "MAPLE", "s2": "ST", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3" })
         self.assertEqual({"STREET": "Maple Street", "NUMBER": "123", "LON": "-119.2", "LAT": "39.3",
-                          "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None}, r)
+                          "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None, "ID": None}, r)
 
         d = { "conform": { "street": ["s1", "s2"], "number": "n", "lon": "y", "lat": "x" } }
         r = row_transform_and_convert(d, { "n": "123", "s1": "MAPLE", "s2": "ST", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3" })
         self.assertEqual({"STREET": "Maple Street", "NUMBER": "123", "LON": "-119.2", "LAT": "39.3",
-                          "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None}, r)
+                          "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None, "ID": None}, r)
 
         d = { "conform": { "street": "auto_street", "number": "auto_number", "split": "s", "lon": "y", "lat": "x" } }
         r = row_transform_and_convert(d, { "s": "123 MAPLE ST", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3" })
         self.assertEqual({"STREET": "Maple Street", "NUMBER": "123", "LON": "-119.2", "LAT": "39.3",
-                          "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None}, r)
+                          "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None, "ID": None}, r)
 
     def test_row_canonicalize_street_and_number(self):
         r = row_canonicalize_street_and_number({}, {"NUMBER": "324 ", "STREET": " OAK DR."})
@@ -279,7 +279,7 @@ class TestConformCli (unittest.TestCase):
 
         with csvopen(dest_path) as fp:
             reader = csvDictReader(fp)
-            self.assertEqual(["LON", "LAT", "NUMBER", "STREET", "CITY", "DISTRICT", "REGION", "POSTCODE"], reader.fieldnames)
+            self.assertEqual(["LON", "LAT", "NUMBER", "STREET", "CITY", "DISTRICT", "REGION", "POSTCODE", "ID"], reader.fieldnames)
 
             rows = list(reader)
 

--- a/openaddr/tests/sources/us-ca-berkeley-apn.json
+++ b/openaddr/tests/sources/us-ca-berkeley-apn.json
@@ -1,0 +1,23 @@
+{
+    "coverage": {
+        "US Census": {"geoid": "0606000", "place": "Berkeley", "state": "California"},
+        "country": "us",
+        "state": "ca",
+        "place": "Berkeley"
+    },
+    "conform": {
+        "id": "APN",
+        "number": "StreetNum",
+        "street": [
+            "StreetName",
+            "StreetSufx",
+            "Direction"
+        ],
+        "type": "shapefile-polygon"
+    },
+    "data": "http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.zip",
+    "website": "http://www.ci.berkeley.ca.us/datacatalog/",
+    "type": "http",
+    "compression": "zip",
+    "note": "Metadata at http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.shp(1).xml"
+}


### PR DESCRIPTION
Recognizes an optional ID tag in the conform object, and outputs it as part of the processed CSV. Part of #163; this will be important for parcels later..