### PR TITLE
Allow license dictionary

### DIFF
--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -31,6 +31,7 @@ from .conform import (
     ExcerptDataTask,
     ConvertToCsvTask,
     elaborate_filenames,
+    conform_license,
 )
 
 with open(join(dirname(__file__), 'VERSION')) as file:
@@ -180,7 +181,7 @@ def conform(srcjson, destdir, extras):
     return ConformResult(data.get('processed', None),
                          data_sample,
                          data.get('website'),
-                         data.get('license'),
+                         conform_license(data.get('license')),
                          geometry_type,
                          addr_count,
                          out_path,

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -872,3 +872,8 @@ def conform_cli(source_definition, source_path, dest_path):
         os.remove(extract_path)
 
     return 0
+
+def conform_license(license):
+    ''' Convert optional license tag.
+    '''
+    return license

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -876,4 +876,20 @@ def conform_cli(source_definition, source_path, dest_path):
 def conform_license(license):
     ''' Convert optional license tag.
     '''
-    return license
+    if license is None:
+        return None
+    
+    if not hasattr(license, 'get'):
+        # Old behavior: treat it like a string instead of a dictionary
+        return str(license)
+    
+    if 'url' in license and 'text' in license:
+        return '{text} ({url})'.format(**license)
+    elif 'url' in license:
+        return str(license['url'])
+    elif 'text' in license:
+        return str(license['text'])
+    else:
+        return None
+    
+    raise ValueError('Unknown license format "{}"'.format(repr(license)))

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -430,6 +430,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point')
         self.assertIsNone(state['website'])
         self.assertEqual(state['license'][:21], 'Polish Law on Geodesy')
+        self.assertIn('issues/187#issuecomment-63327973', state['license'])
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -456,6 +457,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point')
         self.assertIsNone(state['website'])
         self.assertEqual(state['license'][:21], 'Polish Law on Geodesy')
+        self.assertIn('issues/187#issuecomment-63327973', state['license'])
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -17,7 +17,7 @@ from ..conform import (
     row_fxn_regexp, row_smash_case, row_round_lat_lon, row_merge,
     row_extract_and_reproject, row_convert_to_out, row_fxn_join,
     row_canonicalize_street_and_number, conform_smash_case, conform_cli,
-    csvopen, csvDictReader, convert_regexp_replace
+    csvopen, csvDictReader, convert_regexp_replace, conform_license
     )
 
 class TestConformTransforms (unittest.TestCase):
@@ -693,3 +693,12 @@ class TestConformCsv(unittest.TestCase):
         r = self._convert(c, d)
         self.assertEqual(self._ascii_header_out, r[0])
         self.assertEqual(self._ascii_row_out, r[1])
+
+class TestConformLicense (unittest.TestCase):
+
+    def test_license_string(self):
+        ''' Test that simple license strings are converted correctly.
+        '''
+        self.assertEqual(conform_license(None), None)
+        self.assertEqual(conform_license('CC-BY-SA'), 'CC-BY-SA')
+        self.assertEqual(conform_license('http://example.com'), 'http://example.com')

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -699,6 +699,17 @@ class TestConformLicense (unittest.TestCase):
     def test_license_string(self):
         ''' Test that simple license strings are converted correctly.
         '''
-        self.assertEqual(conform_license(None), None)
+        self.assertIsNone(conform_license(None))
         self.assertEqual(conform_license('CC-BY-SA'), 'CC-BY-SA')
         self.assertEqual(conform_license('http://example.com'), 'http://example.com')
+
+    def test_license_dictionary(self):
+        ''' Test that simple license strings are converted correctly.
+        '''
+        self.assertIsNone(conform_license({}))
+        self.assertEqual(conform_license({'text': 'CC-BY-SA'}), 'CC-BY-SA')
+        self.assertEqual(conform_license({'url': 'http://example.com'}), 'http://example.com')
+        
+        license = {'text': 'CC-BY-SA', 'url': 'http://example.com'}
+        self.assertIn(license['text'], conform_license(license))
+        self.assertIn(license['url'], conform_license(license))

--- a/openaddr/tests/sources/pl-dolnoslaskie.json
+++ b/openaddr/tests/sources/pl-dolnoslaskie.json
@@ -8,7 +8,10 @@
         "state": "dolnośląskie",
         "country": "pl"
     },
-    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "license": {
+        "text": "Polish Law on Geodesy and Cartography of 17 May 1989",
+        "url": "https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973"
+    },
     "compression": "zip",
     "conform": {
         "srs": "EPSG:2180",

--- a/openaddr/tests/sources/pl-lodzkie.json
+++ b/openaddr/tests/sources/pl-lodzkie.json
@@ -8,7 +8,10 @@
         "state": "łódzkie",
         "country": "pl"
     },
-    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "license": {
+        "text": "Polish Law on Geodesy and Cartography of 17 May 1989",
+        "url": "https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973"
+    },
     "compression": "zip",
     "conform": {
         "srs": "EPSG:2180",

--- a/openaddr/tests/sources/us-ca-alameda_county.json
+++ b/openaddr/tests/sources/us-ca-alameda_county.json
@@ -10,7 +10,7 @@
         "county": "Alameda"
     },
     "data": "https://data.acgov.org/api/geospatial/8e4s-7f4v?method=export&format=Original",
-    "license": "http://www.acgov.org/acdata/terms.htm",
+    "license": { "url": "http://www.acgov.org/acdata/terms.htm" },
     "year": "",
     "type": "http",
     "compression": "zip",

--- a/openaddr/tests/sources/us-ca-berkeley.json
+++ b/openaddr/tests/sources/us-ca-berkeley.json
@@ -7,6 +7,7 @@
     },
     "data": "http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.zip",
     "website": "http://www.ci.berkeley.ca.us/datacatalog/",
+    "license": { },
     "type": "http",
     "compression": "zip",
     "note": "Metadata at http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.shp(1).xml"

--- a/openaddr/tests/sources/us-ca-san_francisco.json
+++ b/openaddr/tests/sources/us-ca-san_francisco.json
@@ -5,7 +5,7 @@
         "city": "San Francisco"
     },
     "data": "https://data.sfgov.org/download/kvej-w5kb/ZIPPED%20SHAPEFILE",
-    "license": "",
+    "license": { "text": "" },
     "year": "",
     "type": "http",
     "compression": "zip",

--- a/test.py
+++ b/test.py
@@ -18,7 +18,7 @@ from openaddr import jobs
 from openaddr.tests import TestOA, TestPackage
 from openaddr.tests.sample import TestSample
 from openaddr.tests.cache import TestCacheExtensionGuessing, TestCacheEsriDownload
-from openaddr.tests.conform import TestConformCli, TestConformTransforms, TestConformMisc, TestConformCsv
+from openaddr.tests.conform import TestConformCli, TestConformTransforms, TestConformMisc, TestConformCsv, TestConformLicense
 from openaddr.tests.expand import TestExpand
 from openaddr.tests.render import TestRender
 from openaddr.tests.dotmap import TestDotmap


### PR DESCRIPTION
Supports new license dictionary behavior with two optional keys: `url` and `text`.

Closes #228, part of https://github.com/openaddresses/openaddresses-ops/issues/7.