### PR TITLE
Populate attribution

### DIFF
--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -32,6 +32,7 @@ from .conform import (
     ConvertToCsvTask,
     elaborate_filenames,
     conform_license,
+    conform_attribution,
 )
 
 with open(join(dirname(__file__), 'VERSION')) as file:
@@ -177,6 +178,8 @@ def conform(srcjson, destdir, extras):
         out_path = realpath(join(destdir, 'out.csv'))
 
     rmtree(workdir)
+    
+    attr_flag, attr_name = conform_attribution(data.get('license'), data.get('attribution'))
 
     return ConformResult(data.get('processed', None),
                          data_sample,
@@ -185,7 +188,9 @@ def conform(srcjson, destdir, extras):
                          geometry_type,
                          addr_count,
                          out_path,
-                         datetime.now() - start)
+                         datetime.now() - start,
+                         attr_flag,
+                         attr_name)
 
 def package_output(source, processed_path, website, license):
     ''' Write a zip archive to temp dir with processed data and optional .vrt.

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -125,7 +125,7 @@ def app_get_state_txt():
     buffer = csvIO()
     output = csvDictWriter(buffer, CSV_HEADER, dialect='excel-tab', encoding='utf8')
     output.writerow({col: col for col in CSV_HEADER})
-    for run in runs:
+    for run in sorted(runs, key=attrgetter('source_path')):
         run_state = run.state or {}
         row = {col: run_state.get(col, None) for col in CSV_HEADER}
         row['source'] = os.path.relpath(run.source_path, 'sources')
@@ -281,7 +281,7 @@ def app_get_set_state_txt(set_id):
     buffer = csvIO()
     output = csvDictWriter(buffer, CSV_HEADER, dialect='excel-tab', encoding='utf8')
     output.writerow({col: col for col in CSV_HEADER})
-    for run in runs:
+    for run in sorted(runs, key=attrgetter('source_path')):
         run_state = run.state or {}
         row = {col: run_state.get(col, None) for col in CSV_HEADER}
         row['source'] = os.path.relpath(run.source_path, 'sources')

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -32,7 +32,7 @@ from ..summarize import summarize_runs, GLASS_HALF_FULL, GLASS_HALF_EMPTY, nice_
 
 CSV_HEADER = 'source', 'cache', 'sample', 'geometry type', 'address count', \
              'version', 'fingerprint', 'cache time', 'processed', 'process time', \
-             'output'
+             'output', 'attribution required', 'attribution name'
 
 webhooks = Blueprint('webhooks', __name__, template_folder='templates')
 

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -912,8 +912,16 @@ def conform_attribution(license, attribution):
         attr_flag = True
         attr_name = str(attribution)
     
+    is_dict = license is not None and hasattr(license, 'get')
+    
+    # Look for an attribution name inside license dictionary
+    if is_dict and 'attribution name' in license:
+        if license['attribution name']:
+            attr_flag = True
+            attr_name = str(license['attribution name'])
+    
     # Look for an explicit flag inside license dictionary.
-    if license is not None and hasattr(license, 'get') and 'attribution' in license:
+    if is_dict and 'attribution' in license:
         attr_flag = license['attribution']
     
     # Override null flag if name has been defined.

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -908,17 +908,23 @@ def conform_attribution(license, attribution):
     if attribution in (None, False, ''):
         attr_flag = False
         attr_name = None
-    else:
+    elif not hasattr(attribution, 'encode'):
         attr_flag = True
         attr_name = str(attribution)
+    else:
+        attr_flag = True
+        attr_name = attribution
     
     is_dict = license is not None and hasattr(license, 'get')
     
     # Look for an attribution name inside license dictionary
     if is_dict and 'attribution name' in license:
-        if license['attribution name']:
+        if not hasattr(license['attribution name'], 'encode'):
             attr_flag = True
             attr_name = str(license['attribution name'])
+        elif license['attribution name']:
+            attr_flag = True
+            attr_name = license['attribution name']
     
     # Look for an explicit flag inside license dictionary.
     if is_dict and 'attribution' in license:

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -893,3 +893,30 @@ def conform_license(license):
         return None
     
     raise ValueError('Unknown license format "{}"'.format(repr(license)))
+
+def conform_attribution(license, attribution):
+    ''' Convert optional license and attribution tags.
+    
+        Return tuple with attribution-required flag and attribution name.
+    '''
+    # Initially guess based on old attribution tag.
+    if attribution in (None, False, ''):
+        attr_flag = False
+        attr_name = None
+    else:
+        attr_flag = True
+        attr_name = str(attribution)
+    
+    # Look for an explicit flag inside license dictionary.
+    if license is not None and hasattr(license, 'get') and 'attribution' in license:
+        attr_flag = license['attribution']
+    
+    # Override null flag if name has been defined.
+    if attr_flag is None and attr_name:
+        attr_flag = True
+    
+    # Blank name if flag is not true.
+    if not attr_flag:
+        attr_name = None
+    
+    return attr_flag, attr_name

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -76,8 +76,11 @@ class ConformResult:
     address_count = None
     path = None
     elapsed = None
+    attribution_flag = None
+    attribution_name = None
     
-    def __init__(self, processed, sample, website, license, geometry_type, address_count, path, elapsed):
+    def __init__(self, processed, sample, website, license, geometry_type,
+                 address_count, path, elapsed, attribution_flag, attribution_name):
         self.processed = processed
         self.sample = sample
         self.website = website
@@ -86,10 +89,12 @@ class ConformResult:
         self.address_count = address_count
         self.path = path
         self.elapsed = elapsed
+        self.attribution_flag = attribution_flag
+        self.attribution_name = attribution_name
 
     @staticmethod
     def empty():
-        return ConformResult(None, None, None, None, None, None, None, None)
+        return ConformResult(None, None, None, None, None, None, None, None, None, None)
 
     def todict(self):
         return dict(processed=self.processed, sample=self.sample)

--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -145,7 +145,9 @@ def write_state(source, skipped, destination, log_handler, cache_result,
         ('cache time', cache_result.elapsed and str(cache_result.elapsed)),
         ('processed', conform_result.path and relpath(processed_path2, statedir)),
         ('process time', conform_result.elapsed and str(conform_result.elapsed)),
-        ('output', relpath(output_path, statedir))
+        ('output', relpath(output_path, statedir)),
+        ('attribution required', conform_result.attribution_flag),
+        ('attribution name', conform_result.attribution_name),
         ]
                
     with csvopen(join(statedir, 'index.txt'), 'w', encoding='utf8') as file:

--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -16,6 +16,20 @@ from .compat import csvopen, csvwriter
 
 class SourceSaysSkip(RuntimeError): pass
 
+def boolstr(value):
+    '''
+    '''
+    if value is True:
+        return 'true'
+    
+    if value is False:
+        return 'false'
+    
+    if value is None:
+        return ''
+    
+    raise ValueError(repr(value))
+
 def process(source, destination, extras=dict()):
     ''' Process a single source and destination, return path to JSON state file.
     
@@ -146,7 +160,7 @@ def write_state(source, skipped, destination, log_handler, cache_result,
         ('processed', conform_result.path and relpath(processed_path2, statedir)),
         ('process time', conform_result.elapsed and str(conform_result.elapsed)),
         ('output', relpath(output_path, statedir)),
-        ('attribution required', conform_result.attribution_flag),
+        ('attribution required', boolstr(conform_result.attribution_flag)),
         ('attribution name', conform_result.attribution_name),
         ]
                

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -492,6 +492,8 @@ class TestOA (unittest.TestCase):
         self.assertTrue(state['sample'] is not None)
         self.assertEqual(state['website'], 'http://nlftp.mlit.go.jp/isj/index.html')
         self.assertEqual(state['license'], 'http://nlftp.mlit.go.jp/ksj/other/yakkan.html')
+        self.assertIs(state['attribution required'], True)
+        self.assertIn('Ministry of Land', state['attribution name'])
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -492,7 +492,7 @@ class TestOA (unittest.TestCase):
         self.assertTrue(state['sample'] is not None)
         self.assertEqual(state['website'], 'http://nlftp.mlit.go.jp/isj/index.html')
         self.assertEqual(state['license'], 'http://nlftp.mlit.go.jp/ksj/other/yakkan.html')
-        self.assertIs(state['attribution required'], True)
+        self.assertEqual(state['attribution required'], 'true')
         self.assertIn('Ministry of Land', state['attribution name'])
         
         with open(join(dirname(state_path), state['sample'])) as file:
@@ -538,7 +538,7 @@ class TestOA (unittest.TestCase):
         self.assertTrue(state['sample'] is not None)
         self.assertEqual(state['website'], 'http://adresse.data.gouv.fr/download/')
         self.assertIsNone(state['license'])
-        self.assertIs(state['attribution required'], True)
+        self.assertEqual(state['attribution required'], 'true')
         self.assertIn(u'Géographique et Forestière', state['attribution name'])
 
         with open(join(dirname(state_path), state['sample'])) as file:
@@ -565,7 +565,7 @@ class TestOA (unittest.TestCase):
         self.assertTrue(state['sample'] is not None)
         self.assertEqual(state['website'], 'http://adresse.data.gouv.fr/download/')
         self.assertIsNone(state['license'])
-        self.assertIs(state['attribution required'], True)
+        self.assertEqual(state['attribution required'], 'true')
         self.assertIn(u'Géographique et Forestière', state['attribution name'])
 
         with open(join(dirname(state_path), state['sample'])) as file:

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -538,6 +538,8 @@ class TestOA (unittest.TestCase):
         self.assertTrue(state['sample'] is not None)
         self.assertEqual(state['website'], 'http://adresse.data.gouv.fr/download/')
         self.assertIsNone(state['license'])
+        self.assertIs(state['attribution required'], True)
+        self.assertIn(u'Géographique et Forestière', state['attribution name'])
 
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -563,6 +565,8 @@ class TestOA (unittest.TestCase):
         self.assertTrue(state['sample'] is not None)
         self.assertEqual(state['website'], 'http://adresse.data.gouv.fr/download/')
         self.assertIsNone(state['license'])
+        self.assertIs(state['attribution required'], True)
+        self.assertIn(u'Géographique et Forestière', state['attribution name'])
 
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -1037,6 +1037,20 @@ class TestHook (unittest.TestCase):
         yesterday = now - timedelta(days=1)
         last_week = now - timedelta(days=7)
         
+        # Old-style run predating attribution columns.
+        run_state1 = {
+            'source': 'a1.json', 'skipped': 'b', 'cache': 'c', 'sample': 'd',
+            'website': 'e', 'license': 'f', 'geometry type': 'g',
+            'address count': 'h', 'version': 'i', 'fingerprint': 'j',
+            'cache time': 'k', 'processed': 'l', 'process time': 'm',
+            'output': 'n'
+            }
+        
+        # New-style run including attribution columns.
+        run_state2 = {'attribution required': 'true', 'attribution name': 'p'}
+        run_state2.update(run_state1)
+        run_state2['source'] = 'a2.json'
+        
         # Look for the task in the task queue.
         with db_connect(self.database_url) as conn:
             with db_cursor(conn) as db:
@@ -1046,10 +1060,41 @@ class TestHook (unittest.TestCase):
                                [(1, 'openaddresses', 'openaddresses', now, None),
                                 (2, 'openaddresses', 'openaddresses', yesterday, now),
                                 (3, 'openaddresses', 'openaddresses', last_week, now)])
+                
+                run_id1 = add_run(db)
+                set_run(db, run_id1, 'sources/a1.json', 'abc', b'def',
+                        run_state1, True, None, None, None, 2)
+                
+                run_id2 = add_run(db)
+                set_run(db, run_id2, 'sources/a2.json', 'ghi', b'jkl',
+                        run_state2, True, None, None, None, 2)
         
-        got = self.client.get('/latest/set')
-        self.assertEqual(got.status_code, 302)
-        self.assertTrue(got.headers.get('Location').endswith('/sets/2'))
+        got1 = self.client.get('/latest/set')
+        self.assertEqual(got1.status_code, 302)
+        self.assertTrue(got1.headers.get('Location').endswith('/sets/2'))
+
+        got2 = self.client.get('/state.txt')
+        self.assertEqual(got2.status_code, 200)
+        
+        # El-Cheapo CSV parser.
+        lines = got2.data.decode('utf8').split('\r\n')[:3]
+        head, row1, row2 = [row.split('\t') for row in lines]
+        got_state1 = dict(zip(head, row1))
+        got_state2 = dict(zip(head, row2))
+        
+        for key in ('source', 'cache', 'sample', 'geometry type', 'address count',
+                    'version', 'fingerprint', 'cache time', 'processed', 'output',
+                    'process time', 'attribution required', 'attribution name'):
+            self.assertIn(key, got_state1)
+            self.assertIn(key, got_state2)
+        
+        for (key, value) in got_state1.items():
+            if key in run_state1:
+                self.assertEqual(value, run_state1[key])
+        
+        for (key, value) in got_state2.items():
+            if key in run_state2:
+                self.assertEqual(value, run_state2[key])
     
 class TestRuns (unittest.TestCase):
 

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -1073,28 +1073,29 @@ class TestHook (unittest.TestCase):
         self.assertEqual(got1.status_code, 302)
         self.assertTrue(got1.headers.get('Location').endswith('/sets/2'))
 
-        got2 = self.client.get('/state.txt')
-        self.assertEqual(got2.status_code, 200)
+        for path in ('/state.txt', '/sets/2/state.txt'):
+            got2 = self.client.get(path)
+            self.assertEqual(got2.status_code, 200)
         
-        # El-Cheapo CSV parser.
-        lines = got2.data.decode('utf8').split('\r\n')[:3]
-        head, row1, row2 = [row.split('\t') for row in lines]
-        got_state1 = dict(zip(head, row1))
-        got_state2 = dict(zip(head, row2))
+            # El-Cheapo CSV parser.
+            lines = got2.data.decode('utf8').split('\r\n')[:3]
+            head, row1, row2 = [row.split('\t') for row in lines]
+            got_state1 = dict(zip(head, row1))
+            got_state2 = dict(zip(head, row2))
         
-        for key in ('source', 'cache', 'sample', 'geometry type', 'address count',
-                    'version', 'fingerprint', 'cache time', 'processed', 'output',
-                    'process time', 'attribution required', 'attribution name'):
-            self.assertIn(key, got_state1)
-            self.assertIn(key, got_state2)
+            for key in ('source', 'cache', 'sample', 'geometry type', 'address count',
+                        'version', 'fingerprint', 'cache time', 'processed', 'output',
+                        'process time', 'attribution required', 'attribution name'):
+                self.assertIn(key, got_state1)
+                self.assertIn(key, got_state2)
         
-        for (key, value) in got_state1.items():
-            if key in run_state1:
-                self.assertEqual(value, run_state1[key])
+            for (key, value) in got_state1.items():
+                if key in run_state1:
+                    self.assertEqual(value, run_state1[key])
         
-        for (key, value) in got_state2.items():
-            if key in run_state2:
-                self.assertEqual(value, run_state2[key])
+            for (key, value) in got_state2.items():
+                if key in run_state2:
+                    self.assertEqual(value, run_state2[key])
     
 class TestRuns (unittest.TestCase):
 

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -17,7 +17,8 @@ from ..conform import (
     row_fxn_regexp, row_smash_case, row_round_lat_lon, row_merge,
     row_extract_and_reproject, row_convert_to_out, row_fxn_join,
     row_canonicalize_street_and_number, conform_smash_case, conform_cli,
-    csvopen, csvDictReader, convert_regexp_replace, conform_license
+    csvopen, csvDictReader, convert_regexp_replace, conform_license,
+    conform_attribution
     )
 
 class TestConformTransforms (unittest.TestCase):
@@ -713,3 +714,42 @@ class TestConformLicense (unittest.TestCase):
         license = {'text': 'CC-BY-SA', 'url': 'http://example.com'}
         self.assertIn(license['text'], conform_license(license))
         self.assertIn(license['url'], conform_license(license))
+    
+    def test_attribution(self):
+        ''' Test combinations of attribution data.
+        '''
+        attr_flag1, attr_name1 = conform_attribution(None, None)
+        self.assertIs(attr_flag1, False)
+        self.assertIsNone(attr_name1)
+
+        attr_flag2, attr_name2 = conform_attribution({}, None)
+        self.assertIs(attr_flag2, False)
+        self.assertIsNone(attr_name2)
+
+        attr_flag3, attr_name3 = conform_attribution(None, '')
+        self.assertIs(attr_flag3, False)
+        self.assertIsNone(attr_name3)
+
+        attr_flag4, attr_name4 = conform_attribution({}, '')
+        self.assertIs(attr_flag4, False)
+        self.assertIsNone(attr_name4)
+
+        attr_flag5, attr_name5 = conform_attribution(None, 'Joe Blow')
+        self.assertIs(attr_flag5, True)
+        self.assertEqual(attr_name5, 'Joe Blow')
+
+        attr_flag6, attr_name6 = conform_attribution({}, 'Joe Blow')
+        self.assertIs(attr_flag6, True)
+        self.assertEqual(attr_name6, 'Joe Blow')
+
+        attr_flag7, attr_name7 = conform_attribution({'attribution': False}, 'Joe Blow')
+        self.assertIs(attr_flag7, False)
+        self.assertEqual(attr_name7, None)
+
+        attr_flag8, attr_name8 = conform_attribution({'attribution': True}, 'Joe Blow')
+        self.assertIs(attr_flag8, True)
+        self.assertEqual(attr_name8, 'Joe Blow')
+
+        attr_flag9, attr_name9 = conform_attribution({'attribution': None}, 'Joe Blow')
+        self.assertIs(attr_flag9, True)
+        self.assertEqual(attr_name9, 'Joe Blow')

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -753,3 +753,19 @@ class TestConformLicense (unittest.TestCase):
         attr_flag9, attr_name9 = conform_attribution({'attribution': None}, 'Joe Blow')
         self.assertIs(attr_flag9, True)
         self.assertEqual(attr_name9, 'Joe Blow')
+
+        attr_flag10, attr_name10 = conform_attribution({'attribution': False, 'attribution name': 'Joe Blow'}, None)
+        self.assertIs(attr_flag10, False)
+        self.assertEqual(attr_name10, None)
+
+        attr_flag11, attr_name11 = conform_attribution({'attribution': True, 'attribution name': 'Joe Blow'}, None)
+        self.assertIs(attr_flag11, True)
+        self.assertEqual(attr_name11, 'Joe Blow')
+
+        attr_flag12, attr_name12 = conform_attribution({'attribution': None, 'attribution name': 'Joe Blow'}, None)
+        self.assertIs(attr_flag12, True)
+        self.assertEqual(attr_name12, 'Joe Blow')
+
+        attr_flag13, attr_name13 = conform_attribution({'attribution': None, 'attribution name': 'Joe Blow'}, 'Jon Snow')
+        self.assertIs(attr_flag13, True)
+        self.assertEqual(attr_name13, 'Joe Blow')

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -769,3 +769,7 @@ class TestConformLicense (unittest.TestCase):
         attr_flag13, attr_name13 = conform_attribution({'attribution': None, 'attribution name': 'Joe Blow'}, 'Jon Snow')
         self.assertIs(attr_flag13, True)
         self.assertEqual(attr_name13, 'Joe Blow')
+
+        attr_flag14, attr_name14 = conform_attribution({'attribution': None, 'attribution name': False}, None)
+        self.assertIs(attr_flag14, True)
+        self.assertEqual(attr_name14, 'False')

--- a/openaddr/tests/sources/fr-paris.json
+++ b/openaddr/tests/sources/fr-paris.json
@@ -18,5 +18,10 @@
         "lat": "lat",
         "city": "nom_commune",
         "postcode": "code_post"
+    },
+    "license":
+    {
+        "attribution": true,
+        "attribution name": "Institut National de l'Information Géographique et Forestière"
     }
 }

--- a/openaddr/tests/sources/fr/la-réunion.json
+++ b/openaddr/tests/sources/fr/la-réunion.json
@@ -19,5 +19,9 @@
         "city": "nom_commune",
         "postcode": "code_post",
         "encoding": "ISO-8859-1"
+    },
+    "license":
+    {
+        "attribution name": "Institut National de l'Information Géographique et Forestière"
     }
 }


### PR DESCRIPTION
Adds input and output for required attribution flags on each run result, based on license and attribution source tags.

* [x] Resolve @NelsonMinar’s questions about implicit values.
* [x] Output attribution values in public `state.txt` listings.

Closes #230, part of https://github.com/openaddresses/openaddresses-ops/issues/7.