### PR TITLE
Separate attribution collections #236

### DIFF
--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -62,6 +62,12 @@ class S3:
         self._make_bucket()
         return self._bucket.new_key(name)
 
+class LocalProcessedResult:
+    def __init__(self, source_base, filename, run_state):
+        self.source_base = source_base
+        self.filename = filename
+        self.run_state = run_state
+
 def cache(srcjson, destdir, extras):
     ''' Python wrapper for openaddress-cache.
     
@@ -243,7 +249,7 @@ def iterate_local_processed_files(runs):
             continue
         
         else:
-            yield (source_base, filename, run_state)
+            yield LocalProcessedResult(source_base, filename, run_state)
 
             if filename and exists(filename):
                 remove(filename)

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -693,13 +693,13 @@ def pop_task_from_duequeue(queue, github_auth):
         if job_id:
             update_job_status(db, job_id, job_url, filename, run_status, False, github_auth)
 
-def db_connect(dsn=None, user=None, password=None, host=None, database=None, sslmode=None):
+def db_connect(dsn=None, user=None, password=None, host=None, port=None, database=None, sslmode=None):
     ''' Connect to database.
     
         Use DSN string if given, but allow other calls for older systems.
     '''
     if dsn is None:
-        return connect(user=user, password=password, host=host, database=database, sslmode=sslmode)
+        return connect(user=user, password=password, host=host, port=port, database=database, sslmode=sslmode)
 
     return connect(dsn)
 

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -67,7 +67,7 @@ def main():
     
     # Maps of file suffixes to test functions
     area_tests = {
-        '-collected': (lambda result: True), '-us_northeast': is_us_northeast,
+        '-global': (lambda result: True), '-us_northeast': is_us_northeast,
         '-us_midwest': is_us_midwest, '-us_south': is_us_south, 
         '-us_west': is_us_west, '-europe': is_europe, '-asia': is_asia
         }
@@ -98,7 +98,7 @@ def prepare_collections(s3, set, dir, area_tests, attr_tests):
         return lambda result: (test1(result) and test2(result))
 
     for ((area_suffix, area_test), (attr_suffix, attr_test)) in pairs:
-        new_name = 'openaddresses{}{}.zip'.format(area_suffix, attr_suffix)
+        new_name = 'openaddr-collected{}{}.zip'.format(area_suffix, attr_suffix)
         new_zip = _prepare_zip(set, join(dir, new_name))
         new_collection = CollectorPublisher(s3, new_zip)
         collections.append((new_collection, _and(area_test, attr_test)))

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -15,7 +15,7 @@ from shutil import rmtree
 
 from .objects import read_latest_set, read_completed_runs_to_date
 from . import db_connect, db_cursor, setup_logger, render_index_maps, log_function_errors
-from .. import S3, iterate_local_processed_files
+from .. import S3, iterate_local_processed_files, util
 
 parser = ArgumentParser(description='Run some source files.')
 
@@ -56,7 +56,7 @@ def main():
     setup_logger(args.sns_arn, log_level=args.loglevel)
     s3 = S3(args.access_key, args.secret_key, args.bucket)
     
-    with db_connect(args.database_url) as conn:
+    with db_connect(**util.prepare_db_kwargs(args.database_url)) as conn:
         with db_cursor(conn) as db:
             set = read_latest_set(db, args.owner, args.repository)
             runs = read_completed_runs_to_date(db, set.id)

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -9,6 +9,7 @@ from os.path import splitext, exists, basename, join
 from urllib.parse import urlparse
 from operator import attrgetter
 from tempfile import mkstemp, mkdtemp
+from itertools import product
 from datetime import date
 from shutil import rmtree
 
@@ -64,14 +65,18 @@ def main():
     
     dir = mkdtemp(prefix='collected-')
     
-    # Map of file suffixes to test functions
+    # Maps of file suffixes to test functions
     area_tests = {
-        'collected': (lambda result: True), 'us_northeast': is_us_northeast,
-        'us_midwest': is_us_midwest, 'us_south': is_us_south, 
-        'us_west': is_us_west, 'europe': is_europe, 'asia': is_asia
+        '-collected': (lambda result: True), '-us_northeast': is_us_northeast,
+        '-us_midwest': is_us_midwest, '-us_south': is_us_south, 
+        '-us_west': is_us_west, '-europe': is_europe, '-asia': is_asia
+        }
+    attr_tests = {
+        '-by': (lambda result: result.run_state.get('attribution required', '') != 'false'),
+        '': (lambda result: result.run_state.get('attribution required', '') == 'false')
         }
     
-    collections = prepare_collections(s3, set, dir, area_tests)
+    collections = prepare_collections(s3, set, dir, area_tests, attr_tests)
 
     for result in iterate_local_processed_files(runs):
         for (collection, test) in collections:
@@ -83,16 +88,20 @@ def main():
     
     rmtree(dir)
 
-def prepare_collections(s3, set, dir, area_tests):
+def prepare_collections(s3, set, dir, area_tests, attr_tests):
     '''
     '''
     collections = []
+    pairs = product(area_tests.items(), attr_tests.items())
     
-    for (suffix, test) in area_tests.items():
-        new_name = 'openaddresses-{}.zip'.format(suffix)
+    def _and(test1, test2):
+        return lambda result: (test1(result) and test2(result))
+
+    for ((area_suffix, area_test), (attr_suffix, attr_test)) in pairs:
+        new_name = 'openaddresses{}{}.zip'.format(area_suffix, attr_suffix)
         new_zip = _prepare_zip(set, join(dir, new_name))
         new_collection = CollectorPublisher(s3, new_zip)
-        collections.append((new_collection, test))
+        collections.append((new_collection, _and(area_test, attr_test)))
         
     return collections
 

--- a/openaddr/ci/templates/index.html
+++ b/openaddr/ci/templates/index.html
@@ -18,28 +18,107 @@
 <p>
     We update these zipped global and regional address collections regularly:
 </p>
-<ul>
-    <li><a href="http://data.openaddresses.io/openaddresses-collected.zip">Global collection</a></li>
-    <li>
-        U.S. addresses
-        (<a href="http://www2.census.gov/geo/pdfs/maps-data/maps/reference/us_regdiv.pdf">list of states by region</a>):
-        <ul>
-            <li><a href="http://data.openaddresses.io/openaddresses-us_northeast.zip">U.S. Northeast collection</a></li>
-            <li><a href="http://data.openaddresses.io/openaddresses-us_midwest.zip">U.S. Midwest collection</a></li>
-            <li><a href="http://data.openaddresses.io/openaddresses-us_south.zip">U.S. South collection</a></li>
-            <li><a href="http://data.openaddresses.io/openaddresses-us_west.zip">U.S. West collection</a></li>
-        </ul>
-    </li>
-    <li>
-        <a href="http://data.openaddresses.io/openaddresses-europe.zip">Europe collection</a>
-        (<a href="http://publications.europa.eu/code/pdf/370000en.htm">list of European countries</a>)
-    </li>
-    <li>
-        <a href="http://data.openaddresses.io/openaddresses-asia.zip">Asia/Oceania collection</a>
-        (<a href="http://www.countrycallingcodes.com/iso-country-codes/asia-codes.php">list of Asian</a>,
-        <a href="http://www.countrycallingcodes.com/iso-country-codes/australia-codes.php">Oceania countries</a>)
-    </li>
-</ul>
+<style lang="text/css">
+
+    #downloads tr th,
+    #downloads tr td
+    {
+        text-align: left;
+        border: none;
+    }
+
+    #downloads tr th { font-size: 65% }
+    
+    #downloads tr:nth-child(2n+0) td { background-color: #f8f8f8 }
+    #downloads tr:nth-child(2n+1) td { background-color: #ffffff }
+
+    #downloads tr td code
+    {
+        background-color: white;
+        border-color: #bcb7df;
+    }
+    
+   /*
+    * Progressively show additional sample data columns.
+    */
+
+    #downloads tr th:nth-child(1),
+    #downloads tr td:nth-child(1),
+    #downloads tr th:nth-child(2),
+    #downloads tr td:nth-child(2)
+    {
+        display: none
+    }
+
+    @media (min-width: 400px)
+    {
+        #downloads tr th:nth-child(1),
+        #downloads tr td:nth-child(1)
+        {
+            display: table-cell
+        }
+    }
+
+    @media (min-width: 960px)
+    {
+        #downloads tr th:nth-child(2),
+        #downloads tr td:nth-child(2)
+        {
+            display: table-cell
+        }
+    }
+
+</style>
+<table id="downloads">
+    <tr>
+        <th width="25%">Collection</th>
+        <th width="25%">What’s Included</th>
+        <th width="25%">No Attribution</th>
+        <th width="25%">Attribution Required</th>
+    </tr>
+    <tr>
+        <td>Global</td>
+        <td>Everything</td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-global.zip"><code>global.zip</code></a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-global-by.zip"><code>global-by.zip</code></a></td>
+    </tr>
+    <tr>
+        <td>U.S. Northeast</td>
+        <td><a href="http://www2.census.gov/geo/pdfs/maps-data/maps/reference/us_regdiv.pdf">List of states by region</a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-us_northeast.zip"><code>us_northeast.zip</code></a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-us_northeast-by.zip"><code>us_northeast-by.zip</code></a></td>
+    </tr>
+    <tr>
+        <td>U.S. Midwest</td>
+        <td><a href="http://www2.census.gov/geo/pdfs/maps-data/maps/reference/us_regdiv.pdf">List of states by region</a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-us_midwest.zip"><code>us_midwest.zip</code></a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-us_midwest-by.zip"><code>us_midwest-by.zip</code></a></td>
+    </tr>
+    <tr>
+        <td>U.S. South</td>
+        <td><a href="http://www2.census.gov/geo/pdfs/maps-data/maps/reference/us_regdiv.pdf">List of states by region</a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-us_south.zip"><code>us_south.zip</code></a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-us_south-by.zip"><code>us_south-by.zip</code></a></td>
+    </tr>
+    <tr>
+        <td>U.S. West</td>
+        <td><a href="http://www2.census.gov/geo/pdfs/maps-data/maps/reference/us_regdiv.pdf">List of states by region</a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-us_west.zip"><code>us_west.zip</code></a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-us_west-by.zip"><code>us_west-by.zip</code></a></td>
+    </tr>
+    <tr>
+        <td>Europe</td>
+        <td><a href="http://publications.europa.eu/code/pdf/370000en.htm">List of European countries</a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-europe.zip"><code>europe.zip</code></a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-europe-by.zip"><code>europe-by.zip</code></a></td>
+    </tr>
+    <tr>
+        <td>Asia/Oceania</td>
+        <td><a href="http://www.countrycallingcodes.com/iso-country-codes/asia-codes.php">List of Asian</a>, <a href="http://www.countrycallingcodes.com/iso-country-codes/australia-codes.php">Oceania countries</a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-asia.zip"><code>asia.zip</code></a></td>
+        <td><a href="http://data.openaddresses.io/openaddr-collected-asia-by.zip"><code>asia-by.zip</code></a></td>
+    </tr>
+</table>
 <p>
     <button onclick="choosemap('http://data.openaddresses.io/render-world.png')">Show World</button>
     <button onclick="choosemap('http://data.openaddresses.io/render-usa.png')">Show United States</button>

--- a/openaddr/ci/templates/runs-table.html
+++ b/openaddr/ci/templates/runs-table.html
@@ -1,25 +1,25 @@
 <style lang="text/css">
 
-    table { border-collapse: collapse }
+    #runs { border-collapse: collapse }
     
-    table tr th,
-    table tr td.type,
-    table tr td.cached,
-    table tr td.problems,
-    table tr td.sample,
-    table tr td table tr td
+    #runs tr th,
+    #runs tr td.type,
+    #runs tr td.cached,
+    #runs tr td.problems,
+    #runs tr td.sample,
+    #runs tr td table tr td
     {
         font-size: 65%;
     }
     
-    table tr th, table tr td
+    #runs tr th, #runs tr td
     {
         text-align: left;
         padding: 3px 10px;
         border: none;
     }
     
-    table tr td>a
+    #runs tr td>a
     {
         display: block;
         margin: -3px -10px;
@@ -27,28 +27,28 @@
         text-decoration: underline;
     }
     
-    table tr td.problems>a,
-    table tr td.sample>a
+    #runs tr td.problems>a,
+    #runs tr td.sample>a
     {
         display: inline;
         margin: 0;
         padding: 0;
     }
     
-    table tr td.name>a
+    #runs tr td.name>a
     {
         text-decoration: none;
     }
     
-    table tr:nth-child(4n-2) td, table tr:nth-child(4n-1) td { background-color: #f8f8f8 }
-    table tr:nth-child(4n+0) td, table tr:nth-child(4n+1) td { background-color: #ffffff }
+    #runs tr:nth-child(4n-2) td, #runs tr:nth-child(4n-1) td { background-color: #f8f8f8 }
+    #runs tr:nth-child(4n+0) td, #runs tr:nth-child(4n+1) td { background-color: #ffffff }
 
-    table tr td table { margin: 1em 0 }
-    table tr td table { margin: 1em 0 }
-    table tr td table tr th { color: #666 }
+    #runs tr td table { margin: 1em 0 }
+    #runs tr td table { margin: 1em 0 }
+    #runs tr td table tr th { color: #666 }
 
-    table tr td table tr th,
-    table tr td table tr td
+    #runs tr td table tr th,
+    #runs tr td table tr td
     {
         font-family: monospace;
         background-color: transparent !important;
@@ -60,8 +60,8 @@
     * Progressively show additional sample data columns.
     */
 
-    table tr th,
-    table tr td
+    #runs tr th,
+    #runs tr td
     {
         display: none
     }
@@ -71,26 +71,26 @@
     1. name, 2. type, 3. cached, 4. processed, 5. problems, 6. sample
     */
 
-    table tr th:nth-child(1), /* name + data sample */
-    table tr td:nth-child(1), /* name + data sample */
-    table tr.init th.processed,
-    table tr.init th.sample,
-    table tr.init td.processed,
-    table tr.init td.sample,
-    table tr td table tr th:nth-child(1),
-    table tr td table tr th:nth-child(2),
-    table tr td table tr th:nth-child(3),
-    table tr td table tr td:nth-child(1),
-    table tr td table tr td:nth-child(2),
-    table tr td table tr td:nth-child(3)
+    #runs tr th:nth-child(1), /* name + data sample */
+    #runs tr td:nth-child(1), /* name + data sample */
+    #runs tr.init th.processed,
+    #runs tr.init th.sample,
+    #runs tr.init td.processed,
+    #runs tr.init td.sample,
+    #runs tr td table tr th:nth-child(1),
+    #runs tr td table tr th:nth-child(2),
+    #runs tr td table tr th:nth-child(3),
+    #runs tr td table tr td:nth-child(1),
+    #runs tr td table tr td:nth-child(2),
+    #runs tr td table tr td:nth-child(3)
     {
         display: table-cell
     }
 
     @media (min-width: 400px)
     {
-        table tr td table tr th:nth-child(4),
-        table tr td table tr td:nth-child(4)
+        #runs tr td table tr th:nth-child(4),
+        #runs tr td table tr td:nth-child(4)
         {
             display: table-cell
         }
@@ -98,10 +98,10 @@
     
     @media (min-width: 640px)
     {
-        table tr.init th.cached,
-        table tr.init td.cached,
-        table tr td table tr th:nth-child(5),
-        table tr td table tr td:nth-child(5)
+        #runs tr.init th.cached,
+        #runs tr.init td.cached,
+        #runs tr td table tr th:nth-child(5),
+        #runs tr td table tr td:nth-child(5)
         {
             display: table-cell
         }
@@ -109,12 +109,12 @@
     
     @media (min-width: 960px)
     {
-        table tr.init th.type,
-        table tr.init th.problems,
-        table tr.init td.type,
-        table tr.init td.problems,
-        table tr td table tr th:nth-child(6),
-        table tr td table tr td:nth-child(6)
+        #runs tr.init th.type,
+        #runs tr.init th.problems,
+        #runs tr.init td.type,
+        #runs tr.init td.problems,
+        #runs tr td table tr th:nth-child(6),
+        #runs tr td table tr td:nth-child(6)
         {
             display: table-cell
         }
@@ -187,7 +187,7 @@
     }
 
 </script>
-<table>
+<table id="runs">
     <tr class="init">
         <th class="name">Name</th>
         <th class="type">Type</th>

--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -164,10 +164,9 @@ def main():
     close(handle)
     
     tippecanoe = call_tippecanoe(mbtiles_filename)
-    zip_details = ((source, filename) for (source, filename, _)
-                   in iterate_local_processed_files(runs))
+    results = iterate_local_processed_files(runs)
     
-    for feature in stream_all_features(zip_details):
+    for feature in stream_all_features(results):
         print(json.dumps(feature), file=tippecanoe.stdin)
     
     tippecanoe.stdin.close()
@@ -175,13 +174,13 @@ def main():
     
     mapbox_upload(mbtiles_filename, args.tileset_id, args.mapbox_user, args.mapbox_key)
 
-def stream_all_features(zip_details):
+def stream_all_features(results):
     ''' Generate a stream of all locations as GeoJSON features.
     '''
-    for (source_base, zip_filename) in zip_details:
-        _L.debug(u'Opening {} ({})'.format(zip_filename, source_base))
+    for result in results:
+        _L.debug(u'Opening {} ({})'.format(result.filename, result.source_base))
 
-        zipfile = ZipFile(zip_filename, mode='r')
+        zipfile = ZipFile(result.filename, mode='r')
         for filename in zipfile.namelist():
             # Look for the one expected .csv file in the zip archive.
             _, ext = splitext(filename)

--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -167,7 +167,8 @@ def main():
     results = iterate_local_processed_files(runs)
     
     for feature in stream_all_features(results):
-        print(json.dumps(feature), file=tippecanoe.stdin)
+        tippecanoe.stdin.write(json.dumps(feature).encode('utf8'))
+        tippecanoe.stdin.write(b'\n')
     
     tippecanoe.stdin.close()
     tippecanoe.wait()

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -706,8 +706,15 @@ class TestPackage (unittest.TestCase):
             download_processed_file.return_value = 'nonexistent file'
             local_processed_files = iterate_local_processed_files(runs)
             
-            self.assertEqual(next(local_processed_files), ('123', 'nonexistent file', state1))
-            self.assertEqual(next(local_processed_files), ('7/9', 'nonexistent file', state3))
+            local_processed_result1 = next(local_processed_files)
+            local_processed_result2 = next(local_processed_files)
+            
+            self.assertEqual(local_processed_result1.source_base, '123')
+            self.assertEqual(local_processed_result1.filename, 'nonexistent file')
+            self.assertEqual(local_processed_result1.run_state, state1)
+            self.assertEqual(local_processed_result2.source_base, '7/9')
+            self.assertEqual(local_processed_result2.filename, 'nonexistent file')
+            self.assertEqual(local_processed_result2.run_state, state3)
 
     def response_content(self, url, request):
         '''

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -1905,14 +1905,18 @@ class TestCollect (unittest.TestCase):
         set = mock.Mock()
         set.owner, set.repository, set.commit_sha = 'oa', 'oa', 'ff9900'
         
-        tests = {'nothing': lambda result: False, 'everything': lambda result: True}
-        collections = prepare_collections(self.s3, set, self.output_dir, tests)
+        tests = {'-nothing': lambda result: False, '-everything': lambda result: True}
+        collections = prepare_collections(self.s3, set, self.output_dir, tests, tests)
         
         for (collection, test) in collections:
-            if '-everything' in collection.zip.filename:
-                self.assertTrue(test(None))
-            elif '-nothing' in collection.zip.filename:
-                self.assertFalse(test(None))
+            self.assertIn('README.txt', collection.zip.namelist())
+            self.assertIn(b'oa/oa', collection.zip.read('README.txt'))
+            self.assertIn(b'ff9900', collection.zip.read('README.txt'))
+
+            if '-nothing' not in collection.zip.filename:
+                self.assertTrue(test(None), test(None))
+            else:
+                self.assertFalse(test(None), test(None))
 
     def test_collector_publisher(self):
         '''

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -44,7 +44,7 @@ from ..ci.collect import (
     )
 
 from ..jobs import JOB_TIMEOUT
-from .. import compat
+from .. import compat, LocalProcessedResult
 from . import FakeS3
 
 def en64(bytes):
@@ -1899,8 +1899,8 @@ class TestCollect (unittest.TestCase):
             s1 = {'license': 'ODbL', 'attribution name': 'ABC Co.'}
             s2 = {'website': 'http://example.com', 'attribution flag': 'false'}
             
-            collector_publisher.collect(('abc', 'abc.zip', s1))
-            collector_publisher.collect(('def', 'def.zip', s2))
+            collector_publisher.collect(LocalProcessedResult('abc', 'abc.zip', s1))
+            collector_publisher.collect(LocalProcessedResult('def', 'def.zip', s2))
             collector_publisher.publish()
 
             add_source_to_zipfile.assert_has_calls([
@@ -1930,46 +1930,51 @@ class TestCollect (unittest.TestCase):
         
         for abbr in ('ct', 'me', 'ma', 'nh', 'ri', 'vt', 'nj', 'ny', 'pa'):
             for source_base in ('us/{}'.format(abbr), 'us/{}.---'.format(abbr), 'us/{}/---'.format(abbr)):
-                self.assertTrue(is_us_northeast(source_base, _, _), 'is_us_northeast("{}") should be true'.format(source_base))
+                result = LocalProcessedResult(source_base, None, None)
+                self.assertTrue(is_us_northeast(result), 'is_us_northeast("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
                     if test_func is not is_us_northeast:
-                        self.assertFalse(test_func(source_base, _, _), '{}("{}") should be false'.format(test_func.__name__, source_base))
+                        self.assertFalse(test_func(result), '{}("{}") should be false'.format(test_func.__name__, source_base))
 
         for abbr in ('il', 'in', 'mi', 'oh', 'wi', 'ia', 'ks', 'mn', 'mo', 'ne', 'nd', 'sd'):
             for source_base in ('us/{}'.format(abbr), 'us/{}.---'.format(abbr), 'us/{}/---'.format(abbr)):
-                self.assertTrue(is_us_midwest(source_base, _, _), 'is_us_midwest("{}") should be true'.format(source_base))
+                result = LocalProcessedResult(source_base, None, None)
+                self.assertTrue(is_us_midwest(result), 'is_us_midwest("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
                     if test_func is not is_us_midwest:
-                        self.assertFalse(test_func(source_base, _, _), '{}("{}") should be false'.format(test_func.__name__, source_base))
+                        self.assertFalse(test_func(result), '{}("{}") should be false'.format(test_func.__name__, source_base))
 
         for abbr in ('de', 'fl', 'ga', 'md', 'nc', 'sc', 'va', 'dc', 'wv', 'al',
                      'ky', 'ms', 'ar', 'la', 'ok', 'tx', 'tn'):
             for source_base in ('us/{}'.format(abbr), 'us/{}.---'.format(abbr), 'us/{}/---'.format(abbr)):
-                self.assertTrue(is_us_south(source_base, _, _), 'is_us_south("{}") should be true'.format(source_base))
+                result = LocalProcessedResult(source_base, None, None)
+                self.assertTrue(is_us_south(result), 'is_us_south("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
                     if test_func is not is_us_south:
-                        self.assertFalse(test_func(source_base, _, _), '{}("{}") should be false'.format(test_func.__name__, source_base))
+                        self.assertFalse(test_func(result), '{}("{}") should be false'.format(test_func.__name__, source_base))
 
         for abbr in ('az', 'co', 'id', 'mt', 'nv', 'nm', 'ut', 'wy', 'ak', 'ca', 'hi', 'or', 'wa'):
             for source_base in ('us/{}'.format(abbr), 'us/{}.---'.format(abbr), 'us/{}/---'.format(abbr)):
-                self.assertTrue(is_us_west(source_base, _, _), 'is_us_west("{}") should be true'.format(source_base))
+                result = LocalProcessedResult(source_base, None, None)
+                self.assertTrue(is_us_west(result), 'is_us_west("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
                     if test_func is not is_us_west:
-                        self.assertFalse(test_func(source_base, _, _), '{}("{}") should be false'.format(test_func.__name__, source_base))
+                        self.assertFalse(test_func(result), '{}("{}") should be false'.format(test_func.__name__, source_base))
 
         for iso in ('be', 'bg', 'cz', 'dk', 'de', 'ee', 'ie', 'el', 'es', 'fr',
                     'hr', 'it', 'cy', 'lv', 'lt', 'lu', 'hu', 'mt', 'nl', 'at',
                     'pl', 'pt', 'ro', 'si', 'sk', 'fi', 'se', 'uk', 'gr', 'gb'):
             for source_base in (iso, '{}.---'.format(iso), '{}/---'.format(iso)):
-                self.assertTrue(is_europe(source_base, _, _), 'is_europe("{}") should be true'.format(source_base))
+                result = LocalProcessedResult(source_base, None, None)
+                self.assertTrue(is_europe(result), 'is_europe("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
                     if test_func is not is_europe:
-                        self.assertFalse(test_func(source_base, _, _), '{}("{}") should be false'.format(test_func.__name__, source_base))
+                        self.assertFalse(test_func(result), '{}("{}") should be false'.format(test_func.__name__, source_base))
 
         for iso in ('af', 'am', 'az', 'bh', 'bd', 'bt', 'bn', 'kh', 'cn', 'cx',
                     'cc', 'io', 'ge', 'hk', 'in', 'id', 'ir', 'iq', 'il', 'jp',
@@ -1982,11 +1987,12 @@ class TestCollect (unittest.TestCase):
                     'fm', 'um', 'nr', 'nc', 'nz', 'nu', 'nf', 'pw', 'pg', 'mp',
                     'sb', 'tk', 'to', 'tv', 'vu', 'um', 'wf', 'ws', 'is'):
             for source_base in (iso, '{}.---'.format(iso), '{}/---'.format(iso)):
-                self.assertTrue(is_asia(source_base, _, _), 'is_asia("{}") should be true'.format(source_base))
+                result = LocalProcessedResult(source_base, None, None)
+                self.assertTrue(is_asia(result), 'is_asia("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
                     if test_func is not is_asia:
-                        self.assertFalse(test_func(source_base, _, _), '{}("{}") should be false'.format(test_func.__name__, source_base))
+                        self.assertFalse(test_func(result), '{}("{}") should be false'.format(test_func.__name__, source_base))
 
     def test_add_source_to_zipfile(self):
         '''

--- a/openaddr/tests/util.py
+++ b/openaddr/tests/util.py
@@ -8,7 +8,31 @@ from mimetypes import guess_type
 from urllib.parse import urlparse, parse_qs
 from httmock import HTTMock, response
 
+from .. import util
 from ..util.esri2geojson import esri2geojson
+
+class TestUtilities (unittest.TestCase):
+
+    def test_db_kwargs(self):
+        '''
+        '''
+        dsn1 = 'postgres://who@where.kitchen/what'
+        kwargs1 = util.prepare_db_kwargs(dsn1)
+        self.assertEqual(kwargs1['user'], 'who')
+        self.assertIsNone(kwargs1['password'])
+        self.assertEqual(kwargs1['host'], 'where.kitchen')
+        self.assertIsNone(kwargs1['port'])
+        self.assertEqual(kwargs1['database'], 'what')
+        self.assertNotIn('sslmode', kwargs1)
+
+        dsn2 = 'postgres://who:open-sesame@where.kitchen:5432/what?sslmode=require'
+        kwargs2 = util.prepare_db_kwargs(dsn2)
+        self.assertEqual(kwargs2['user'], 'who')
+        self.assertEqual(kwargs2['password'], 'open-sesame')
+        self.assertEqual(kwargs2['host'], 'where.kitchen')
+        self.assertEqual(kwargs2['port'], 5432)
+        self.assertEqual(kwargs2['database'], 'what')
+        self.assertEqual(kwargs2['sslmode'], 'require')
 
 class TestEsri2GeoJSON (unittest.TestCase):
     

--- a/openaddr/util/__init__.py
+++ b/openaddr/util/__init__.py
@@ -1,0 +1,16 @@
+from urllib.parse import urlparse, parse_qsl
+
+def prepare_db_kwargs(dsn):
+    '''
+    '''
+    p = urlparse(dsn)
+    q = dict(parse_qsl(p.query))
+
+    assert p.scheme == 'postgres'
+    kwargs = dict(user=p.username, password=p.password, host=p.hostname, port=p.port)
+    kwargs.update(dict(database=p.path.lstrip('/')))
+
+    if 'sslmode' in q:
+        kwargs.update(dict(sslmode=q['sslmode']))
+    
+    return kwargs

--- a/test.py
+++ b/test.py
@@ -22,7 +22,7 @@ from openaddr.tests.conform import TestConformCli, TestConformTransforms, TestCo
 from openaddr.tests.expand import TestExpand
 from openaddr.tests.render import TestRender
 from openaddr.tests.dotmap import TestDotmap
-from openaddr.tests.util import TestEsri2GeoJSON
+from openaddr.tests.util import TestEsri2GeoJSON, TestUtilities
 from openaddr.tests.summarize import TestSummarizeFunctions
 from openaddr.tests.ci import TestHook, TestRuns, TestWorker, TestBatch, TestObjects, TestCollect
 

--- a/test.py
+++ b/test.py
@@ -15,7 +15,7 @@ import logging
 
 from openaddr import jobs
 
-from openaddr.tests import TestOA, TestPackage
+from openaddr.tests import TestOA, TestState, TestPackage
 from openaddr.tests.sample import TestSample
 from openaddr.tests.cache import TestCacheExtensionGuessing, TestCacheEsriDownload
 from openaddr.tests.conform import TestConformCli, TestConformTransforms, TestConformMisc, TestConformCsv, TestConformLicense


### PR DESCRIPTION
Splits collection files along attribution-required flags from run state, and introduces `LocalProcessedResult` class instead of implicit tuple values.

* [x] Display collection options on results page.
* [ ] Wait until share-alike flag is implemented in #253.

Closes #236, part of https://github.com/openaddresses/openaddresses-ops/issues/7.