### PR TITLE
Lying to OGR about .txt files

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -208,8 +208,8 @@ class ExcerptDataTask(object):
         data_path = known_paths[0]
         _, data_ext = os.path.splitext(data_path.lower())
 
-        # Sample a few GeoJSON features to save on memory for large datasets.
         if data_ext in ('.geojson', '.json'):
+            # Sample a few GeoJSON features to save on memory for large datasets.
             with open(data_path, 'r') as complete_layer:
                 temp_dir = os.path.dirname(data_path)
                 _, temp_path = tempfile.mkstemp(dir=temp_dir, suffix='.json')
@@ -217,6 +217,12 @@ class ExcerptDataTask(object):
                 with open(temp_path, 'w') as temp_file:
                     temp_file.write(sample_geojson(complete_layer, 10))
                     data_path = temp_path
+        
+        elif data_ext == '.txt':
+            # Convince OGR it's looking at a CSV file.
+            new_path = data_path + '.csv'
+            os.link(data_path, new_path)
+            data_path, data_ext = new_path, '.csv'
         
         datasource = ogr.Open(data_path, 0)
         layer = datasource.GetLayer()


### PR DESCRIPTION
Completes the work from https://github.com/openaddresses/machine/pull/245, and might wrap up #244.

OGR doesn’t understand the `.txt` extension on its own, and needs to be told that these are CSV files.