### PR TITLE
Populate share-alike

### DIFF
--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -33,6 +33,7 @@ from .conform import (
     elaborate_filenames,
     conform_license,
     conform_attribution,
+    conform_sharealike,
 )
 
 with open(join(dirname(__file__), 'VERSION')) as file:
@@ -179,6 +180,7 @@ def conform(srcjson, destdir, extras):
 
     rmtree(workdir)
     
+    sharealike_flag = conform_sharealike(data.get('license'))
     attr_flag, attr_name = conform_attribution(data.get('license'), data.get('attribution'))
 
     return ConformResult(data.get('processed', None),
@@ -189,6 +191,7 @@ def conform(srcjson, destdir, extras):
                          addr_count,
                          out_path,
                          datetime.now() - start,
+                         sharealike_flag,
                          attr_flag,
                          attr_name)
 

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -32,7 +32,7 @@ from ..summarize import summarize_runs, GLASS_HALF_FULL, GLASS_HALF_EMPTY, nice_
 
 CSV_HEADER = 'source', 'cache', 'sample', 'geometry type', 'address count', \
              'version', 'fingerprint', 'cache time', 'processed', 'process time', \
-             'output', 'attribution required', 'attribution name'
+             'output', 'attribution required', 'attribution name', 'share-alike'
 
 webhooks = Blueprint('webhooks', __name__, template_folder='templates')
 

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -979,3 +979,26 @@ def conform_attribution(license, attribution):
         attr_name = None
     
     return attr_flag, attr_name
+
+def conform_sharealike(share_alike):
+    ''' Convert optional license share-alike tags.
+    
+        Return boolean share-alike flag.
+    '''
+    if share_alike is None:
+        return False
+
+    if share_alike is False:
+        return False
+
+    if share_alike is True:
+        return True
+    
+    if hasattr(share_alike, 'lower'):
+        if share_alike.lower() in ('n', 'no', 'f', 'false', ''):
+            return False
+    
+    if hasattr(share_alike, 'lower'):
+        if share_alike.lower() in ('y', 'yes', 't', 'true'):
+            return True
+

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -991,7 +991,7 @@ def conform_sharealike(license):
     is_dict = license is not None and hasattr(license, 'get')
     
     if not is_dict or 'share-alike' not in license:
-        return False
+        return None
     
     share_alike = license.get('share-alike')
     

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -78,11 +78,13 @@ class ConformResult:
     address_count = None
     path = None
     elapsed = None
+    sharealike_flag = None
     attribution_flag = None
     attribution_name = None
     
     def __init__(self, processed, sample, website, license, geometry_type,
-                 address_count, path, elapsed, attribution_flag, attribution_name):
+                 address_count, path, elapsed, sharealike_flag,
+                 attribution_flag, attribution_name):
         self.processed = processed
         self.sample = sample
         self.website = website
@@ -91,12 +93,13 @@ class ConformResult:
         self.address_count = address_count
         self.path = path
         self.elapsed = elapsed
+        self.sharealike_flag = sharealike_flag
         self.attribution_flag = attribution_flag
         self.attribution_name = attribution_name
 
     @staticmethod
     def empty():
-        return ConformResult(None, None, None, None, None, None, None, None, None, None)
+        return ConformResult(None, None, None, None, None, None, None, None, None, None, None)
 
     def todict(self):
         return dict(processed=self.processed, sample=self.sample)
@@ -980,11 +983,18 @@ def conform_attribution(license, attribution):
     
     return attr_flag, attr_name
 
-def conform_sharealike(share_alike):
+def conform_sharealike(license):
     ''' Convert optional license share-alike tags.
     
         Return boolean share-alike flag.
     '''
+    is_dict = license is not None and hasattr(license, 'get')
+    
+    if not is_dict or 'share-alike' not in license:
+        return False
+    
+    share_alike = license.get('share-alike')
+    
     if share_alike is None:
         return False
 

--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -162,6 +162,7 @@ def write_state(source, skipped, destination, log_handler, cache_result,
         ('output', relpath(output_path, statedir)),
         ('attribution required', boolstr(conform_result.attribution_flag)),
         ('attribution name', conform_result.attribution_name),
+        ('share-alike', boolstr(conform_result.sharealike_flag)),
         ]
                
     with csvopen(join(statedir, 'index.txt'), 'w', encoding='utf8') as file:

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -436,6 +436,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point')
         self.assertIsNone(state['website'])
         self.assertEqual(state['license'][:21], 'Polish Law on Geodesy')
+        self.assertEqual(state['share-alike'], 'false')
         self.assertIn('issues/187#issuecomment-63327973', state['license'])
         
         with open(join(dirname(state_path), state['sample'])) as file:
@@ -463,6 +464,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point')
         self.assertIsNone(state['website'])
         self.assertEqual(state['license'][:21], 'Polish Law on Geodesy')
+        self.assertEqual(state['share-alike'], 'false')
         self.assertIn('issues/187#issuecomment-63327973', state['license'])
         
         with open(join(dirname(state_path), state['sample'])) as file:
@@ -545,6 +547,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['website'], 'http://adresse.data.gouv.fr/download/')
         self.assertIsNone(state['license'])
         self.assertEqual(state['attribution required'], 'true')
+        self.assertEqual(state['share-alike'], 'true')
         self.assertIn(u'Géographique et Forestière', state['attribution name'])
 
         with open(join(dirname(state_path), state['sample'])) as file:
@@ -571,6 +574,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['website'], 'http://adresse.data.gouv.fr/download/')
         self.assertIsNone(state['license'])
         self.assertEqual(state['attribution required'], 'true')
+        self.assertEqual(state['share-alike'], 'true')
         self.assertIn(u'Géographique et Forestière', state['attribution name'])
 
         with open(join(dirname(state_path), state['sample'])) as file:

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -158,6 +158,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point')
         self.assertIsNone(state['website'])
         self.assertEqual(state['license'], 'http://www.acgov.org/acdata/terms.htm')
+        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -201,6 +202,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point')
         self.assertIsNone(state['website'])
         self.assertEqual(state['license'], '')
+        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -244,6 +246,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point 2.5D')
         self.assertEqual(state['website'], 'http://ci.carson.ca.us/')
         self.assertIsNone(state['license'])
+        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -331,6 +334,7 @@ class TestOA (unittest.TestCase):
         self.assertIsNone(state['processed'])
         self.assertEqual(state['website'], 'http://data.openoakland.org/dataset/property-parcels/resource/df20b818-0d16-4da8-a9c1-a7b8b720ff49')
         self.assertIsNone(state['license'])
+        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -369,6 +373,7 @@ class TestOA (unittest.TestCase):
         self.assertTrue(state['processed'] is None)
         self.assertEqual(state['website'], 'http://www.ci.berkeley.ca.us/datacatalog/')
         self.assertIsNone(state['license'])
+        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -404,6 +409,7 @@ class TestOA (unittest.TestCase):
         self.assertIsNotNone(state['processed'])
         self.assertEqual(state['website'], 'http://www.ci.berkeley.ca.us/datacatalog/')
         self.assertIsNone(state['license'])
+        self.assertEqual(state['share-alike'], 'false')
         
         output_path = join(dirname(state_path), state['processed'])
         
@@ -501,6 +507,7 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['website'], 'http://nlftp.mlit.go.jp/isj/index.html')
         self.assertEqual(state['license'], u'http://nlftp.mlit.go.jp/ksj/other/yakkan§.html')
         self.assertEqual(state['attribution required'], 'true')
+        self.assertEqual(state['share-alike'], 'false')
         self.assertIn('Ministry of Land', state['attribution name'])
         
         with open(join(dirname(state_path), state['sample'])) as file:

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -158,7 +158,6 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point')
         self.assertIsNone(state['website'])
         self.assertEqual(state['license'], 'http://www.acgov.org/acdata/terms.htm')
-        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -202,7 +201,6 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point')
         self.assertIsNone(state['website'])
         self.assertEqual(state['license'], '')
-        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -246,7 +244,6 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['geometry type'], 'Point 2.5D')
         self.assertEqual(state['website'], 'http://ci.carson.ca.us/')
         self.assertIsNone(state['license'])
-        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -334,7 +331,6 @@ class TestOA (unittest.TestCase):
         self.assertIsNone(state['processed'])
         self.assertEqual(state['website'], 'http://data.openoakland.org/dataset/property-parcels/resource/df20b818-0d16-4da8-a9c1-a7b8b720ff49')
         self.assertIsNone(state['license'])
-        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -373,7 +369,6 @@ class TestOA (unittest.TestCase):
         self.assertTrue(state['processed'] is None)
         self.assertEqual(state['website'], 'http://www.ci.berkeley.ca.us/datacatalog/')
         self.assertIsNone(state['license'])
-        self.assertEqual(state['share-alike'], 'false')
         
         with open(join(dirname(state_path), state['sample'])) as file:
             sample_data = json.load(file)
@@ -409,7 +404,6 @@ class TestOA (unittest.TestCase):
         self.assertIsNotNone(state['processed'])
         self.assertEqual(state['website'], 'http://www.ci.berkeley.ca.us/datacatalog/')
         self.assertIsNone(state['license'])
-        self.assertEqual(state['share-alike'], 'false')
         
         output_path = join(dirname(state_path), state['processed'])
         
@@ -507,7 +501,6 @@ class TestOA (unittest.TestCase):
         self.assertEqual(state['website'], 'http://nlftp.mlit.go.jp/isj/index.html')
         self.assertEqual(state['license'], u'http://nlftp.mlit.go.jp/ksj/other/yakkan§.html')
         self.assertEqual(state['attribution required'], 'true')
-        self.assertEqual(state['share-alike'], 'false')
         self.assertIn('Ministry of Land', state['attribution name'])
         
         with open(join(dirname(state_path), state['sample'])) as file:

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -780,12 +780,12 @@ class TestConformLicense (unittest.TestCase):
         ''' Test combinations of share=alike data.
         '''
         for undict in (None, False, True, 'this', 'that'):
-            self.assertFalse(conform_sharealike(undict), '{} should be False'.format(undict))
+            self.assertIs(conform_sharealike(undict), None, '{} should be None'.format(undict))
         
         for value1 in (False, 'No', 'no', 'false', 'False', 'n', 'f', None, ''):
             dict1 = {'share-alike': value1}
-            self.assertFalse(conform_sharealike(dict1), 'sa:{} should be False'.format(repr(value1)))
+            self.assertIs(conform_sharealike(dict1), False, 'sa:{} should be False'.format(repr(value1)))
 
         for value2 in (True, 'Yes', 'yes', 'true', 'True', 'y', 't'):
             dict2 = {'share-alike': value2}
-            self.assertTrue(conform_sharealike(dict2), 'sa:{} should be True'.format(repr(value2)))
+            self.assertIs(conform_sharealike(dict2), True, 'sa:{} should be True'.format(repr(value2)))

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -779,8 +779,13 @@ class TestConformLicense (unittest.TestCase):
     def test_sharealike(self):
         ''' Test combinations of share=alike data.
         '''
+        for undict in (None, False, True, 'this', 'that'):
+            self.assertFalse(conform_sharealike(undict), '{} should be False'.format(undict))
+        
         for value1 in (False, 'No', 'no', 'false', 'False', 'n', 'f', None, ''):
-            self.assertFalse(conform_sharealike(value1), '{} should be False'.format(repr(value1)))
+            dict1 = {'share-alike': value1}
+            self.assertFalse(conform_sharealike(dict1), 'sa:{} should be False'.format(repr(value1)))
 
         for value2 in (True, 'Yes', 'yes', 'true', 'True', 'y', 't'):
-            self.assertTrue(conform_sharealike(value2), '{} should be True'.format(repr(value2)))
+            dict2 = {'share-alike': value2}
+            self.assertTrue(conform_sharealike(dict2), 'sa:{} should be True'.format(repr(value2)))

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -18,7 +18,7 @@ from ..conform import (
     row_extract_and_reproject, row_convert_to_out, row_fxn_join,
     row_canonicalize_street_and_number, conform_smash_case, conform_cli,
     csvopen, csvDictReader, convert_regexp_replace, conform_license,
-    conform_attribution
+    conform_attribution, conform_sharealike
     )
 
 class TestConformTransforms (unittest.TestCase):
@@ -775,3 +775,12 @@ class TestConformLicense (unittest.TestCase):
         attr_flag14, attr_name14 = conform_attribution({'attribution': None, 'attribution name': False}, None)
         self.assertIs(attr_flag14, True)
         self.assertEqual(attr_name14, 'False')
+    
+    def test_sharealike(self):
+        ''' Test combinations of share=alike data.
+        '''
+        for value1 in (False, 'No', 'no', 'false', 'False', 'n', 'f', None, ''):
+            self.assertFalse(conform_sharealike(value1), '{} should be False'.format(repr(value1)))
+
+        for value2 in (True, 'Yes', 'yes', 'true', 'True', 'y', 't'):
+            self.assertTrue(conform_sharealike(value2), '{} should be True'.format(repr(value2)))

--- a/openaddr/tests/sources/fr-paris.json
+++ b/openaddr/tests/sources/fr-paris.json
@@ -22,6 +22,7 @@
     "license":
     {
         "attribution": true,
-        "attribution name": "Institut National de l'Information Géographique et Forestière"
+        "attribution name": "Institut National de l'Information Géographique et Forestière",
+        "share-alike": "yes"
     }
 }

--- a/openaddr/tests/sources/fr/la-réunion.json
+++ b/openaddr/tests/sources/fr/la-réunion.json
@@ -22,6 +22,7 @@
     },
     "license":
     {
-        "attribution name": "Institut National de l'Information Géographique et Forestière"
+        "attribution name": "Institut National de l'Information Géographique et Forestière",
+        "share-alike": true
     }
 }

--- a/openaddr/tests/sources/pl-dolnoslaskie.json
+++ b/openaddr/tests/sources/pl-dolnoslaskie.json
@@ -10,7 +10,8 @@
     },
     "license": {
         "text": "Polish Law on Geodesy and Cartography of 17 May 1989",
-        "url": "https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973"
+        "url": "https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+        "share-alike": false
     },
     "compression": "zip",
     "conform": {

--- a/openaddr/tests/sources/pl-lodzkie.json
+++ b/openaddr/tests/sources/pl-lodzkie.json
@@ -10,7 +10,8 @@
     },
     "license": {
         "text": "Polish Law on Geodesy and Cartography of 17 May 1989",
-        "url": "https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973"
+        "url": "https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+        "share-alike": "no"
     },
     "compression": "zip",
     "conform": {


### PR DESCRIPTION
* [x] Read share-alike flags from sources.
* [x] Add share-alike columns to output CSV.
* [x] Decide on implicit values.

Closes #253, part of https://github.com/openaddresses/openaddresses-ops/issues/7.