### PR TITLE
use mapbox sdk for uploads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'psycopg2 == 2.6.1',
         
         # https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991/comments/10
-        'requests == 2.2.1',
+        'requests == 2.8.1',
 
         # https://pypi.python.org/pypi/requests-ftp, appears no longer maintained.
         'requests-ftp == 0.2.0',
@@ -93,6 +93,9 @@ setup(
         
         # https://boto3.readthedocs.org
         'boto3 == 1.1.4',
+
+        # https://github.com/mapbox/mapbox-sdk-py
+        'mapbox == 0.5.0',
 
         ] + conditional_requirements
 )


### PR DESCRIPTION
I think we were actually stymied by a busted upload in the deep guts of the Mapbox machine, doubtless wedged in there during some now-forgotten openaddresses dotmap test run. Some colleagues in devops helped me un-jam the gears, at which point this code started working.

I would not be surprised if your existing code works. But I think it's probably worthwhile to upgrade to the officially supported SDK for simplicity's sake. It's got tests & a clearer upgrade path.

Note that I had to bump up the version of `requests` in order to get access to its `json()` convenience method.