### PR TITLE
Replaced default "user_input" name in worker with meaningful string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ install:
   - pip install cairocffi
   - sudo chef/run.sh testing
   - pip install -U .
-env:  DATABASE_URL=postgres://openaddr:openaddr@localhost/openaddr
+env:  BOTO_CONFIG=/tmp/nowhere DATABASE_URL=postgres://openaddr:openaddr@localhost/openaddr
 script:  python setup.py test

--- a/openaddr/ci/worker.py
+++ b/openaddr/ci/worker.py
@@ -32,6 +32,11 @@ def upload_file(s3, keyname, filename):
     
     return url, key.md5
 
+def make_source_filename(source_name):
+    '''
+    '''
+    return source_name.replace(u'/', u'--') + '.txt'
+
 def do_work(s3, run_id, source_name, job_contents_b64, output_dir):
     "Do the actual work of running a source file in job_contents"
 
@@ -39,7 +44,7 @@ def do_work(s3, run_id, source_name, job_contents_b64, output_dir):
     workdir = tempfile.mkdtemp(prefix='work-', dir=output_dir)
 
     # Write the user input to a file
-    out_fn = os.path.join(workdir, 'user_input.txt')
+    out_fn = os.path.join(workdir, make_source_filename(source_name))
     with open(out_fn, 'wb') as out_fp:
         out_fp.write(base64.b64decode(job_contents_b64))
 

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -44,6 +44,7 @@ from ..ci.collect import (
     )
 
 from ..jobs import JOB_TIMEOUT
+from ..ci.worker import make_source_filename
 from .. import compat, LocalProcessedResult
 from . import FakeS3
 
@@ -1506,6 +1507,13 @@ class TestWorker (unittest.TestCase):
         rmtree(self.output_dir)
         remove(self.s3._fake_keys)
     
+    def test_make_source_filename(self):
+        '''
+        '''
+        self.assertEqual(make_source_filename(u'yo'), u'yo.txt')
+        self.assertEqual(make_source_filename(u'yo-yo'), u'yo-yo.txt')
+        self.assertEqual(make_source_filename(u'yo/yo'), u'yo--yo.txt')
+    
     @patch('tempfile.mkdtemp')
     @patch('openaddr.compat.check_output')
     def test_happy_worker(self, check_output, mkdtemp):
@@ -1540,7 +1548,7 @@ class TestWorker (unittest.TestCase):
         check_output.assert_called_with((
             'openaddr-process-one', '-l',
             os.path.join(self.output_dir, 'work/logfile.txt'),
-            os.path.join(self.output_dir, 'work/user_input.txt'),
+            os.path.join(self.output_dir, u'work/so--exalté.txt'),
             os.path.join(self.output_dir, 'work/out')
             ),
             timeout=JOB_TIMEOUT.seconds + JOB_TIMEOUT.days * 86400)
@@ -1593,7 +1601,7 @@ class TestWorker (unittest.TestCase):
         check_output.assert_called_with((
             'openaddr-process-one', '-l',
             os.path.join(self.output_dir, 'work/logfile.txt'),
-            os.path.join(self.output_dir, 'work/user_input.txt'),
+            os.path.join(self.output_dir, 'work/angry.txt'),
             os.path.join(self.output_dir, 'work/out')
             ),
             timeout=JOB_TIMEOUT.seconds + JOB_TIMEOUT.days * 86400)
@@ -1635,7 +1643,7 @@ class TestWorker (unittest.TestCase):
         check_output.assert_called_with((
             'openaddr-process-one', '-l',
             os.path.join(self.output_dir, 'work/logfile.txt'),
-            os.path.join(self.output_dir, 'work/user_input.txt'),
+            os.path.join(self.output_dir, u'work/so--exalté.txt'),
             os.path.join(self.output_dir, 'work/out')
             ),
             timeout=JOB_TIMEOUT.seconds + JOB_TIMEOUT.days * 86400)


### PR DESCRIPTION
* [ ] Wait for tests to pass on Travis.

Closes #218.