### PR TITLE
Give cacher knowledge of the conform object so it can request only the required fields

### DIFF
--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -97,7 +97,7 @@ def cache(srcjson, destdir, extras):
         source_urls = [source_urls]
 
     task = DownloadTask.from_type_string(data.get('type'), source)
-    downloaded_files = task.download(source_urls, workdir)
+    downloaded_files = task.download(source_urls, workdir, data.get('conform'))
 
     # FIXME: I wrote the download stuff to assume multiple files because
     # sometimes a Shapefile fileset is splayed across multiple files instead

--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -229,7 +229,7 @@ class URLDownloadTask(DownloadTask):
 
         return os.path.join(dir_path, name_base + path_ext)
 
-    def download(self, source_urls, workdir, conform):
+    def download(self, source_urls, workdir, conform=None):
         output_files = []
         download_path = os.path.join(workdir, 'http')
         mkdirsp(download_path)
@@ -412,7 +412,7 @@ class EsriRestDownloadTask(DownloadTask):
             if k in attrib_types:
                 if isinstance(v, dict):
                     # It's a function of some sort
-                    fields.add(k.get('field'))
+                    fields.add(v.get('field'))
                 elif isinstance(v, list):
                     # It's a list of field names
                     for f in v:
@@ -421,11 +421,11 @@ class EsriRestDownloadTask(DownloadTask):
                     fields.add(v)
 
         if fields:
-            return ','.join(filter(None, fields))
+            return ','.join(filter(None, sorted(fields)))
         else:
             return '*'
 
-    def download(self, source_urls, workdir, conform):
+    def download(self, source_urls, workdir, conform=None):
         output_files = []
         download_path = os.path.join(workdir, 'esri')
         mkdirsp(download_path)

--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -408,7 +408,7 @@ class EsriRestDownloadTask(DownloadTask):
             return '*'
 
         fields = set()
-        for k, v in conform.iteritems():
+        for k, v in conform.items():
             if k in attrib_types:
                 if isinstance(v, dict):
                     # It's a function of some sort

--- a/openaddr/tests/cache.py
+++ b/openaddr/tests/cache.py
@@ -169,28 +169,41 @@ class TestCacheEsriDownload (unittest.TestCase):
         """ ESRI Caching Supports Object ID Enumeration """
         with httmock.HTTMock(self.response_content):
             task = EsriRestDownloadTask('us-ca-carson')
-            task.download(['http://www.carsonproperty.info/ArcGIS/rest/services/basemap/MapServer/1'], self.workdir)
-    
+            task.download(['http://www.carsonproperty.info/ArcGIS/rest/services/basemap/MapServer/1'], self.workdir, None)
+
     def test_download_madison(self):
         """ ESRI Caching Supports Statistics Pagination """
         with httmock.HTTMock(self.response_content):
             task = EsriRestDownloadTask('us-ms-madison')
-            task.download(['http://gis.cmpdd.org/arcgis/rest/services/Viewers/Madison/MapServer/13'], self.workdir)
+            task.download(['http://gis.cmpdd.org/arcgis/rest/services/Viewers/Madison/MapServer/13'], self.workdir, None)
 
     def test_download_esri_sample(self):
         """ ESRI Caching Supports Advanced Query Pagination """
         with httmock.HTTMock(self.response_content):
             task = EsriRestDownloadTask('us-esri-test')
-            task.download(['https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0'], self.workdir)
+            task.download(['https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0'], self.workdir, None)
 
     def test_download_tuolumne(self):
         """ ESRI Caching Supports Statistics That Doesn't Respect Requested outField Name """
         with httmock.HTTMock(self.response_content):
             task = EsriRestDownloadTask('us-ca-tuolumne')
-            task.download(['http://gis.co.tuolumne.ca.us/arcgis/rest/services/Address_Parcels/MapServer/0'], self.workdir)
+            task.download(['http://gis.co.tuolumne.ca.us/arcgis/rest/services/Address_Parcels/MapServer/0'], self.workdir, None)
 
     def test_download_palmbeach(self):
         """ ESRI Caching Falls Through To OID Enumeration When Statistics Doesn't Work """
         with httmock.HTTMock(self.response_content):
             task = EsriRestDownloadTask('us-fl-palmbeach')
-            task.download(['http://gis.kentcountymi.gov/prodarcgis/rest/services/External/MapServer/5'], self.workdir)
+            task.download(['http://gis.kentcountymi.gov/prodarcgis/rest/services/External/MapServer/5'], self.workdir, None)
+
+    def test_download_with_conform(self):
+        """ ESRI Caching Will Request With The Minimum Fields Required """
+        conforms = (
+            ('*', None),
+            ('a,b,c', {'type': 'csv', 'street': ['a', 'b'], 'number': 'c'}),
+            ('a', {'type': 'csv', 'street': {'function': 'regexp', 'field': 'a'}, 'number': {'function': 'regexp', 'field': 'a'}}),
+        )
+
+        task = EsriRestDownloadTask('us-fl-palmbeach')
+        for expected, conform in conforms:
+            actual = task.field_names_to_request(conform)
+            self.assertEquals(expected, actual)


### PR DESCRIPTION
Fixes #268.