### PR TITLE
Time-sort stream of sources for batch set

### DIFF
--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -328,8 +328,46 @@ def update_success_status(status_url, job_url, filenames, github_auth):
     
     return post_github_status(status_url, status, github_auth)
 
-def find_batch_sources(owner, repository, github_auth):
+def find_batch_sources(owner, repository, github_auth, run_times={}):
     ''' Starting with a Github repo API URL, generate a stream of master sources.
+    '''
+    source_urls = list(_find_batch_source_urls(owner, repository, github_auth))
+    
+    # sort with the shortest known runs at the end, keeping the 9999's alphabetical.
+    source_urls.sort(key=lambda su: su['path'])
+    source_urls.sort(key=lambda su: (run_times.get(su['path']) or '9999'), reverse=True)
+    
+    for source_url in source_urls:
+        _L.debug('Getting source {url}'.format(**source_url))
+        try:
+            more_source = get(source_url['url'], auth=github_auth).json()
+        except ConnectionError:
+            _L.info('Retrying to download {url}'.format(**source))
+            try:
+                sleep(GITHUB_RETRY_DELAY.seconds + GITHUB_RETRY_DELAY.days * 86400)
+                more_source = get(source_url['url'], auth=github_auth).json()
+            except ConnectionError:
+                _L.error('Failed to download {url}'.format(**source_url))
+                raise
+
+        source = dict(content=more_source['content'])
+        source.update(source_url)
+        
+        yield source
+
+def get_batch_run_times(db, owner, repository):
+    '''
+    '''
+    from .objects import read_latest_set, read_completed_runs_to_date
+    last_set = read_latest_set(db, owner, repository)
+    run_times = {run.source_path: run.state['process time']
+                 for run in read_completed_runs_to_date(db, last_set.id)
+                 if run.state}
+    
+    return run_times
+
+def _find_batch_source_urls(owner, repository, github_auth):
+    ''' Starting with a Github repo API URL, generate a stream of sources.
     '''
     resp = get('https://api.github.com/', auth=github_auth)
     if resp.status_code >= 400:
@@ -348,7 +386,7 @@ def find_batch_sources(owner, repository, github_auth):
     
     contents_url += '{?ref}' # So that we are consistently at the same commit.
     sources_urls = [expand_uri(contents_url, dict(path='sources', ref=commit_sha))]
-    sources_dict = dict()
+    sources_list = list()
 
     for sources_url in sources_urls:
         _L.debug('Getting sources {sources_url}'.format(**locals()))
@@ -366,6 +404,11 @@ def find_batch_sources(owner, repository, github_auth):
             path_base, ext = splitext(source['path'])
         
             if ext == '.json':
+                sources_list.append(dict(commit_sha=commit_sha, url=source['url'],
+                                         blob_sha=source['sha'], path=source['path']))
+
+                continue
+            
                 _L.debug('Getting source {url}'.format(**source))
                 try:
                     more_source = get(source['url'], auth=github_auth).json()
@@ -378,9 +421,11 @@ def find_batch_sources(owner, repository, github_auth):
                         _L.error('Failed to download {url}'.format(**source))
                         raise
 
-                yield dict(commit_sha=commit_sha, url=source['url'],
-                           blob_sha=source['sha'], path=source['path'],
-                           content=more_source['content'])
+                #yield dict(commit_sha=commit_sha, url=source['url'],
+                #           blob_sha=source['sha'], path=source['path'],
+                #           content=more_source['content'])
+
+    return sources_list
 
 def enqueue_sources(queue, the_set, sources):
     ''' Batch task generator, yields counts of remaining expected paths.

--- a/openaddr/ci/enqueue.py
+++ b/openaddr/ci/enqueue.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 
 from . import (
     db_connect, db_queue, TASK_QUEUE, load_config, setup_logger,
-    enqueue_sources, find_batch_sources
+    enqueue_sources, find_batch_sources, get_batch_run_times
     )
 
 from .objects import add_set
@@ -72,14 +72,10 @@ def main():
             minimum_capacity = count(1)
         
             with task_Q as db:
-                from . import get_batch_run_times
                 run_times = get_batch_run_times(db, args.owner, args.repository)
 
             sources = find_batch_sources(args.owner, args.repository, github_auth, run_times)
-
-            print len(list(sources))
-            return 1
-
+            
             with task_Q as db:
                 new_set = add_set(db, args.owner, args.repository)
 


### PR DESCRIPTION
We want to sort the list of sources for a batch set, so that lengthy or unpredictable ones come first. This will reduce the long tail of workers enabling the the auto-scale pool to shrink in a more timely way. Follow-on to #298 related to potentially long-running mega sources.

* [x] Clean up messy first pass.
* [x] Test that it all works.
