### PR TITLE
Fix attribution language in downloads

### DIFF
--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -156,7 +156,7 @@ class CollectorPublisher:
 
         attribution = 'No'
         if result.run_state.get('attribution flag') != 'false':
-            attribution = result.run_state.get('attribution name')
+            attribution = result.run_state.get('attribution name') or 'Yes'
     
         self.sources[result.source_base] = {
             'website': result.run_state.get('website') or 'Unknown',


### PR DESCRIPTION
* [x] Use "Yes" for attribution required in collections LICENSE.txt when no name provided.
* [x] Check what’s going on in individual source downloads.

Closes #326.