### PR TITLE
Fix argparse arguments that append and are required.

### DIFF
--- a/openaddr/util/esri2geojson.py
+++ b/openaddr/util/esri2geojson.py
@@ -125,10 +125,10 @@ parser.add_argument('-q', '--quiet', help='Turn off most logging',
                     action='store_const', dest='loglevel',
                     const=logging.WARNING, default=logging.INFO)
 
-parser.add_argument('-H', '--header', help='Add an HTTP header for ESRI server',
+parser.add_argument('-H', '--header', default=[], help='Add an HTTP header for ESRI server',
                     action='append', dest='header')
 
-parser.add_argument('-p', '--param', help='Add a URL parameter for ESRI server',
+parser.add_argument('-p', '--param', default=[], help='Add a URL parameter for ESRI server',
                     action='append', dest='param')
 
 def main():


### PR DESCRIPTION
Fixes #336 

I came across this when I tried to use `esri2geojson` without the new header and params flags. Adding the default empty lists prevents `_collect_headers()` and `_collect_headers()` from iterating over `None`.