### PR TITLE
Switched third arg of LocalProcessedResult to RunState

### DIFF
--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -66,6 +66,9 @@ class S3:
 
 class LocalProcessedResult:
     def __init__(self, source_base, filename, run_state, code_version):
+        for attr in ('attribution_name', 'attribution_flag', 'website', 'license'):
+            assert hasattr(run_state, attr), 'Run state should have {} property'.format(attr)
+        
         self.source_base = source_base
         self.filename = filename
         self.run_state = run_state

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -79,8 +79,8 @@ def main():
         'us_west': is_us_west, 'europe': is_europe, 'asia': is_asia
         }
     sa_tests = {
-        '': (lambda result: result.run_state.get('share-alike', '') != 'true'),
-        'sa': (lambda result: result.run_state.get('share-alike', '') == 'true')
+        '': (lambda result: result.run_state.share_alike != 'true'),
+        'sa': (lambda result: result.run_state.share_alike == 'true')
         }
     
     collections = prepare_collections(s3, set, dir, area_tests, sa_tests)
@@ -155,12 +155,12 @@ class CollectorPublisher:
         add_source_to_zipfile(self.zip, result)
 
         attribution = 'No'
-        if result.run_state.get('attribution flag') != 'false':
-            attribution = result.run_state.get('attribution name') or 'Yes'
+        if result.run_state.attribution_flag != 'false':
+            attribution = result.run_state.attribution_name or 'Yes'
     
         self.sources[result.source_base] = {
-            'website': result.run_state.get('website') or 'Unknown',
-            'license': result.run_state.get('license') or 'Unknown',
+            'website': result.run_state.website or 'Unknown',
+            'license': result.run_state.license or 'Unknown',
             'attribution': attribution
             }
         

--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -72,7 +72,8 @@ class RunState:
         for key in ('source', 'cache', 'sample', 'geometry type',
         'address count', 'version', 'fingerprint', 'cache time', 'processed',
         'output', 'process time', 'website', 'skipped', 'license',
-        'share-alike', 'attribution required', 'attribution name')}
+        'share-alike', 'attribution required', 'attribution name',
+        'attribution flag')}
 
     def __init__(self, json_blob):
         blob_dict = dict(json_blob or {})
@@ -95,6 +96,7 @@ class RunState:
         self.share_alike = blob_dict.get('share-alike')
         self.attribution_required = blob_dict.get('attribution required')
         self.attribution_name = blob_dict.get('attribution name')
+        self.attribution_flag = blob_dict.get('attribution flag')
 
         unexpected = ', '.join(set(self.keys) - set(RunState.key_attrs.keys()))
         assert len(unexpected) == 0, 'RunState should not have keys {}'.format(unexpected)

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2595,9 +2595,9 @@ class TestCollect (unittest.TestCase):
             s1 = {'license': 'ODbL', 'attribution name': 'ABC Co.'}
             s2 = {'website': 'http://example.com', 'attribution flag': 'false'}
             s3 = {'attribution flag': 'true', 'attribution name': ''}
-            r1 = LocalProcessedResult('abc', 'abc.zip', s1, None)
-            r2 = LocalProcessedResult('def', 'def.zip', s2, None)
-            r3 = LocalProcessedResult('ghi', 'ghi.zip', s3, None)
+            r1 = LocalProcessedResult('abc', 'abc.zip', RunState(s1), None)
+            r2 = LocalProcessedResult('def', 'def.zip', RunState(s2), None)
+            r3 = LocalProcessedResult('ghi', 'ghi.zip', RunState(s3), None)
             
             collector_publisher.collect(r1)
             collector_publisher.collect(r2)
@@ -2643,7 +2643,7 @@ class TestCollect (unittest.TestCase):
         
         for abbr in ('ct', 'me', 'ma', 'nh', 'ri', 'vt', 'nj', 'ny', 'pa'):
             for source_base in ('us/{}'.format(abbr), 'us/{}.---'.format(abbr), 'us/{}/---'.format(abbr)):
-                result = LocalProcessedResult(source_base, None, None, None)
+                result = LocalProcessedResult(source_base, None, RunState(None), None)
                 self.assertTrue(is_us_northeast(result), 'is_us_northeast("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
@@ -2652,7 +2652,7 @@ class TestCollect (unittest.TestCase):
 
         for abbr in ('il', 'in', 'mi', 'oh', 'wi', 'ia', 'ks', 'mn', 'mo', 'ne', 'nd', 'sd'):
             for source_base in ('us/{}'.format(abbr), 'us/{}.---'.format(abbr), 'us/{}/---'.format(abbr)):
-                result = LocalProcessedResult(source_base, None, None, None)
+                result = LocalProcessedResult(source_base, None, RunState(None), None)
                 self.assertTrue(is_us_midwest(result), 'is_us_midwest("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
@@ -2662,7 +2662,7 @@ class TestCollect (unittest.TestCase):
         for abbr in ('de', 'fl', 'ga', 'md', 'nc', 'sc', 'va', 'dc', 'wv', 'al',
                      'ky', 'ms', 'ar', 'la', 'ok', 'tx', 'tn'):
             for source_base in ('us/{}'.format(abbr), 'us/{}.---'.format(abbr), 'us/{}/---'.format(abbr)):
-                result = LocalProcessedResult(source_base, None, None, None)
+                result = LocalProcessedResult(source_base, None, RunState(None), None)
                 self.assertTrue(is_us_south(result), 'is_us_south("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
@@ -2671,7 +2671,7 @@ class TestCollect (unittest.TestCase):
 
         for abbr in ('az', 'co', 'id', 'mt', 'nv', 'nm', 'ut', 'wy', 'ak', 'ca', 'hi', 'or', 'wa'):
             for source_base in ('us/{}'.format(abbr), 'us/{}.---'.format(abbr), 'us/{}/---'.format(abbr)):
-                result = LocalProcessedResult(source_base, None, None, None)
+                result = LocalProcessedResult(source_base, None, RunState(None), None)
                 self.assertTrue(is_us_west(result), 'is_us_west("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
@@ -2682,7 +2682,7 @@ class TestCollect (unittest.TestCase):
                     'hr', 'it', 'cy', 'lv', 'lt', 'lu', 'hu', 'mt', 'nl', 'at',
                     'pl', 'pt', 'ro', 'si', 'sk', 'fi', 'se', 'uk', 'gr', 'gb'):
             for source_base in (iso, '{}.---'.format(iso), '{}/---'.format(iso)):
-                result = LocalProcessedResult(source_base, None, None, None)
+                result = LocalProcessedResult(source_base, None, RunState(None), None)
                 self.assertTrue(is_europe(result), 'is_europe("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
@@ -2700,7 +2700,7 @@ class TestCollect (unittest.TestCase):
                     'fm', 'um', 'nr', 'nc', 'nz', 'nu', 'nf', 'pw', 'pg', 'mp',
                     'sb', 'tk', 'to', 'tv', 'vu', 'um', 'wf', 'ws', 'is'):
             for source_base in (iso, '{}.---'.format(iso), '{}/---'.format(iso)):
-                result = LocalProcessedResult(source_base, None, None, None)
+                result = LocalProcessedResult(source_base, None, RunState(None), None)
                 self.assertTrue(is_asia(result), 'is_asia("{}") should be true'.format(source_base))
             
                 for test_func in test_funcs:
@@ -2731,12 +2731,12 @@ class TestCollect (unittest.TestCase):
         output.write.side_effect = remember_write_contents
         
         with patch('openaddr.ci.collect.expand_and_add_csv_to_zipfile') as expand_and_add_csv_to_zipfile:
-            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', 'temp', {}, '2.0.0'))
-            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', filename1, {}, '2.12.0'))
-            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', filename2, {}, '2.13.0'))
-            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', filename1, {}, '3'))
-            add_source_to_zipfile(output, LocalProcessedResult('ca/bc/vancouver', filename1, {}, '3'))
-            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', filename1, {}, None))
+            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', 'temp', RunState({}), '2.0.0'))
+            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', filename1, RunState({}), '2.12.0'))
+            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', filename2, RunState({}), '2.13.0'))
+            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', filename1, RunState({}), '3'))
+            add_source_to_zipfile(output, LocalProcessedResult('ca/bc/vancouver', filename1, RunState({}), '3'))
+            add_source_to_zipfile(output, LocalProcessedResult('us/ca/oakland', filename1, RunState({}), None))
         
         self.assertEqual(len(expand_and_add_csv_to_zipfile.mock_calls), 5)
         self.assertEqual(expand_and_add_csv_to_zipfile.mock_calls[0][1][1], 'us/ca/oakland.csv')

--- a/openaddr/tests/dotmap.py
+++ b/openaddr/tests/dotmap.py
@@ -15,6 +15,7 @@ import mock
 from httmock import HTTMock, response
 
 from .. import LocalProcessedResult
+from ..ci.objects import RunState
 
 from ..dotmap import (
     stream_all_features, call_tippecanoe, _upload_to_s3,
@@ -27,13 +28,13 @@ class TestDotmap (unittest.TestCase):
         self.test_dir = mkdtemp()
         self.results = list()
         
-        self.results.append(LocalProcessedResult('us/anytown', join(self.test_dir, 'file1.zip'), None, None))
+        self.results.append(LocalProcessedResult('us/anytown', join(self.test_dir, 'file1.zip'), RunState(None), None))
         zf = ZipFile(self.results[-1].filename, 'w')
         zf.writestr('README.txt', b'Good times')
         zf.writestr('stuff.csv', u'LAT,LON\n0,0\n37.804319,-122.271210\n'.encode('utf8'))
         zf.close()
         
-        self.results.append(LocalProcessedResult('us/whoville', join(self.test_dir, 'file2.zip'), None, None))
+        self.results.append(LocalProcessedResult('us/whoville', join(self.test_dir, 'file2.zip'), RunState(None), None))
         zf = ZipFile(self.results[-1].filename, 'w')
         zf.writestr('README.txt', b'Good times')
         zf.writestr('stuff.csv', u'LON,LAT,CITY\n0,0,Womp\n-122.413729,37.775641,Wómp Wómp\n'.encode('utf8'))


### PR DESCRIPTION
Found some straggling problems in collector process:

```
2016-06-29 05:00:06,964   ERROR: get() takes exactly 2 arguments (3 given)
Traceback (most recent call last):
 File "/usr/local/lib/python2.7/dist-packages/openaddr/ci/__init__.py", line 932, in decorated_function
   return route_function(*args, **kwargs)
 File "/usr/local/lib/python2.7/dist-packages/openaddr/ci/collect.py", line 90, in main
   if test(result):
 File "/usr/local/lib/python2.7/dist-packages/openaddr/ci/collect.py", line 108, in <lambda>
   return lambda result: (test1(result) and test2(result))
 File "/usr/local/lib/python2.7/dist-packages/openaddr/ci/collect.py", line 82, in <lambda>
   '': (lambda result: result.run_state.get('share-alike', '') != 'true'),
TypeError: get() takes exactly 2 arguments (3 given)
```