### PR TITLE
Handle worker timeouts differently

### DIFF
--- a/openaddr/ci/worker.py
+++ b/openaddr/ci/worker.py
@@ -60,7 +60,7 @@ def do_work(s3, run_id, source_name, job_contents_b64, output_dir):
         timeout_seconds = JOB_TIMEOUT.seconds + JOB_TIMEOUT.days * 86400
         result_stdout = compat.check_output(cmd, timeout=timeout_seconds)
     except compat.TimeoutExpired as e:
-        known_error, cmd_status, result_stdout = True, None, getattr(e, 'stdout', None)
+        known_error, cmd_status, result_stdout = True, None, e.output
     except compat.CalledProcessError as e:
         known_error, cmd_status, result_stdout = True, e.returncode, e.output
     except Exception:

--- a/openaddr/compat.py
+++ b/openaddr/compat.py
@@ -9,6 +9,7 @@ if PY2:
     
     check_output = subprocess32.check_output
     CalledProcessError = subprocess32.CalledProcessError
+    TimeoutExpired = subprocess32.TimeoutExpired
     
     csvIO = io.BytesIO
     
@@ -78,6 +79,7 @@ else:
     
     check_output = subprocess.check_output
     CalledProcessError = subprocess.CalledProcessError
+    TimeoutExpired = subprocess.TimeoutExpired
     
     csvIO = io.StringIO
     

--- a/openaddr/parcels/parse.py
+++ b/openaddr/parcels/parse.py
@@ -15,7 +15,6 @@ from .utils import fetch, unzip, rlistdir, import_with_fiona, import_csv
 _L = logging.getLogger('openaddr.parcels')
 
 csv.field_size_limit(sys.maxsize)
-setup_logger()
 
 def parse_source(source, idx, header):
     """
@@ -124,6 +123,8 @@ def filter_polygons(state, header):
 
 
 if __name__ == '__main__':
+    setup_logger()
+
     if not os.path.isfile(config.statefile_path):
         fetch(config.state_url, config.statefile_path)
 

--- a/openaddr/parcels/utils.py
+++ b/openaddr/parcels/utils.py
@@ -13,13 +13,10 @@ from . import config
 from shapely.geometry import shape
 from shapely.wkt import loads, dumps
 from openaddr.conform import conform_smash_case, row_transform_and_convert
-from openaddr.jobs import setup_logger
 
 _L = logging.getLogger('openaddr.parcels')
 
 csv.field_size_limit(sys.maxsize)
-setup_logger()
-
 
 def fetch(url, filepath):
     r = requests.get(url, stream=True)

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -1884,6 +1884,11 @@ class TestRuns (unittest.TestCase):
             
             # Look for log file message in output.
             self.assertNotIn('output', state)
+        
+        # Briefly sleep to account for an intermittent Postgres deadlock
+        # between this test and test_working_run(), that is reproducible
+        # only on Circle CI.
+        sleep(1)
 
     @patch('openaddr.jobs.JOB_TIMEOUT', new=timedelta(seconds=1))
     @patch('openaddr.ci.DUETASK_DELAY', new=timedelta(seconds=1))

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -1805,13 +1805,13 @@ class TestRuns (unittest.TestCase):
     @patch('openaddr.ci.DUETASK_DELAY', new=timedelta(seconds=1))
     @patch('openaddr.ci.WORKER_COOLDOWN', new=timedelta(seconds=0))
     @patch('openaddr.compat.check_output')
-    def test_failure_logging_run(self, check_output):
-        ''' Test a run that fails without producing JSON output.
+    def test_timeout_logging_run(self, check_output):
+        ''' Test a run that times out after producing logging output.
         '''
         def takes_a_long_time(cmd, timeout):
             with open(cmd[2], 'w') as file:
                 file.write('Took too long.\n')
-            raise compat.CalledProcessError(1, cmd, 'Took too long')
+            raise compat.TimeoutExpired(cmd, timeout, 'Took too long')
 
         check_output.side_effect = takes_a_long_time
 
@@ -1842,17 +1842,17 @@ class TestRuns (unittest.TestCase):
                 ((state, ), ) = db.fetchall()
             
             # Look for log file message in output.
-            self.assertIn('Took too long.', self.s3._read_fake_key(urlparse(state['output']).path))
+            self.assertIn(b'Took too long.', self.s3._read_fake_key(urlparse(state['output']).path))
 
     @patch('openaddr.jobs.JOB_TIMEOUT', new=timedelta(seconds=1))
     @patch('openaddr.ci.DUETASK_DELAY', new=timedelta(seconds=1))
     @patch('openaddr.ci.WORKER_COOLDOWN', new=timedelta(seconds=0))
     @patch('openaddr.compat.check_output')
-    def test_failure_nonlogging_run(self, check_output):
-        ''' Test a run that fails without producing JSON output.
+    def test_timeout_nonlogging_run(self, check_output):
+        ''' Test a run that times out without producing logging output.
         '''
         def takes_a_long_time(cmd, timeout):
-            raise compat.CalledProcessError(1, cmd, 'Took too long')
+            raise compat.TimeoutExpired(cmd, timeout, 'Took too long')
 
         check_output.side_effect = takes_a_long_time
 


### PR DESCRIPTION
Try to collect output from more kinds of failed jobs.