### PR TITLE
Use multipart s3 upload

### DIFF
--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -188,8 +188,7 @@ class CollectorPublisher:
 
         _upload()
 
-    def write_to_s3(self, filename, key,
-        policy='public-read', content_type='application/zip', parallelism=4):
+    def write_to_s3(self, filename, key, policy='public-read', content_type='application/zip'):
         ''' Writes the file at `filename` to the S3 key `key` using
             S3's multipart upload functionality.
 
@@ -217,7 +216,7 @@ class CollectorPublisher:
             return key
         else:
             mp.cancel_upload()
-            raise Exception("Error uploading multipart data")
+            raise Exception("Error uploading multipart data, expected {} chunks and got {}".format(chunk_amount, len(mp.get_all_parts())))
 
     def publish(self, db):
         ''' Create new S3 object with zipfile name and upload the collection.

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -23,6 +23,8 @@ from .. import S3, iterate_local_processed_files, util, expand
 from ..conform import OPENADDR_CSV_SCHEMA
 from ..compat import PY2
 
+MULTIPART_CHUNK_SIZE = 5 * 1024 * 1024
+
 parser = ArgumentParser(description='Run some source files.')
 
 parser.add_argument('-o', '--owner', default='openaddresses',
@@ -198,8 +200,7 @@ class CollectorPublisher:
 
         # With help from https://gist.github.com/fabiant7t/924094
         source_size = stat(filename).st_size
-        five_megabytes = 5 * 1024 * 1024
-        bytes_per_chunk = max(int(sqrt(five_megabytes) * sqrt(source_size)), five_megabytes)
+        bytes_per_chunk = max(int(sqrt(MULTIPART_CHUNK_SIZE) * sqrt(source_size)), MULTIPART_CHUNK_SIZE)
         chunk_amount = int(ceil(source_size / float(bytes_per_chunk)))
 
         for i in range(chunk_amount):

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -215,13 +215,13 @@ def _upload_s3_part(s3, multipart_id, part_num, source_path, offset, bytes, retr
             _L.info('... Uploaded part #%d', part_num)
             return
 
-def write_to_s3(s3, filename, key, policy='public-read', content_type='application/zip'):
-    ''' Writes the file at `filename` to the S3 key `key` using
+def write_to_s3(s3, filename, keyname, policy='public-read', content_type='application/zip'):
+    ''' Writes the file at `filename` to the S3 key `keyname` using
         S3's multipart upload functionality.
 
         Returns the S3 Key object for the file that was uploaded.
     '''
-    mp = s3.initiate_multipart_upload(key, headers={'Content-Type': content_type})
+    mp = s3.initiate_multipart_upload(keyname, headers={'Content-Type': content_type})
 
     # With help from https://gist.github.com/fabiant7t/924094
     source_size = stat(filename).st_size
@@ -240,7 +240,7 @@ def write_to_s3(s3, filename, key, policy='public-read', content_type='applicati
         raise Exception("Error uploading multipart data, expected {} chunks and got {}".format(chunk_count, len(mp.get_all_parts())))
 
     mp.complete_upload()
-    key = s3.get_key(key)
+    key = s3.get_key(keyname)
     key.set_acl(policy)
     return key
 

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -170,7 +170,8 @@ class CollectorPublisher:
         """
         Uploads a part with retries.
         """
-        def _upload(retries_left=retries):
+        while True:
+            retries -= 1
             try:
                 _L.info('Start uploading part #%d ...', part_num)
                 for mp in self.s3.get_all_multipart_uploads():
@@ -180,15 +181,12 @@ class CollectorPublisher:
                             mp.upload_part_from_file(fp=fp, part_num=part_num, size=bytes)
                         break
             except Exception, exc:
-                if retries_left:
-                    _upload(retries_left=retries_left - 1)
-                else:
+                if retries == 0:
                     _L.info('... Failed uploading part #%d', part_num)
                     raise
             else:
                 _L.info('... Uploaded part #%d', part_num)
-
-        _upload()
+                return
 
     def write_to_s3(self, filename, key, policy='public-read', content_type='application/zip'):
         ''' Writes the file at `filename` to the S3 key `key` using

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -164,7 +164,7 @@ class CollectorPublisher:
             'attribution': attribution
             }
 
-    def _upload_part(self, multipart_id, part_num, source_path, offset, bytes, retries=10):
+    def _upload_part(self, multipart_id, part_num, source_path, offset, bytes, retries=3):
         """
         Uploads a part with retries.
         """
@@ -182,7 +182,7 @@ class CollectorPublisher:
                     _upload(retries_left=retries_left - 1)
                 else:
                     _L.info('... Failed uploading part #%d', part_num)
-                    raise exc
+                    raise
             else:
                 _L.info('... Uploaded part #%d', part_num)
 

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2653,16 +2653,12 @@ class TestCollect (unittest.TestCase):
         S3, collected_zip = mock.Mock(), mock.Mock()
         collected_zip.filename = filename1
         mock_mp = mock.Mock()
-        mock_mp.id = 242
         S3.initiate_multipart_upload.return_value = mock_mp
         S3.get_all_multipart_uploads.return_value = [mock_mp]
-        mock_mp.get_all_parts.return_value = [None]
+        mock_mp.get_all_parts.return_value = [None, None]
 
         collector_publisher = CollectorPublisher(S3, collected_zip, 'everywhere', 'yo')
-
-        with patch('openaddr.ci.collect.stat') as stat_mock:
-            stat_mock.st_size.return_value = 5000000
-            collector_publisher.write_to_s3(collected_zip.filename, 'keyname')
+        collector_publisher.write_to_s3(collected_zip.filename, 'keyname')
 
     def test_collection_checks(self):
         '''

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -46,7 +46,7 @@ from ..ci.objects import (
 from ..ci.collect import (
     is_us_northeast, is_us_midwest, is_us_south, is_us_west, is_europe, is_asia,
     add_source_to_zipfile, CollectorPublisher, prepare_collections,
-    expand_and_add_csv_to_zipfile
+    expand_and_add_csv_to_zipfile, MULTIPART_CHUNK_SIZE
     )
 
 from ..jobs import JOB_TIMEOUT
@@ -2653,9 +2653,9 @@ class TestCollect (unittest.TestCase):
         S3.get_all_multipart_uploads.return_value = [mp_upload]
         collector_publisher = CollectorPublisher(S3, collected_zip, 'everywhere', 'yo')
 
-        # Write a sample file just below the chunk size cutoff
+        # Write a sample file just at the chunk size cutoff
         with open(filename1, 'wb') as f:
-            f.seek(5 * 1024 * 1024 - 1)
+            f.seek(MULTIPART_CHUNK_SIZE - 1)
             f.write('\0')
 
         mp_upload.get_all_parts.return_value = [None]
@@ -2682,7 +2682,7 @@ class TestCollect (unittest.TestCase):
 
         # Write a sample file just above the chunk size cutoff
         with open(filename1, 'wb') as f:
-            f.seek(5 * 1024 * 1024 + 1)
+            f.seek(MULTIPART_CHUNK_SIZE + 1)
             f.write('\0')
 
         mp_upload.get_all_parts.return_value = [None, None]

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2656,6 +2656,7 @@ class TestCollect (unittest.TestCase):
         mock_mp.id = 242
         S3.initiate_multipart_upload.return_value = mock_mp
         S3.get_all_multipart_uploads.return_value = [mock_mp]
+        mock_mp.get_all_parts.return_value = [None]
 
         collector_publisher = CollectorPublisher(S3, collected_zip, 'everywhere', 'yo')
 

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2658,7 +2658,13 @@ class TestCollect (unittest.TestCase):
         mock_mp.get_all_parts.return_value = [None, None]
 
         collector_publisher = CollectorPublisher(S3, collected_zip, 'everywhere', 'yo')
-        collector_publisher.write_to_s3(collected_zip.filename, 'keyname')
+        collector_publisher.write_to_s3(collected_zip.filename, 'keyname.csv', content_type='text/csv')
+        
+        self.assertEqual(len(mock_mp.upload_part_from_file.mock_calls), 2, 'Should have uploaded two parts')
+        self.assertEqual(S3.initiate_multipart_upload.mock_calls[0][2]['headers']['Content-Type'], 'text/csv', 'Should upload a text/csv')
+        self.assertEqual(S3.get_key.mock_calls[-1][1], ('public-read', ), 'Should upload a publicly-readable key')
+        self.assertEqual(S3.get_key.mock_calls[0][1], ('keyname.csv', ), 'Should upload a correctly-named key')
+        self.assertEqual(S3.get_key.mock_calls[1][1], ('public-read', ), 'Should upload a publicly-readable key')
 
     def test_collection_checks(self):
         '''


### PR DESCRIPTION
Fixes #350

Uses multipart S3 upload inspired by [this post](http://codeinpython.blogspot.de/2015/08/s3-upload-large-files-to-amazon-using.html) and kinda copied from [this gist](https://gist.github.com/fabiant7t/924094).