### PR TITLE
Upgrade CircleCI to use Ubuntu 14.04 (Trusty)

### DIFF
--- a/chef/run.sh
+++ b/chef/run.sh
@@ -11,8 +11,9 @@ if [ ! `which chef-solo` ]; then
         gem1.9.3 install chef -v 11.16.4 --no-rdoc --no-ri
     else
         # Otherwise, assume Ubuntu ~14+
-        apt-get install -y build-essential ruby ruby-dev
-        gem install chef -v 11.16.4 --no-rdoc --no-ri
+        # Suppress chef_server_url prompt with hint from
+        # http://unix.stackexchange.com/questions/106552/apt-get-install-without-debconf-prompt
+        DEBIAN_FRONTEND=noninteractive apt-get install -y chef
     fi
 fi
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,23 +14,15 @@ dependencies:
     # CircleCI does not include ppa:ubuntugis by default, Travis does.
     - sudo add-apt-repository -y ppa:ubuntugis
     - sudo apt-get update -y
-    - sudo apt-get install -y -qq libgdal1h proj gmsh gmt
-    - sudo apt-get install -y -qq libgdal1-dev python3-dev python-dev
-    - sudo apt-get install -y -qq libffi-dev libcairo2
+    - sudo apt-get install -y -qq libgdal-dev
     # Determine GDAL library version and install a compatible python binding.
     #   http://gis.stackexchange.com/questions/28966/python-gdal-package-missing-header-file-when-installing-via-pip
-    - V=`dpkg -s libgdal1-dev | grep Version | cut -d' ' -f2 | cut -d'-' -f1`; env CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal pip install "GDAL==$V"
-    # PyOpenSSL later wants a fresher setuptools, and
-    # complains about CircleCI's existing 3.4.4 _and_ 0.6rc11.
-    - sudo pip -q uninstall setuptools -y || true
-    - sudo pip install -U setuptools
+    - V=`dpkg -s libgdal-dev | grep Version | cut -d' ' -f2 | cut -d'-' -f1 | cut -d'+' -f1`; env CPLUS_INCLUDE_PATH=/usr/include/gdal C_INCLUDE_PATH=/usr/include/gdal pip install "GDAL==$V"
     # cairocffi is a drop-in replacement for Pycairo, which is absent from pip.
     #   http://stackoverflow.com/questions/11491268/install-pycairo-in-virtualenv
     #   https://pythonhosted.org/cairocffi/
     - pip install cairocffi
     - sudo chef/run.sh testing
-    # Older CircleCI-provided pip complains about install of a directory.
-    - pip install -U pip
     - pip install -U .
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,9 @@ dependencies:
     # CircleCI does not include ppa:ubuntugis by default, Travis does.
     - sudo add-apt-repository -y ppa:ubuntugis
     - sudo apt-get update -y
+    # Install Machine globally via Chef recipe, to pick up complete dependencies.
+    - sudo chef/run.sh testing
+    # Reinstall Machine for virtualenv, to test with this Python version.
     - sudo apt-get install -y -qq libgdal-dev
     # Determine GDAL library version and install a compatible python binding.
     #   http://gis.stackexchange.com/questions/28966/python-gdal-package-missing-header-file-when-installing-via-pip
@@ -22,7 +25,6 @@ dependencies:
     #   http://stackoverflow.com/questions/11491268/install-pycairo-in-virtualenv
     #   https://pythonhosted.org/cairocffi/
     - pip install cairocffi
-    - sudo chef/run.sh testing
     - pip install -U .
 
 test:


### PR DESCRIPTION
PR #349 wants a newer version of GDAL that appears to be available on 14.04, so these changes are made in connection with a modification to build settings in Circle CI. It may be necessary to rebase PRs #333 and #351.