### PR TITLE
Expanding the installation prereqs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ state-*.txt
 state-*.json
 env-*
 venv-hooked-on-sources
+
+# PyCharm/JetBrains IDE files
+.idea

--- a/README.md
+++ b/README.md
@@ -26,8 +26,14 @@ submissions.
 ### CI Mode
 
 Installation scripts for preparing a fresh install of Ubuntu 14.04 can be found
-in `chef`. You will need a pre-installed PostgreSQL database initialized with
-the schema `openaddr/ci/schema.pgsql` and Amazon S3 bucket with credentials.
+in `chef`. You will need a local installation of PostgreSQL, a PostgreSQL role 
+named `dashboard`, a database named `openaddr` that's been initialized with the 
+schema `openaddr/ci/schema.pgsql`, and an Amazon S3 bucket with credentials.
+
+    createuser dashboard
+    createdb openaddr
+    ﻿psql -f openaddr/ci/schema.pgsql openaddr
+
 After editing `chef/role-webhooks.json` and `chef/role-worker.json`, run them
 from a Git checkout like this:
 


### PR DESCRIPTION
Installation seems to require a `dashboard` role so I've added that, as well as a couple of more trivial steps.

I've also added `.idea` to `.gitignore` as I often use PyCharm and I may not be the only one.