### PR TITLE
Added EC2 runner for collection process

### DIFF
--- a/chef/collector/recipes/default.rb
+++ b/chef/collector/recipes/default.rb
@@ -1,0 +1,44 @@
+db_user = node[:db_user]
+db_pass = node[:db_pass]
+db_host = node[:db_host]
+db_name = node[:db_name]
+aws_access_id = node[:aws_access_id]
+aws_secret_key = node[:aws_secret_key]
+aws_s3_bucket = node[:aws_s3_bucket]
+aws_sns_arn = node[:aws_sns_arn]
+
+gag_github_status = node['gag_github_status']
+database_url = "postgres://#{db_user}:#{db_pass}@#{db_host}/#{db_name}?sslmode=require"
+github_token = node['github_token']
+slack_url = node['slack_url']
+
+execute 'pip install honcho[export]'
+
+#
+# Prepare configuration files.
+#
+file "/etc/openaddr-collector.conf" do
+  content <<-CONF
+DATABASE_URL=#{database_url}
+AWS_ACCESS_KEY_ID=#{aws_access_id}
+AWS_SECRET_ACCESS_KEY=#{aws_secret_key}
+GITHUB_TOKEN=#{github_token}
+CONF
+end
+
+rotation = <<-ROTATION
+{
+	copytruncate
+	rotate 4
+	weekly
+	missingok
+	notifempty
+	compress
+	delaycompress
+	endscript
+}
+ROTATION
+
+file "/etc/logrotate.d/openaddr-collector" do
+    content "/var/log/openaddr-collector.log\n#{rotation}\n"
+end

--- a/chef/role-collector.json
+++ b/chef/role-collector.json
@@ -1,0 +1,18 @@
+{
+    "db_user": "openaddr",
+    "db_pass": "openaddr",
+    "db_host": "localhost",
+    "db_name": "openaddr",
+    "aws_access_id": "{Amazon Access Key ID}",
+    "aws_secret_key": "{Amazon Secret Access Key}",
+    "aws_sns_arn": "{Amazon SNS Subscription ID}",
+    "aws_s3_bucket": "{Amazon S3 Bucket Name}",
+    "github_token": "{Github Token}",
+    "slack_url": "https://hooks.slack.com/services/{etc.}",
+    "run_list":
+    [
+        "openaddr-prereqs",
+        "openaddr",
+        "collector"
+    ]
+}

--- a/openaddr/util/templates/collector-userdata.sh
+++ b/openaddr/util/templates/collector-userdata.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -ex
+apt-get update -y
+apt-get install -y git htop curl
+
+# (Re)install machine.
+cd /home/ubuntu/machine
+sudo -u ubuntu git fetch origin 2.x
+sudo -u ubuntu git rebase FETCH_HEAD
+chef/run.sh collector
+
+cat /etc/openaddr-collector.conf
+shutdown -h now


### PR DESCRIPTION
Introduces a Chef script and utility function for preparing collections on another server. This functionality is still dark, and requires further EC2 changes before it can be exposed.