### PR TITLE
Removing package data prior to CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ install:
   - pip install -U .
   # Create necessary database tables.
   - openaddr-ci-recreate-db
+  # Destroy the evidence.
+  - rm -rf openaddr
 env:  BOTO_CONFIG=/tmp/nowhere DATABASE_URL=postgres://openaddr:openaddr@localhost/openaddr
 script:  python setup.py test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - pip install -U .
   # Create necessary database tables.
   - openaddr-ci-recreate-db
-  # Destroy the evidence.
+  # Destroy the evidence, so that tests use a setup-installed version of openaddr.
   - find openaddr -type f -a ! -name VERSION -delete
 env:  BOTO_CONFIG=/tmp/nowhere DATABASE_URL=postgres://openaddr:openaddr@localhost/openaddr
 script:  python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   # Create necessary database tables.
   - openaddr-ci-recreate-db
   # Destroy the evidence.
-  - rm -rf openaddr
+  - find openaddr -type f -a ! -name VERSION -delete
 env:  BOTO_CONFIG=/tmp/nowhere DATABASE_URL=postgres://openaddr:openaddr@localhost/openaddr
 script:  python setup.py test
 

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ dependencies:
     - pip install -U .
     # Create necessary database tables.
     - openaddr-ci-recreate-db
-    # Destroy the evidence.
+    # Destroy the evidence, so that tests use a setup-installed version of openaddr.
     - find openaddr -type f -a ! -name VERSION -delete
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
     # Create necessary database tables.
     - openaddr-ci-recreate-db
     # Destroy the evidence.
-    - rm -rf openaddr
+    - find openaddr -type f -a ! -name VERSION -delete
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,8 @@ dependencies:
     - pip install -U .
     # Create necessary database tables.
     - openaddr-ci-recreate-db
+    # Destroy the evidence.
+    - rm -rf openaddr
 
 test:
   override:

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         ],
         'openaddr.tests': [
             'data/*.*', 'sources/*.*', 'sources/fr/*.*',
+            'sources/us/*/*.*', 'sources/de/*.*',
             'conforms/lake-man-gdb.gdb/*',
             'conforms/*.csv', 'conforms/*.dbf', 'conforms/*.zip', 'conforms/*.gfs',
             'conforms/*.gml', 'conforms/*.json', 'conforms/*.prj', 'conforms/*.shp',
@@ -74,6 +75,9 @@ setup(
         ],
         'openaddr.parcels': [
             'README.md'
+        ],
+        'openaddr.util': [
+            'templates/*.*'
         ]
     },
     test_suite = 'openaddr.tests',


### PR DESCRIPTION
Forces CI to use the pip-installed version of openaddr so it will correctly fail when files aren't included in setup.py.