### PR TITLE
Added configurable EC2 instance type to openaddr-run-ec2-command

### DIFF
--- a/openaddr/ci/collect_supervise.py
+++ b/openaddr/ci/collect_supervise.py
@@ -60,7 +60,7 @@ def main():
             '--database-url', args.database_url, '--access-key', args.access_key,
             '--secret-key', args.secret_key, '--sns-arn', args.sns_arn
             )
-        instance = request_task_instance(ec2, autoscale, 'openaddr', command)
+        instance = request_task_instance(ec2, autoscale, 'm3.medium', 'openaddr', command)
 
         while True:
             instance.update()

--- a/openaddr/run_ec2_ami.py
+++ b/openaddr/run_ec2_ami.py
@@ -46,7 +46,7 @@ def main():
     try:
         ec2 = connect_ec2(args.access_key, args.secret_key)
         autoscale = connect_autoscale(args.access_key, args.secret_key)
-        instance = request_task_instance(ec2, autoscale, args.role, args.command)
+        instance = request_task_instance(ec2, autoscale, 'm3.medium', args.role, args.command)
 
         while True:
             instance.update()

--- a/openaddr/run_ec2_ami.py
+++ b/openaddr/run_ec2_ami.py
@@ -24,6 +24,9 @@ parser.add_argument('--sns-arn', default=environ.get('AWS_SNS_ARN', None),
 parser.add_argument('--role', default='openaddr',
                     help='Machine chef role to execute. Defaults to "openaddr".')
 
+parser.add_argument('--instance-type', default='m3.medium',
+                    help='EC2 instance type. Defaults to "m3.medium".')
+
 parser.add_argument('-v', '--verbose', help='Turn on verbose logging',
                     action='store_const', dest='loglevel',
                     const=logging.DEBUG, default=logging.INFO)
@@ -46,7 +49,8 @@ def main():
     try:
         ec2 = connect_ec2(args.access_key, args.secret_key)
         autoscale = connect_autoscale(args.access_key, args.secret_key)
-        instance = request_task_instance(ec2, autoscale, 'm3.medium', args.role, args.command)
+        instance = request_task_instance(ec2, autoscale, args.instance_type,
+                                         args.role, args.command)
 
         while True:
             instance.update()

--- a/openaddr/tests/util.py
+++ b/openaddr/tests/util.py
@@ -95,7 +95,7 @@ class TestUtilities (unittest.TestCase):
         image.run.return_value = reservation
         reservation.instances = [instance]
         
-        util.request_task_instance(ec2, autoscale, chef_role, command)
+        util.request_task_instance(ec2, autoscale, 'm3.medium', chef_role, command)
         
         autoscale.get_all_groups.assert_called_once_with([expected_group_name])
         autoscale.get_all_launch_configurations.assert_called_once_with(names=[group.launch_config_name])

--- a/openaddr/util/__init__.py
+++ b/openaddr/util/__init__.py
@@ -40,7 +40,7 @@ def set_autoscale_capacity(autoscale, cloudwatch, capacity):
     if measure['Maximum'] > .9:
         group.set_capacity(capacity)
 
-def request_task_instance(ec2, autoscale, chef_role, command):
+def request_task_instance(ec2, autoscale, instance_type, chef_role, command):
     '''
     '''
     group_name = 'CI Workers {0}.x'.format(*__version__.split('.'))
@@ -54,7 +54,7 @@ def request_task_instance(ec2, autoscale, chef_role, command):
         userdata_kwargs = dict(role=chef_role, command=' '.join(map(quote, command)))
         userdata_kwargs.update(version=quote(__version__))
     
-        run_kwargs = dict(instance_type='m3.medium', security_groups=['default'],
+        run_kwargs = dict(instance_type=instance_type, security_groups=['default'],
                           instance_initiated_shutdown_behavior='terminate',
                           user_data=file.read().format(**userdata_kwargs),
                           key_name=keypair.name)


### PR DESCRIPTION
So that Dotmap could benefit from high-memory instances.