### PR TITLE
Format function for conform

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -930,7 +930,7 @@ def row_fxn_format(sd, row, key):
         field_idx = int(m.group(1))
         start, end = m.span()
 
-        if field_idx - 1 < len(fields):
+        if field_index > 0 and field_idx - 1 < len(fields):
             field = fields[field_idx - 1]
 
             if idx == 0 or (num_fields_added > 0 and field):

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -11,7 +11,6 @@ import tempfile
 import itertools
 import json
 import copy
-import six
 import sys
 import re
 
@@ -918,7 +917,7 @@ def row_fxn_format(sd, row, key):
 
     format_var_pattern = re.compile('\$([0-9]+)')
 
-    fields = [(row[n] or six.u('')).strip() for n in fxn["fields"]]
+    fields = [(row[n] or u'').strip() for n in fxn["fields"]]
 
     parts = []
 
@@ -944,9 +943,9 @@ def row_fxn_format(sd, row, key):
 
     if num_fields_added > 0:
         parts.append(format_str[idx:])
-        row[attrib_types[key]] = six.u('').join(parts)
+        row[attrib_types[key]] = u''.join(parts)
     else:
-        row[attrib_types[key]] = six.u('')
+        row[attrib_types[key]] = u''
 
     return row
 

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -930,7 +930,7 @@ def row_fxn_format(sd, row, key):
         field_idx = int(m.group(1))
         start, end = m.span()
 
-        if field_index > 0 and field_idx - 1 < len(fields):
+        if field_idx > 0 and field_idx - 1 < len(fields):
             field = fields[field_idx - 1]
 
             if idx == 0 or (num_fields_added > 0 and field):

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -97,7 +97,7 @@ class TestConformTransforms (unittest.TestCase):
             "street": {
                 "function": "format",
                 "fields": ["b1", "b2", "b3"],
-                "separator": "foo $1$2-$3 bar"
+                "format": "foo $1$2-$3 bar"
             }
         } }
 


### PR DESCRIPTION
Hey folks - here's an implementation for a new ```format``` function in conform as proposed in https://github.com/openaddresses/openaddresses/pull/1925. It allows for more flexibility than ```join``` when mapping multiple input fields to a single field in the output CSV.

Given the following config:
```json
{
    "conform": {
        "number": {
            "function": "format",
            "fields": ["a", "b", "c"],
            "format": "$1$2-$3"
        }
    }
}
```

and these inputs:

```json
{"a": "1", "b": "B", "c": "3"}
```

It will produce ```{"OA:number": "1B-3"}```.

If one of the variables is NULL/empty, its left context will be omitted, except for any initial string that appears before the first variable occurrence. So for the format string above, if "c" is NULL, it will produce ```{"OA:number": "1B"}```, omitting the hyphen.

This is one alternative. It's also possible to implement using Python format strings, allowing type conversion, etc. but that syntax (especially in Python 3 after they decided to depart from the C-style format strings) may be unfamiliar to non-Python users. This simple format aims to mimic bash args or regex groups, hence the counting from 1 business, which should be familiar to most developers regardless of language background.