### PR TITLE
handling NULL/empty values in the join function in conform

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -881,14 +881,16 @@ def row_fxn_join(sd, row, key):
         for new_field_name, merge_spec in advanced_merge.items():
             separator = merge_spec.get("separator", " ")
             try:
-                row[new_field_name] = separator.join([row[n] for n in merge_spec["fields"]])
+                fields = [(row[n] or u'').strip() for n in merge_spec["fields"]]
+                row[new_field_name] = separator.join([f for f in fields if f])
             except Exception as e:
                 _L.debug("Failure to merge row %r %s", e, row)
     else: ## New behavior
         fxn = sd["conform"][key]
         separator = fxn.get("separator", " ")
         try:
-            row[attrib_types[key]] = separator.join([row[n] for n in fxn["fields"]])
+            fields = [(row[n] or u'').strip() for n in fxn["fields"]]
+            row[attrib_types[key]] = separator.join([f for f in fields if f])
         except Exception as e:
             _L.debug("Failure to merge row %r %s", e, row)
     return row

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -86,6 +86,12 @@ class TestConformTransforms (unittest.TestCase):
         d = row_fxn_join(c, d, "number")
         d = row_fxn_join(c, d, "street")
         self.assertEqual(e, d)
+        d = { "a1": "va1", "b1": "vb1", "b2": None}
+        e = copy.deepcopy(d)
+        e.update({ "OA:number": "va1", "OA:street": "vb1" })
+        d = row_fxn_join(c, d, "number")
+        d = row_fxn_join(c, d, "street")
+        self.assertEqual(e, d)
 
     def test_row_fxn_format(self):
         c = { "conform": {


### PR DESCRIPTION
The current join function in conform assumes that all fields are non-NULL/non-empty. This change will simply ignore empty/NULL fields in the join so values like "1/" or "1-" don't end up in the output when one of the join fields is missing.