### PR TITLE
Update pyesridump and filter out Esri geometries with NaN coordinates

### DIFF
--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -5,6 +5,7 @@ from .compat import standard_library, PY2
 
 import os
 import errno
+import math
 import socket
 import mimetypes
 import shutil
@@ -43,11 +44,11 @@ def mkdirsp(path):
 
 def traverse(item):
     "Iterates over nested iterables"
-    try:
-        for i in iter(item):
+    if isinstance(item, list):
+        for i in item:
             for j in traverse(i):
                 yield j
-    except TypeError:
+    else:
         yield item
 
 def request(method, url, **kwargs):
@@ -373,7 +374,7 @@ class EsriRestDownloadTask(DownloadTask):
 
                         if not geom:
                             raise TypeError("No geometry parsed")
-                        if any(math.isnan(g) for g in traverse(geom)):
+                        if any((isinstance(g, float) and math.isnan(g)) for g in traverse(geom)):
                             raise TypeError("Geometry has NaN coordinates")
 
                         shp = shape(feature['geometry'])

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         'boto3 == 1.1.4',
 
         # https://github.com/openaddresses/pyesridump
-        'esridump == 1.1.1',
+        'esridump == 1.4.0',
 
         # Used in openaddr.parcels
         'Shapely == 1.5.15',


### PR DESCRIPTION
- Updates pyesridump to 1.4.0 to bring in better EsriJSON to GeoJSON conversion (it was incorrectly converting MultiPolygons)
- Add code to skip Esri geometries that have NaN coordinates (the root cause of [this source failure](http://s3.amazonaws.com/data.openaddresses.io/runs/110497/output.txt))