### PR TITLE
Fixed GitHub OAuth callback behavior

### DIFF
--- a/chef/role-webhooks.json
+++ b/chef/role-webhooks.json
@@ -11,6 +11,7 @@
     "aws_sns_arn": "{Amazon SNS Subscription ID}",
     "webhook_secrets": "{Comma-delimited list of secrets}",
     "github_token": "{Github Token}",
+    "github_callback": "{Github Callback URL}",
     "github_client_id": "{Github Client ID}",
     "github_secret": "{Github Secret}",
     "gag_github_status": "No",

--- a/chef/webhooks/recipes/default.rb
+++ b/chef/webhooks/recipes/default.rb
@@ -14,6 +14,7 @@ webhook_secrets = node[:webhook_secrets]
 gag_github_status = node['gag_github_status']
 database_url = "postgres://#{db_user}:#{db_pass}@#{db_host}/#{db_name}?sslmode=require"
 github_token = node['github_token']
+github_callback = node['github_callback']
 github_client_id = node['github_client_id']
 github_secret = node['github_secret']
 
@@ -30,6 +31,7 @@ file env_file do
 DATABASE_URL=#{database_url}
 MEMCACHE_SERVER=#{memcache_server}
 GITHUB_TOKEN=#{github_token}
+GITHUB_CALLBACK=#{github_callback}
 GITHUB_CLIENT_ID=#{github_client_id}
 GITHUB_SECRET=#{github_secret}
 GAG_GITHUB_STATUS=#{gag_github_status}

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -46,6 +46,7 @@ def load_config():
                 GITHUB_AUTH=(os.environ['GITHUB_TOKEN'], 'x-oauth-basic'),
                 GITHUB_OAUTH_CLIENT_ID=os.environ.get('GITHUB_CLIENT_ID'),
                 GITHUB_OAUTH_SECRET=os.environ.get('GITHUB_SECRET'),
+                GITHUB_OAUTH_CALLBACK=os.environ.get('GITHUB_CALLBACK'),
                 MEMCACHE_SERVER=os.environ.get('MEMCACHE_SERVER'),
                 DATABASE_URL=os.environ['DATABASE_URL'],
                 WEBHOOK_SECRETS=webhook_secrets)

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -27,18 +27,6 @@ def serialize(secret, data):
 def unserialize(secret, data):
     return URLSafeSerializer(secret).loads(data)
 
-def correct_url(request):
-    path = request.path.encode('utf8') if compat.PY2 else request.path
-
-    if 'X-Forwarded-Proto' not in request.headers:
-        return request.url
-
-    _scheme = request.headers.get('X-Forwarded-Proto')
-    scheme = _scheme.encode('utf8') if compat.PY2 else _scheme
-    actual_url = urlunparse((scheme, request.host, path, None, None, None))
-    
-    return actual_url.decode('utf8') if compat.PY2 else actual_url
-
 def callback_url(request, callback_url):
     '''
     '''
@@ -135,12 +123,9 @@ def app_login():
     state = serialize(current_app.secret_key,
                       dict(url=request.headers.get('Referer')))
 
-    _url = url_for('webauth.app_callback')
-    redirect_url = _url.decode('utf8') if compat.PY2 else _url
-
-    args = dict(redirect_uri=urljoin(correct_url(request), redirect_url))
+    url = current_app.config.get('GITHUB_OAUTH_CALLBACK') or url_for('webauth.app_callback')
+    args = dict(redirect_uri=callback_url(request, url), response_type='code', state=state)
     args.update(client_id=current_app.config['GITHUB_OAUTH_CLIENT_ID'])
-    args.update(response_type='code', state=state)
     
     return redirect(uritemplate.expand(github_authorize_url, args), 303)
 

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -39,6 +39,23 @@ def correct_url(request):
     
     return actual_url.decode('utf8') if compat.PY2 else actual_url
 
+def callback_url(request, callback_url):
+    '''
+    '''
+    if 'X-Forwarded-Proto' in request.headers:
+        _scheme = request.headers.get('X-Forwarded-Proto')
+        scheme = _scheme.encode('utf8') if compat.PY2 else _scheme
+        path = request.path.encode('utf8') if compat.PY2 else request.path
+
+        base_url = urlunparse((scheme, request.host, path, None, None, None))
+    else:
+        base_url = request.url
+    
+    if compat.PY2 and hasattr(callback_url, 'encode'):
+        callback_url = callback_url.encode('utf8')
+
+    return urljoin(base_url, callback_url)
+
 def exchange_tokens(code, client_id, secret):
     ''' Exchange the temporary code for an access token
 

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -867,6 +867,49 @@ class TestAuth (unittest.TestCase):
             self.assertEqual(login, 'migurski')
             self.assertEqual(avatar, 'https://avatars.githubusercontent.com/u/58730?v=3')
             self.assertTrue(orged)
+    
+    def test_callback_url(self):
+        req1 = mock.Mock()
+        req1.url = 'http://example.org/auth'
+        req1.host, req1.path = 'example.org', '/auth'
+        req1.headers = {}
+        url1 = webauth.callback_url(req1, 'http://www.example.com/callback')
+        self.assertEqual(url1, 'http://www.example.com/callback')
+        
+        req2 = mock.Mock()
+        req2.url = 'http://example.org/auth'
+        req2.host, req2.path = 'example.org', '/auth'
+        req2.headers = {}
+        url2 = webauth.callback_url(req2, '/callback')
+        self.assertEqual(url2, 'http://example.org/callback')
+        
+        req3 = mock.Mock()
+        req3.url = 'http://example.org/auth'
+        req3.host, req3.path = 'example.org', '/auth'
+        req3.headers = {'X-Forwarded-Proto': 'https'}
+        url3 = webauth.callback_url(req3, '/callback')
+        self.assertEqual(url3, 'https://example.org/callback')
+        
+        req4 = mock.Mock()
+        req4.url = 'http://example.org/auth'
+        req4.host, req4.path = 'example.org', u'/auth'
+        req4.headers = {'X-Forwarded-Proto': 'https'}
+        url4 = webauth.callback_url(req4, '/callback')
+        self.assertEqual(url4, 'https://example.org/callback')
+        
+        req5 = mock.Mock()
+        req5.url = 'http://example.org/auth'
+        req5.host, req5.path = 'example.org', u'/auth'
+        req5.headers = {'X-Forwarded-Proto': u'https'}
+        url5 = webauth.callback_url(req5, '/callback')
+        self.assertEqual(url5, 'https://example.org/callback')
+        
+        req6 = mock.Mock()
+        req6.url = 'http://example.org/auth'
+        req6.host, req6.path = 'example.org', u'/auth'
+        req6.headers = {'X-Forwarded-Proto': u'https'}
+        url6 = webauth.callback_url(req6, u'/callback')
+        self.assertEqual(url6, 'https://example.org/callback')
 
 class TestHook (unittest.TestCase):
 


### PR DESCRIPTION
On production CI system, `X-Forwarded-Proto` header is not reliably present so explicit OAuth callback URL configuration is necessary.

Part of #378.