### PR TITLE
Start moving crontab jobs to chef recipe

### DIFF
--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -1,0 +1,51 @@
+username = node[:username]
+app_name = 'openaddr_crontab'
+
+db_user = node[:db_user]
+db_pass = node[:db_pass]
+db_host = node[:db_host]
+db_name = node[:db_name]
+aws_access_id = node[:aws_access_id]
+aws_secret_key = node[:aws_secret_key]
+aws_sns_arn = node[:aws_sns_arn]
+github_token = node['github_token']
+mapbox_key = node[:mapbox_key]
+
+database_url = "postgres://#{db_user}:#{db_pass}@#{db_host}/#{db_name}?sslmode=require"
+
+env_file = "/etc/#{app_name}.conf"
+
+#
+# Ensure upstart job exists.
+#
+file env_file do
+  content <<-CONF
+DATABASE_URL=#{database_url}
+AWS_ACCESS_KEY_ID=#{aws_access_id}
+AWS_SECRET_ACCESS_KEY=#{aws_secret_key}
+AWS_SNS_ARN=#{aws_sns_arn}
+GITHUB_TOKEN=#{github_token}
+MAPBOX_KEY=#{mapbox_key}
+CONF
+end
+
+rotation = <<-ROTATION
+{
+	copytruncate
+	rotate 4
+	weekly
+	missingok
+	notifempty
+	compress
+	delaycompress
+	endscript
+}
+ROTATION
+
+file "/etc/logrotate.d/#{app_name}-collect-extracts" do
+    content "/var/log/#{app_name}-collect-extracts.log\n#{rotation}\n"
+end
+
+file "/etc/logrotate.d/#{app_name}-dotmap" do
+    content "/var/log/#{app_name}-dotmap.log\n#{rotation}\n"
+end

--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -1,5 +1,4 @@
 username = node[:username]
-app_name = 'openaddr_crontab'
 
 db_user = node[:db_user]
 db_pass = node[:db_pass]
@@ -12,8 +11,6 @@ github_token = node['github_token']
 mapbox_key = node[:mapbox_key]
 
 database_url = "postgres://#{db_user}:#{db_pass}@#{db_host}/#{db_name}?sslmode=require"
-
-env_file = "/etc/#{app_name}.conf"
 
 #
 # Ensure configuration exists.
@@ -31,31 +28,32 @@ rotation = <<-ROTATION
 }
 ROTATION
 
-file "/etc/logrotate.d/#{app_name}-collect-extracts" do
-    content "/var/log/#{app_name}-collect-extracts.log\n#{rotation}\n"
+file "/etc/logrotate.d/openaddr_crontab-collect-extracts" do
+    content "/var/log/openaddr_crontab/collect-extracts.log\n#{rotation}\n"
 end
 
-file "/etc/logrotate.d/#{app_name}-dotmap" do
-    content "/var/log/#{app_name}-dotmap.log\n#{rotation}\n"
+file "/etc/logrotate.d/openaddr_crontab-dotmap" do
+    content "/var/log/openaddr_crontab/dotmap.log\n#{rotation}\n"
 end
 
 #
 # Place crontab scripts.
 #
 directory '/etc/cron.d'
+directory "/var/log/openaddr_crontab"
 
-file "/etc/cron.d/#{app_name}-collect-extracts" do
+file "/etc/cron.d/openaddr_crontab-collect-extracts" do
     content <<-CRONTAB
 # Archive collection, every other day at 5am UTC (10pm PDT)
 0 5	*/2 * *	openaddr	( openaddr-run-ec2-command \
-	--verbose \
-	-- \
-	openaddr-collect-extracts \
-		-d "#{database_url}" \
-		-a "#{aws_access_id}" \
-		-s "#{aws_secret_key}" \
-		--sns-arn "#{aws_sns_arn}" \
-		--verbose ) \
-		 >> /var/log/#{app_name}-collect-extracts.log 2>&1
+  --verbose \
+  -- \
+    openaddr-collect-extracts \
+    -d "#{database_url}" \
+    -a "#{aws_access_id}" \
+    -s "#{aws_secret_key}" \
+    --sns-arn "#{aws_sns_arn}" \
+    --verbose ) \
+  >> /var/log/openaddr_crontab/collect-extracts.log 2>&1
 CRONTAB
 end

--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -46,7 +46,11 @@ directory "/var/log/openaddr_crontab"
 file "/etc/cron.d/openaddr_crontab-collect-extracts" do
     content <<-CRONTAB
 # Archive collection, every other day at 5am UTC (10pm PDT)
-0 5	*/2 * *	openaddr	( openaddr-run-ec2-command \
+0 5	*/2 * *	openaddr	( \
+  openaddr-run-ec2-command \
+  -a "#{aws_access_id}" \
+  -s "#{aws_secret_key}" \
+  --sns-arn "#{aws_sns_arn}" \
   --verbose \
   -- \
     openaddr-collect-extracts \

--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -9,6 +9,7 @@ aws_secret_key = node[:aws_secret_key]
 aws_sns_arn = node[:aws_sns_arn]
 github_token = node['github_token']
 mapbox_key = node[:mapbox_key]
+slack_url = node[:slack_url]
 
 database_url = "postgres://#{db_user}:#{db_pass}@#{db_host}/#{db_name}?sslmode=require"
 
@@ -53,7 +54,9 @@ file "/etc/cron.d/openaddr_crontab-collect-extracts" do
     -a "#{aws_access_id}" \
     -s "#{aws_secret_key}" \
     --sns-arn "#{aws_sns_arn}" \
-    --verbose ) \
+    --verbose \
+  && curl -X POST -d '{"text": "Completed new collection zips."}' "#{slack_url}" -s \
+  || curl -X POST -d '{"text": "Failed to complete new collection zips."}' "#{slack_url}" -s ) \
   >> /var/log/openaddr_crontab/collect-extracts.log 2>&1
 CRONTAB
 end

--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -40,9 +40,11 @@ file "/etc/logrotate.d/#{app_name}-dotmap" do
 end
 
 #
+# Place crontab scripts.
 #
-#
-file "/etc/crontab.d/#{app_name}-collect-extracts" do
+directory '/etc/cron.d'
+
+file "/etc/cron.d/#{app_name}-collect-extracts" do
     content <<-CRONTAB
 # Archive collection, every other day at 5am UTC (10pm PDT)
 0 5	*/2 * *	openaddr	( openaddr-run-ec2-command \

--- a/chef/role-crontab.json
+++ b/chef/role-crontab.json
@@ -10,6 +10,7 @@
     "aws_sns_arn": "{Amazon SNS Subscription ID}",
     "github_token": "{Github Token}",
     "mapbox_key": "{Mapbox Key}",
+    "slack_url": "{Slack URL}",
     "gag_github_status": "No",
     "run_list":
     [

--- a/chef/role-crontab.json
+++ b/chef/role-crontab.json
@@ -1,0 +1,21 @@
+{
+    "cname": "results.openaddresses.io",
+    "username": "openaddr",
+    "db_user": "openaddr",
+    "db_pass": "openaddr",
+    "db_host": "localhost",
+    "db_name": "openaddr",
+    "aws_access_id": "{Amazon Access Key ID}",
+    "aws_secret_key": "{Amazon Secret Access Key}",
+    "aws_sns_arn": "{Amazon SNS Subscription ID}",
+    "github_token": "{Github Token}",
+    "mapbox_key": "{Mapbox Key}",
+    "gag_github_status": "No",
+    "run_list":
+    [
+        "openaddr-prereqs",
+        "openaddr",
+        "account",
+        "crontab"
+    ]
+}


### PR DESCRIPTION
In preparation for a server move, we need to get certain mystery files out of `/etc` and into chef. This PR starts the process with extract collection.