### PR TITLE
Show messages when login fails

### DIFF
--- a/openaddr/ci/templates/base.html
+++ b/openaddr/ci/templates/base.html
@@ -106,6 +106,11 @@
         <a href="{{ url_for('webhooks.app_get_jobs') }}">All CI Jobs</a>
     </nav>
     <main>
+        {% if error_org_membership %}
+            <p>Error logging in: you need to be a member of the <a href="https://github.com/openaddresses">OpenAddresses Github organization</a>.</p>
+        {% elif error_bad_login %}
+            <p>Error logging in: we couldn’t figure out who you are.</p>
+        {% endif %}
         {% if user_required and not user %}
             <form action="{{ url_for('webauth.app_login') }}" method="post">
                 Please log in with Github. <button>LOG IN</button>

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -98,6 +98,8 @@ def update_authentication(untouched_route):
         if USER_KEY in session:
             session.pop(USER_KEY)
     
+        _L.warning('(update_authentication) in session["github token"]: {}'.format(session.get('github token')))
+
         if 'github token' in session:
             login, avatar_url, in_org = user_information(session['github token'])
             
@@ -151,6 +153,7 @@ def app_callback():
                             current_app.config['GITHUB_OAUTH_CLIENT_ID'],
                             current_app.config['GITHUB_OAUTH_SECRET'])
     
+    _L.warning('(app_callback) set session["github token"] to {}'.format(token['access_token']))
     session['github token'] = token['access_token']
     
     return redirect(state.get('url', url_for('webauth.app_auth')), 302)

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -60,7 +60,7 @@ def exchange_tokens(code, client_id, secret):
                          headers={'Accept': 'application/json'})
     auth = resp.json()
     _L.warning('(exchange_tokens) Posted {} to {}'.format(code, github_exchange_url))
-    _L.warning('(exchange_tokens) Got back {} {}'.format(auth.status_code, auth.text))
+    _L.warning('(exchange_tokens) Got back {} {}'.format(resp.status_code, resp.text))
 
     if 'error' in auth:
         raise RuntimeError('Github said "{error}".'.format(**auth))

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -137,6 +137,8 @@ def s3_upload_form_fields(expires, bucketname, subdir, redirect_url, aws_secret)
 @update_authentication
 @log_application_errors
 def app_auth():
+    _L.warning('(app_auth) rendering with user {}'.format(session.get(USER_KEY, {})))
+
     return render_template('oauth-hello.html', user_required=True,
                            user=session.get(USER_KEY, {}))
 

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -19,7 +19,7 @@ from .. import compat
 from . import setup_logger
 from .webcommon import log_application_errors
 
-github_authorize_url = 'https://github.com/login/oauth/authorize{?state,client_id,redirect_uri,response_type}'
+github_authorize_url = 'https://github.com/login/oauth/authorize{?state,client_id,redirect_uri,response_type,scope}'
 github_exchange_url = 'https://github.com/login/oauth/access_token'
 github_user_url = 'https://api.github.com/user'
 
@@ -167,6 +167,7 @@ def app_login():
     url = current_app.config.get('GITHUB_OAUTH_CALLBACK') or url_for('webauth.app_callback')
     args = dict(redirect_uri=callback_url(request, url), response_type='code', state=state)
     args.update(client_id=current_app.config['GITHUB_OAUTH_CLIENT_ID'])
+    args.update(scope='user,public_repo,read:org')
     
     return redirect(uritemplate.expand(github_authorize_url, args), 303)
 

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -59,6 +59,8 @@ def exchange_tokens(code, client_id, secret):
     resp = requests.post(github_exchange_url, urlencode(data),
                          headers={'Accept': 'application/json'})
     auth = resp.json()
+    _L.warning('(exchange_tokens) Posted {} to {}'.format(code, github_exchange_url))
+    _L.warning('(exchange_tokens) Got back {} {}'.format(auth.status_code, auth.text))
 
     if 'error' in auth:
         raise RuntimeError('Github said "{error}".'.format(**auth))
@@ -73,6 +75,8 @@ def user_information(token, org_id=6895392):
     '''
     header = {'Authorization': 'token {}'.format(token)}
     resp1 = requests.get(github_user_url, headers=header)
+    _L.warning('(user_information) Got {} with {}'.format(github_user_url, token))
+    _L.warning('(user_information) Got back {} {}'.format(resp1.status_code, resp1.text))
     
     if resp1.status_code != 200:
         return None, None, None

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -24,6 +24,7 @@ github_exchange_url = 'https://github.com/login/oauth/access_token'
 github_user_url = 'https://api.github.com/user'
 
 USER_KEY = 'github user'
+TOKEN_KEY = 'github token'
 
 webauth = Blueprint('webauth', __name__)
 
@@ -94,17 +95,17 @@ def update_authentication(untouched_route):
         if USER_KEY in session:
             session.pop(USER_KEY)
     
-        if 'github token' in session:
-            login, avatar_url, in_org = user_information(session['github token'])
+        if TOKEN_KEY in session:
+            login, avatar_url, in_org = user_information(session[TOKEN_KEY])
             
             if login and in_org:
                 session[USER_KEY] = dict(login=login, avatar_url=avatar_url)
             elif not login:
-                session.pop('github token')
+                session.pop(TOKEN_KEY)
                 return render_template('oauth-hello.html', user_required=True,
                                        user=None, error_bad_login=True)
             elif not in_org:
-                session.pop('github token')
+                session.pop(TOKEN_KEY)
                 return render_template('oauth-hello.html', user_required=True,
                                        user=None, error_org_membership=True)
 
@@ -153,7 +154,7 @@ def app_callback():
                             current_app.config['GITHUB_OAUTH_CLIENT_ID'],
                             current_app.config['GITHUB_OAUTH_SECRET'])
     
-    session['github token'] = token['access_token']
+    session[TOKEN_KEY] = token['access_token']
     
     return redirect(state.get('url', url_for('webauth.app_auth')), 302)
 
@@ -173,8 +174,8 @@ def app_login():
 @webauth.route('/auth/logout', methods=['POST'])
 @log_application_errors
 def app_logout():
-    if 'github token' in session:
-        session.pop('github token')
+    if TOKEN_KEY in session:
+        session.pop(TOKEN_KEY)
     
     if USER_KEY in session:
         session.pop(USER_KEY)

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -59,8 +59,6 @@ def exchange_tokens(code, client_id, secret):
     resp = requests.post(github_exchange_url, urlencode(data),
                          headers={'Accept': 'application/json'})
     auth = resp.json()
-    _L.warning('(exchange_tokens) Posted {} to {}'.format(code, github_exchange_url))
-    _L.warning('(exchange_tokens) Got back {} {}'.format(resp.status_code, resp.text))
 
     if 'error' in auth:
         raise RuntimeError('Github said "{error}".'.format(**auth))
@@ -75,8 +73,6 @@ def user_information(token, org_id=6895392):
     '''
     header = {'Authorization': 'token {}'.format(token)}
     resp1 = requests.get(github_user_url, headers=header)
-    _L.warning('(user_information) Got {} with {}'.format(github_user_url, token))
-    _L.warning('(user_information) Got back {} {}'.format(resp1.status_code, resp1.text))
     
     if resp1.status_code != 200:
         return None, None, None
@@ -98,8 +94,6 @@ def update_authentication(untouched_route):
         if USER_KEY in session:
             session.pop(USER_KEY)
     
-        _L.warning('(update_authentication) in session["github token"]: {}'.format(session.get('github token')))
-
         if 'github token' in session:
             login, avatar_url, in_org = user_information(session['github token'])
             
@@ -147,8 +141,6 @@ def s3_upload_form_fields(expires, bucketname, subdir, redirect_url, aws_secret)
 @update_authentication
 @log_application_errors
 def app_auth():
-    _L.warning('(app_auth) rendering with user {}'.format(session.get(USER_KEY, {})))
-
     return render_template('oauth-hello.html', user_required=True,
                            user=session.get(USER_KEY, {}))
 
@@ -161,7 +153,6 @@ def app_callback():
                             current_app.config['GITHUB_OAUTH_CLIENT_ID'],
                             current_app.config['GITHUB_OAUTH_SECRET'])
     
-    _L.warning('(app_callback) set session["github token"] to {}'.format(token['access_token']))
     session['github token'] = token['access_token']
     
     return redirect(state.get('url', url_for('webauth.app_auth')), 302)

--- a/openaddr/ci/webauth.py
+++ b/openaddr/ci/webauth.py
@@ -105,6 +105,14 @@ def update_authentication(untouched_route):
             
             if login and in_org:
                 session[USER_KEY] = dict(login=login, avatar_url=avatar_url)
+            elif not login:
+                session.pop('github token')
+                return render_template('oauth-hello.html', user_required=True,
+                                       user=None, error_bad_login=True)
+            elif not in_org:
+                session.pop('github token')
+                return render_template('oauth-hello.html', user_required=True,
+                                       user=None, error_org_membership=True)
 
         return untouched_route(*args, **kwargs)
     


### PR DESCRIPTION
Specifically when someone is not a member of the OA org. Also ask for `org:read` scope to hopefully make this less of an issue.

Closes #417.