### PR TITLE
Fix CI package dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache:
 addons:
   postgresql: "9.4"
 before_install:
+  # Add Ubuntu GIS PPA for various geospatial dependencies.
+  - sudo add-apt-repository -y ppa:ubuntugis
   - sudo apt-get update -y
 install:
   # Install Machine globally via Chef recipe, to pick up complete dependencies.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ cache:
 addons:
   postgresql: "9.4"
 before_install:
-  # Add Ubuntu GIS PPA for various geospatial dependencies.
-  - sudo add-apt-repository -y ppa:ubuntugis
   - sudo apt-get update -y
 install:
   # Install Machine globally via Chef recipe, to pick up complete dependencies.

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
   postgresql: "9.4"
 before_install:
   # Add Ubuntu GIS PPA for various geospatial dependencies.
-  - sudo add-apt-repository -y ppa:ubuntugis
+  - sudo add-apt-repository -y ppa:openaddresses/ci
   - sudo apt-get update -y
 install:
   # Install Machine globally via Chef recipe, to pick up complete dependencies.

--- a/chef/openaddr-prereqs/recipes/default.rb
+++ b/chef/openaddr-prereqs/recipes/default.rb
@@ -1,9 +1,18 @@
+package 'python3-gdal' do
+  version '1.11.2+dfsg-1~exp2~trusty'
+end
+
+package 'gdal-bin' do
+  version '1.11.2+dfsg-1~exp2~trusty'
+end
+
+package 'libgdal-dev' do
+  version '1.11.2+dfsg-1~exp2~trusty'
+end
+
 package 'python3-cairo'
-package 'python3-gdal'
 package 'python3-pip'
 package 'python3-dev'
 package 'libpq-dev'
 package 'memcached'
 package 'libffi-dev'
-package 'gdal-bin'
-package 'libgdal-dev'

--- a/chef/openaddr-prereqs/recipes/default.rb
+++ b/chef/openaddr-prereqs/recipes/default.rb
@@ -1,9 +1,19 @@
 package 'python3-cairo'
-package 'python3-gdal'
+
+package 'python3-gdal' do
+  version '1.11.2+dfsg-1~exp2~trusty'
+end
+
 package 'python3-pip'
 package 'python3-dev'
 package 'libpq-dev'
 package 'memcached'
 package 'libffi-dev'
-package 'gdal-bin'
-package 'libgdal-dev'
+
+package 'gdal-bin' do
+  version '1.11.2+dfsg-1~exp2~trusty'
+end
+
+package 'libgdal-dev' do
+  version '1.11.2+dfsg-1~exp2~trusty'
+end

--- a/chef/openaddr-prereqs/recipes/default.rb
+++ b/chef/openaddr-prereqs/recipes/default.rb
@@ -1,18 +1,9 @@
-package 'python3-gdal' do
-  version '1.11.2+dfsg-1~exp2~trusty'
-end
-
-package 'gdal-bin' do
-  version '1.11.2+dfsg-1~exp2~trusty'
-end
-
-package 'libgdal-dev' do
-  version '1.11.2+dfsg-1~exp2~trusty'
-end
-
 package 'python3-cairo'
+package 'python3-gdal'
 package 'python3-pip'
 package 'python3-dev'
 package 'libpq-dev'
 package 'memcached'
 package 'libffi-dev'
+package 'gdal-bin'
+package 'libgdal-dev'

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
 dependencies:
   override:
     # Add Ubuntu GIS PPA for various geospatial dependencies.
-    - sudo add-apt-repository -y ppa:ubuntugis
+    - sudo add-apt-repository -y ppa:openaddresses/ci
     - sudo apt-get update -y
     # Install Machine globally via Chef recipe, to pick up complete dependencies.
     - sudo chef/run.sh testing

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,8 @@ machine:
 
 dependencies:
   override:
+    # Add Ubuntu GIS PPA for various geospatial dependencies.
+    - sudo add-apt-repository -y ppa:ubuntugis
     - sudo apt-get update -y
     # Install Machine globally via Chef recipe, to pick up complete dependencies.
     - sudo chef/run.sh testing

--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,6 @@ machine:
 
 dependencies:
   override:
-    # Add Ubuntu GIS PPA for various geospatial dependencies.
-    - sudo add-apt-repository -y ppa:ubuntugis
     - sudo apt-get update -y
     # Install Machine globally via Chef recipe, to pick up complete dependencies.
     - sudo chef/run.sh testing


### PR DESCRIPTION
Earlier today, [ubuntugis-stable](https://launchpad.net/~ubuntugis/+archive/ubuntu/ppa) upgraded from GDAL 1.11 to 2.0, and it appears that PPAs do not continue to make old packages available. I don't want to make the jump to GDAL 2.x just yet, so I’ve copied specific versions of packages to a new [OpenAddresses CI PPA](https://launchpad.net/~openaddresses/+archive/ubuntu/ci) and updated the tests to use it.

Closes #431.