### PR TITLE
Returning 404 for non-existent job

### DIFF
--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -158,6 +158,9 @@ def app_get_job(job_id):
                 job = read_job(db, job_id)
             except TypeError:
                 return Response('Job {} not found'.format(job_id), 404)
+            else:
+                if job is None:
+                    return Response('Job {} not found'.format(job_id), 404)
     
     statuses = False, None, True
     key_func = lambda _path: (statuses.index(job.states[_path[1]]), _path[1])

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -1889,6 +1889,19 @@ class TestHook (unittest.TestCase):
         got5 = self.client.get('/latest/run/a5.zip')
         self.assertEqual(got5.status_code, 302)
         self.assertEqual(got5.headers.get('Location'), 'http://s3.amazonaws.com/past.openaddresses.io/runs/5/a5.zip')
+
+    def test_get_job(self):
+        '''
+        '''
+        got1 = self.client.get('/jobs/abc')
+        self.assertEqual(got1.status_code, 404, 'Job does not exist yet')
+
+        with db_connect(self.database_url) as conn:
+            with db_cursor(conn) as db:
+                add_job(db, 'abc', True, {}, {}, {}, 'oa', 'oa', None)
+
+        got1 = self.client.get('/jobs/abc')
+        self.assertEqual(got1.status_code, 200)
     
 class TestRuns (unittest.TestCase):
 


### PR DESCRIPTION
Fixes this notification due to someone crawling us:

```
ERROR: openaddr.ci.webcommon - GET /jobs/login.cgi

Traceback (most recent call last):
 File "/usr/local/lib/python3.4/dist-packages/openaddr/ci/webcommon.py", line 16, in decorated_function
   return route_function(*args, **kwargs)
 File "/usr/local/lib/python3.4/dist-packages/openaddr/ci/webhooks.py", line 164, in app_get_job
   file_tuples = [(sha, path) for (sha, path) in job.task_files.items()]
AttributeError: 'NoneType' object has no attribute 'task_files'
```