### PR TITLE
Add primitive source history view

### DIFF
--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -391,6 +391,19 @@ def new_read_completed_set_runs(db, set_id):
     
     return [Run(*row[:5]+(RunState(row[5]),)+row[6:]) for row in db.fetchall()]
 
+def read_completed_source_runs(db, source_path):
+    '''
+    '''
+    db.execute('''SELECT id, source_path, source_id, source_data, datetime_tz,
+                         state, status, copy_of, code_version, worker_id,
+                         job_id, set_id, commit_sha, is_merged FROM runs
+                  WHERE source_path = %s AND status IS NOT NULL
+                    AND (is_merged or is_merged is null)
+                    AND copy_of IS NULL''',
+               (source_path, ))
+    
+    return [Run(*row[:5]+(RunState(row[5]),)+row[6:]) for row in db.fetchall()]
+
 def read_completed_runs_to_date(db, starting_set_id):
     ''' Get only successful runs.
     '''

--- a/openaddr/ci/templates/source.html
+++ b/openaddr/ci/templates/source.html
@@ -1,0 +1,188 @@
+{% extends "base.html" %}
+{% block title %}Source whatever{% endblock %}
+{% block main %}
+
+<style lang="text/css">
+
+    #source { border-collapse: collapse }
+    
+    #source tr th,
+    #source tr td.type,
+    #source tr td.cached,
+    #source tr td.problems,
+    #source tr td.sample,
+    #source tr td table tr td
+    {
+        font-size: 65%;
+    }
+    
+    #source tr th, #source tr td
+    {
+        text-align: left;
+        padding: 3px 10px;
+        border: none;
+    }
+    
+    #source tr td>a
+    {
+        display: block;
+        margin: -3px -10px;
+        padding: 3px 10px;
+        text-decoration: underline;
+    }
+    
+    #source tr td small>a,
+    #source tr td.sample>a
+    {
+        display: inline;
+        margin: 0;
+        padding: 0;
+    }
+    
+    #source tr td.name>a
+    {
+        text-decoration: none;
+    }
+    
+    #source tr:nth-child(2n+0) td { background-color: #f8f8f8 }
+    #source tr:nth-child(2n+1) td { background-color: #ffffff }
+
+    #source tr td table { margin: 1em 0 }
+    #source tr td table { margin: 1em 0 }
+    #source tr td table tr th { color: #666 }
+
+    #source tr td table tr th,
+    #source tr td table tr td
+    {
+        font-family: monospace;
+        background-color: transparent !important;
+        line-height: 1.5em;
+        padding: 1px 10px;
+    }
+    
+   /*
+    * Progressively show additional sample data columns.
+    */
+
+    /*
+    #source tr th,
+    #source tr td
+    {
+        display: none
+    }
+    */
+
+    /*
+    Column classes:
+    1. name, 2. type, 3. cached, 4. processed, 5. problems, 6. sample
+    */
+
+    #source tr th:nth-child(1), /* name + data sample */
+    #source tr td:nth-child(1), /* name + data sample */
+    #source tr th.processed,
+    #source tr th.sample,
+    #source tr td.processed,
+    #source tr td.sample
+    {
+        display: table-cell
+    }
+
+    @media (min-width: 400px)
+    {
+        #source tr td table tr th:nth-child(4),
+        #source tr td table tr td:nth-child(4)
+        {
+            display: table-cell
+        }
+    }
+    
+    @media (min-width: 640px)
+    {
+        #source tr th.cached,
+        #source tr td.cached
+        {
+            display: table-cell
+        }
+    }
+    
+    @media (min-width: 960px)
+    {
+        #source tr th.type,
+        #source tr th.problems,
+        #source tr td.type,
+        #source tr td.problems
+        {
+            display: table-cell
+        }
+    }
+
+</style>
+
+<h1><a href="https://github.com/openaddresses/openaddresses/blob/{{ run.commit_sha }}/{{ run.source_path }}">{{ run.source_path }}</a></h1>
+
+{% if run.state.processed %}
+<p>
+    <a href="{{ run.state.processed }}">
+    {{ run.state.address_count|nice_integer }} addresses
+    downloaded {{ run.datetime_tz.strftime('%b %d %Y') }}
+    </a>
+</p>
+{% endif %}
+
+{% if source_data.website %}
+<p>
+    <a href="{{ source_data.website }}">{{ source_data.website }}</a>
+</p>
+{% endif %}
+
+<table id="source">
+<tr>
+    <th></th>
+    <th>Addresses</th>
+    <th>Date</th>
+    <th>Output</th>
+    <th>Cache</th>
+    <th>Source</th>
+    <th>Code</th>
+</tr>
+{% for run in runs %}
+
+    <tr>
+        <td>
+        {% if run.status is sameas False %}
+            <span style="color: #f00">&#x274C;</span>
+        {% else %}
+            <span style="color: #0c3">&#x2714;</span>
+        {% endif %}
+        </td>
+        <td>
+        {{ run.state.address_count|nice_integer }}
+        </td>
+        <td>
+        <a href="{{ run.state.output }}">{{ run.datetime_tz.strftime('%b %d %Y') }}</a>
+        </td>
+        <td>
+        {% if run.state.process_hash %}
+            <a href="{{ run.state.processed }}"><tt>{{ run.state.process_hash[:7] }}</tt></a>
+        {% elif run.state.processed %}
+            <a href="{{ run.state.processed }}">zip</a>
+        {% endif %}
+        </td>
+        <td>
+        {% if run.state.fingerprint %}
+            <a href="{{ run.state.cache }}"><tt>{{ run.state.fingerprint[:7] }}</tt></a>
+        {% elif run.state.cache %}
+            <a href="{{ run.state.cache }}">cache</a>
+        {% endif %}
+        </td>
+        <td>
+        <a href="https://github.com/openaddresses/openaddresses/blob/{{ run.commit_sha }}/{{ run.source_path }}"><tt>{{ run.source_id[:7] }}</tt></a>
+        </td>
+        <td>
+        <a href="https://github.com/openaddresses/machine/releases/tag/{{ run.code_version }}"><tt>{{ run.code_version }}</tt></a>
+        </td>
+    </tr>
+
+{% endfor %}
+</table>
+{% endblock main %}

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -353,15 +353,17 @@ def apply_webhooks_blueprint(app):
     '''
     app.register_blueprint(webhooks)
 
-    app.jinja_env.filters['tojson'] = lambda value: json.dumps(value, ensure_ascii=False)
-    app.jinja_env.filters['element_id'] = lambda value: value.replace("'", '-')
-    app.jinja_env.filters['nice_integer'] = nice_integer
-    app.jinja_env.filters['nice_timedelta'] = nice_timedelta
-    app.jinja_env.filters['breakstate'] = break_state
-    app.jinja_env.filters['nice_size'] = nice_size
-
     @app.before_first_request
     def app_prepare():
+        # Filters are set here so Jinja debug reload works; see also:
+        # https://github.com/pallets/flask/issues/1907#issuecomment-225743376
+        app.jinja_env.filters['tojson'] = lambda value: json.dumps(value, ensure_ascii=False)
+        app.jinja_env.filters['element_id'] = lambda value: value.replace("'", '-')
+        app.jinja_env.filters['nice_integer'] = nice_integer
+        app.jinja_env.filters['nice_timedelta'] = nice_timedelta
+        app.jinja_env.filters['breakstate'] = break_state
+        app.jinja_env.filters['nice_size'] = nice_size
+
         setup_logger(os.environ.get('AWS_ACCESS_KEY_ID'),
                      os.environ.get('AWS_SECRET_ACCESS_KEY'),
                      os.environ.get('AWS_SNS_ARN'), logging.WARNING)

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -259,6 +259,25 @@ def app_get_run_sample(run_id):
     
     return render_template('run-sample.html', sample_data=sample_data or [])
 
+@webhooks.route('/sources/<path:source>', methods=['GET'])
+@log_application_errors
+def app_get_source_history(source):
+    '''
+    '''
+    source_path = u'sources/{}.json'.format(source)
+    
+    with db_connect(current_app.config['DATABASE_URL']) as conn:
+        with db_cursor(conn) as db:
+            db.execute('''select datetime_tz, id, status, code_version, is_merged, state->'fingerprint', state->'process hash', set_id
+                          from runs
+                          where source_path = %s
+                          order by id desc''',
+                       (source_path, ))
+            
+            runs = list(db)
+
+    return jsonify(runs)
+
 def nice_timedelta(delta):
     '''
     >>> nice_timedelta(timedelta(days=2))


### PR DESCRIPTION
This is a super-primitive approach, and I am looking for feedback. I spoke with @iandees about the content of these pages, and we agreed to get broader feedback in Slack. So, I’m going to merge and deploy this immediately, then source histories will be visible at URLs like these:

- https://results.openaddresses.io/sources/us/nm/taos
- https://results.openaddresses.io/sources/us/nd/dickinson
- https://results.openaddresses.io/sources/au/city_of_canberra
- https://results.openaddresses.io/sources/mx/hidalgo/statewide
- https://results.openaddresses.io/sources/us/il/mcdonough

Closes #446.