### PR TITLE
Use a GDAL error handler to extract more info on error

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -27,6 +27,20 @@ from .sample import sample_geojson
 from osgeo import ogr, osr
 ogr.UseExceptions()
 
+
+def gdal_error_handler(err_class, err_num, err_msg):
+    errtype = {
+            gdal.CE_None:'None',
+            gdal.CE_Debug:'Debug',
+            gdal.CE_Warning:'Warning',
+            gdal.CE_Failure:'Failure',
+            gdal.CE_Fatal:'Fatal'
+    }
+    err_msg = err_msg.replace('\n',' ')
+    err_class = errtype.get(err_class, 'None')
+    _L.error("GDAL gave %s %s: %s", err_class, err_num, err_msg)
+
+
 # The canonical output schema for conform
 OPENADDR_CSV_SCHEMA = ['LON', 'LAT', 'NUMBER', 'STREET', 'UNIT', 'CITY',
                        'DISTRICT', 'REGION', 'POSTCODE', 'ID', 'HASH']

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 from .compat import csvopen, csvreader, csvDictReader, csvDictWriter
 from .sample import sample_geojson
 
-from osgeo import ogr, osr
+from osgeo import ogr, osr, gdal
 ogr.UseExceptions()
 
 
@@ -39,6 +39,7 @@ def gdal_error_handler(err_class, err_num, err_msg):
     err_msg = err_msg.replace('\n',' ')
     err_class = errtype.get(err_class, 'None')
     _L.error("GDAL gave %s %s: %s", err_class, err_num, err_msg)
+gdal.PushErrorHandler(gdal_error_handler)
 
 
 # The canonical output schema for conform


### PR DESCRIPTION
There is more to the error we see in results like [this](http://s3.amazonaws.com/data.openaddresses.io/runs/127169/output.txt). According to [this StackOverflow suggestion](http://stackoverflow.com/a/27573967), I'm [installing a GDAL error handler](http://pcjericks.github.io/py-gdalogr-cookbook/gdal_general.html#install-gdal-ogr-error-handler) and logging out what it gives us.