### PR TITLE
Support more preview points than fit in memory

### DIFF
--- a/openaddr/preview.py
+++ b/openaddr/preview.py
@@ -33,6 +33,7 @@ def render(filename_or_url, png_filename, width, resolution, mapzen_key):
     project = get_projection()
 
     try:
+        _L.info('Writing from {} to {}...'.format(src_filename, points_filename))
         file_points = iterate_file_points(src_filename)
         xy_points = project_points(file_points, project)
         write_points(xy_points, points_filename)
@@ -192,10 +193,14 @@ def project_points(lonlats, project):
     '''
     for (lon, lat) in lonlats:
         geom = ogr.CreateGeometryFromWkt('POINT({:.7f} {:.7f})'.format(lon, lat))
-        geom.Transform(project)
-        xy = geom.GetX(), geom.GetY()
-        del geom
-        yield xy
+        try:
+            geom.Transform(project)
+        except:
+            pass
+        else:
+            yield (geom.GetX(), geom.GetY())
+        finally:
+            del geom
 
 def write_points(points, points_filename):
     ''' Write a stream of (x, y) points into a file of packed values.

--- a/openaddr/preview.py
+++ b/openaddr/preview.py
@@ -220,35 +220,30 @@ def read_points(points_filename):
                 return
 
 def stats(points_filename):
+    ''' Return means and standard deviations for points in file.
+        
+        Uses Welford's numerically stable algorithm from
+        https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
     '''
-    '''
-    xmean, ymean, count = 0, 0, count_points(points_filename)
+    n, xmean, xM2, ymean, yM2 = 0, 0, 0, 0, 0
     
     for (x, y) in read_points(points_filename):
-        xmean += x / count
-        ymean += y / count
-    
-    print(xmean, ymean)
-    
-    xdev, ydev = 0, 0
-    
-    for (x, y) in read_points(points_filename):
-        xdev += pow(x - xmean, 2) / count
-        ydev += pow(y - ymean, 2) / count
-    
-    print(xdev, ydev)
-    
-    xsdev, ysdev = sqrt(xdev), sqrt(ydev)
-    
-    print(xsdev, ysdev)
-    
-    return xmean, xsdev, ymean, ysdev
+        n += 1
 
-    mean = sum(values) / len(values)
-    deviations = [pow(val - mean, 2) for val in values]
-    stddev = sqrt(sum(deviations) / len(values))
-
-    return mean, stddev
+        xdelta = x - xmean
+        xmean += xdelta / n
+        xM2 += xdelta * (x - xmean)
+        
+        ydelta = y - ymean
+        ymean += ydelta / n
+        yM2 += ydelta * (y - ymean)
+    
+    if n < 2:
+        raise ValueError()
+    
+    xstddev, ystddev = sqrt(xM2 / (n - 1)), sqrt(yM2 / (n - 1))
+    
+    return xmean, xstddev, ymean, ystddev
 
 def calculate_zoom(scale, resolution):
     ''' Calculate web map zoom based on scale.

--- a/openaddr/preview.py
+++ b/openaddr/preview.py
@@ -191,16 +191,18 @@ def get_projection():
 def project_points(lonlats, project):
     '''
     '''
+    geom = ogr.Geometry(ogr.wkbPoint)
+
     for (lon, lat) in lonlats:
-        geom = ogr.CreateGeometryFromWkt('POINT({:.7f} {:.7f})'.format(lon, lat))
+        geom.SetPoint(0, lon, lat)
         try:
             geom.Transform(project)
         except:
             pass
         else:
             yield (geom.GetX(), geom.GetY())
-        finally:
-            del geom
+
+    del geom
 
 def write_points(points, points_filename):
     ''' Write a stream of (x, y) points into a file of packed values.

--- a/openaddr/preview.py
+++ b/openaddr/preview.py
@@ -8,7 +8,7 @@ from tempfile import mkstemp
 from math import pow, sqrt, pi, log
 from argparse import ArgumentParser
 from urllib.parse import urlparse
-import json, itertools, os
+import json, itertools, os, struct
 
 import requests, uritemplate
 
@@ -28,8 +28,15 @@ def render(filename_or_url, png_filename, width, resolution, mapzen_key):
     '''
     '''
     src_filename = get_local_filename(filename_or_url)
-    points = project_points(iterate_file_points(src_filename))
-    xmin, ymin, xmax, ymax = calculate_bounds(points)
+    _, points_filename = mkstemp(prefix='points-', suffix='.bin')
+    print('points_filename:', points_filename)
+
+    project = get_projection()
+    file_points = iterate_file_points(src_filename)
+    xy_points = project_points(file_points, project)
+    write_points(xy_points, points_filename)
+
+    xmin, ymin, xmax, ymax = calculate_bounds(points_filename)
     
     surface, context, scale = make_context(xmin, ymin, xmax, ymax, width, resolution)
 
@@ -64,7 +71,7 @@ def render(filename_or_url, png_filename, width, resolution, mapzen_key):
     
     context.set_line_width(.25 * muppx)
 
-    for (x, y) in points:
+    for (x, y) in read_points(points_filename):
         context.arc(x, y, 15, 0, 2 * pi)
         context.set_source_rgb(*point_fill)
         context.fill()
@@ -175,22 +182,68 @@ def get_projection():
     sref_map = osr.SpatialReference(); sref_map.ImportFromProj4(EPSG900913)
     return osr.CoordinateTransformation(sref_geo, sref_map)
 
-def project_points(lonlats):
+def project_points(lonlats, project):
     '''
     '''
-    project = get_projection()
-    points = list()
-    
     for (lon, lat) in lonlats:
         geom = ogr.CreateGeometryFromWkt('POINT({:.7f} {:.7f})'.format(lon, lat))
         geom.Transform(project)
-        points.append((geom.GetX(), geom.GetY()))
-    
-    return points
+        xy = geom.GetX(), geom.GetY()
+        del geom
+        yield xy
 
-def stats(values):
+def write_points(points, dest_filename):
     '''
     '''
+    with open(dest_filename, mode='wb') as file:
+        for (x, y) in points:
+            file.write(struct.pack('ff', x, y))
+
+def count_points(points_filename):
+    '''
+    '''
+    chunk_size = struct.calcsize('ff')
+    return os.stat(points_filename).st_size // chunk_size
+
+def read_points(points_filename):
+    '''
+    '''
+    _L.debug('Reading from {}'.format(points_filename))
+    chunk_size = struct.calcsize('ff')
+    
+    with open(points_filename, mode='rb') as file:
+        while True:
+            chunk = file.read(chunk_size)
+            if chunk:
+                yield struct.unpack('ff', chunk)
+            else:
+                return
+
+def stats(points_filename):
+    '''
+    '''
+    xmean, ymean, count = 0, 0, count_points(points_filename)
+    
+    for (x, y) in read_points(points_filename):
+        xmean += x / count
+        ymean += y / count
+    
+    print(xmean, ymean)
+    
+    xdev, ydev = 0, 0
+    
+    for (x, y) in read_points(points_filename):
+        xdev += pow(x - xmean, 2) / count
+        ydev += pow(y - ymean, 2) / count
+    
+    print(xdev, ydev)
+    
+    xsdev, ysdev = sqrt(xdev), sqrt(ydev)
+    
+    print(xsdev, ysdev)
+    
+    return xmean, xsdev, ymean, ysdev
+
     mean = sum(values) / len(values)
     deviations = [pow(val - mean, 2) for val in values]
     stddev = sqrt(sum(deviations) / len(values))
@@ -205,22 +258,25 @@ def calculate_zoom(scale, resolution):
     
     return zoom
 
-def calculate_bounds(points):
+def calculate_bounds(points_filename):
     '''
     '''
-    xs, ys = zip(*points)
-
+    xmean, xsdev, ymean, ysdev = stats(points_filename)
+    
     # use standard deviation to avoid far-flung mistakes, and look further
     # horizontally to account for Github comment thread image appearance.
-    (xmean, xsdev), (ymean, ysdev) = stats(xs), stats(ys)
     xmin, xmax = xmean - 5 * xsdev, xmean + 5 * xsdev
     ymin, ymax = ymean - 3 * ysdev, ymean + 3 * ysdev
     
     # look at the actual points
-    okay_xs = [x for (x, y) in points if (xmin <= x <= xmax)]
-    okay_ys = [y for (x, y) in points if (ymin <= y <= ymax)]
-    left, bottom = min(okay_xs), min(okay_ys)
-    right, top = max(okay_xs), max(okay_ys)
+    left, right = xmax, xmin
+    bottom, top = ymax, ymin
+    
+    for (x, y) in read_points(points_filename):
+        if xmin <= x <= xmax:
+            left, right = min(left, x), max(right, x)
+        if ymin <= y <= ymax:
+            bottom, top = min(bottom, y), max(top, y)
     
     # pad by 2% on all sides
     width, height = right - left, top - bottom

--- a/openaddr/tests/preview.py
+++ b/openaddr/tests/preview.py
@@ -28,7 +28,7 @@ class TestPreview (unittest.TestCase):
         
         xmean, xsdev, ymean, ysdev = preview.stats(points_filename)
         self.assertAlmostEqual(xmean, 0)
-        self.assertAlmostEqual(xsdev, 577.638872191)
+        self.assertAlmostEqual(xsdev, 577.783263863)
         self.assertAlmostEqual(ymean, xmean)
         self.assertAlmostEqual(ysdev, xsdev)
 

--- a/openaddr/tests/preview.py
+++ b/openaddr/tests/preview.py
@@ -7,6 +7,7 @@ import subprocess
 
 from os.path import join, dirname
 from zipfile import ZipFile
+from shutil import rmtree
 
 from httmock import HTTMock, response
 
@@ -14,16 +15,30 @@ from .. import preview
 
 class TestPreview (unittest.TestCase):
 
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix='TestPreview-')
+    
+    def tearDown(self):
+        rmtree(self.temp_dir)
+
     def test_stats(self):
-        values = range(-1000, 1001)
-        mean, stddev = preview.stats(values)
-        self.assertEqual(mean, 0)
-        self.assertAlmostEqual(stddev, 577.638872191)
+        points = [(n, n) for n in range(-1000, 1001)]
+        points_filename = join(self.temp_dir, 'points.bin')
+        preview.write_points(points, points_filename)
+        
+        xmean, xsdev, ymean, ysdev = preview.stats(points_filename)
+        self.assertAlmostEqual(xmean, 0)
+        self.assertAlmostEqual(xsdev, 577.638872191)
+        self.assertAlmostEqual(ymean, xmean)
+        self.assertAlmostEqual(ysdev, xsdev)
 
     def test_calculate_bounds(self):
         points = [(-10000, -10000), (10000, 10000)]
         points += [(-1, -1), (0, 0), (1, 1)] * 100
-        bbox = preview.calculate_bounds(points)
+        points_filename = join(self.temp_dir, 'points.bin')
+        preview.write_points(points, points_filename)
+        
+        bbox = preview.calculate_bounds(points_filename)
         self.assertEqual(bbox, (-1.04, -1.04, 1.04, 1.04), 'The two outliers are ignored')
     
     def test_render_zip(self):


### PR DESCRIPTION
Uses a temporary file with packed float values to store points outside of RAM, and catch geometry transformation errors.

Closes #455.
Closes #454.