### PR TITLE
added `prefix_number` and `prefix_street` conform functions

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -82,8 +82,8 @@ geometry_types = {
     ogr.wkbUnknown: 'Unknown'
     }
 
-basic_number_pattern = re.compile("^\s*([0-9]+)\s+", False)
-basic_street_pattern = re.compile("^(?:\s*[0-9]+\s+)?(.*)", False)
+prefix_number_pattern = re.compile("^\s*([0-9]+)\s+", False)
+prefix_street_pattern = re.compile("^(?:\s*[0-9]+\s+)?(.*)", False)
 
 def mkdirsp(path):
     try:
@@ -878,10 +878,10 @@ def row_transform_and_convert(sd, row):
                 row = row_fxn_regexp(sd, row, k)
             elif c[k]["function"] == "format":
                 row = row_fxn_format(sd, row, k)
-            elif c[k]["function"] == "basic_number":
-                row = row_fxn_basic_number(sd, row, k)
-            elif c[k]["function"] == "basic_street":
-                row = row_fxn_basic_street(sd, row, k)
+            elif c[k]["function"] == "prefix_number":
+                row = row_fxn_prefix_number(sd, row, k)
+            elif c[k]["function"] == "prefix_street":
+                row = row_fxn_prefix_street(sd, row, k)
 
     if "advanced_merge" in c:
         raise ValueError('Found unsupported "advanced_merge" option in conform')
@@ -951,20 +951,20 @@ def row_fxn_regexp(sd, row, key):
         row[attrib_types[key]] = ''.join(match.groups()) if match else '';
     return row
 
-def row_fxn_basic_number(sd, row, key):
+def row_fxn_prefix_number(sd, row, key):
     "Extract '123' from '123 Maple St'"
     fxn = sd["conform"][key]
 
-    match = basic_number_pattern.search(row[fxn["field"]])
+    match = prefix_number_pattern.search(row[fxn["field"]])
     row[attrib_types[key]] = ''.join(match.groups()) if match else '';
 
     return row
 
-def row_fxn_basic_street(sd, row, key):
+def row_fxn_prefix_street(sd, row, key):
     "Extract 'Maple St' from '123 Maple St'"
     fxn = sd["conform"][key]
 
-    match = basic_street_pattern.search(row[fxn["field"]])
+    match = prefix_street_pattern.search(row[fxn["field"]])
     row[attrib_types[key]] = ''.join(match.groups()) if match else '';
 
     return row

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -82,6 +82,9 @@ geometry_types = {
     ogr.wkbUnknown: 'Unknown'
     }
 
+basic_number_pattern = re.compile("^\s*([0-9]+)\s+", False)
+basic_street_pattern = re.compile("^(?:\s*[0-9]+\s+)?(.*)", False)
+
 def mkdirsp(path):
     try:
         os.makedirs(path)
@@ -952,8 +955,7 @@ def row_fxn_basic_number(sd, row, key):
     "Extract '123' from '123 Maple St'"
     fxn = sd["conform"][key]
 
-    pattern = re.compile("^\s*([0-9]+)\s+", False)
-    match = pattern.search(row[fxn["field"]])
+    match = basic_number_pattern.search(row[fxn["field"]])
     row[attrib_types[key]] = ''.join(match.groups()) if match else '';
 
     return row
@@ -962,8 +964,7 @@ def row_fxn_basic_street(sd, row, key):
     "Extract 'Maple St' from '123 Maple St'"
     fxn = sd["conform"][key]
 
-    pattern = re.compile("^(?:\s*[0-9]+\s+)?(.*)", False)
-    match = pattern.search(row[fxn["field"]])
+    match = basic_street_pattern.search(row[fxn["field"]])
     row[attrib_types[key]] = ''.join(match.groups()) if match else '';
 
     return row

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -875,6 +875,10 @@ def row_transform_and_convert(sd, row):
                 row = row_fxn_regexp(sd, row, k)
             elif c[k]["function"] == "format":
                 row = row_fxn_format(sd, row, k)
+            elif c[k]["function"] == "basic_number":
+                row = row_fxn_basic_number(sd, row, k)
+            elif c[k]["function"] == "basic_street":
+                row = row_fxn_basic_street(sd, row, k)
 
     if "advanced_merge" in c:
         raise ValueError('Found unsupported "advanced_merge" option in conform')
@@ -942,6 +946,26 @@ def row_fxn_regexp(sd, row, key):
     else:
         match = pattern.search(row[fxn["field"]])
         row[attrib_types[key]] = ''.join(match.groups()) if match else '';
+    return row
+
+def row_fxn_basic_number(sd, row, key):
+    "Extract '123' from '123 Maple St'"
+    fxn = sd["conform"][key]
+
+    pattern = re.compile("^\s*([0-9]+)\s+", False)
+    match = pattern.search(row[fxn["field"]])
+    row[attrib_types[key]] = ''.join(match.groups()) if match else '';
+
+    return row
+
+def row_fxn_basic_street(sd, row, key):
+    "Extract 'Maple St' from '123 Maple St'"
+    fxn = sd["conform"][key]
+
+    pattern = re.compile("^(?:\s*[0-9]+\s+)?(.*)", False)
+    match = pattern.search(row[fxn["field"]])
+    row[attrib_types[key]] = ''.join(match.groups()) if match else '';
+
     return row
 
 def row_fxn_format(sd, row, key):

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -16,7 +16,7 @@ from ..conform import (
     csv_source_to_csv, find_source_path, row_transform_and_convert,
     row_fxn_regexp, row_smash_case, row_round_lat_lon, row_merge,
     row_extract_and_reproject, row_convert_to_out, row_fxn_join, row_fxn_format,
-    row_fxn_basic_number, row_fxn_basic_street,
+    row_fxn_prefix_number, row_fxn_prefix_street,
     row_canonicalize_unit_and_number, conform_smash_case, conform_cli,
     csvopen, csvDictReader, convert_regexp_replace, conform_license,
     conform_attribution, conform_sharealike, normalize_ogr_filename_case,
@@ -275,15 +275,15 @@ class TestConformTransforms (unittest.TestCase):
         r = row_extract_and_reproject(d, {"LONG_WGS84": "-21,77", "LAT_WGS84": "64,11"})
         self.assertEqual({Y_FIELDNAME: "64.11", X_FIELDNAME: "-21.77"}, r)
 
-    def test_row_fxn_basic_number_and_street(self):
-        "Regex basic_number and basic_street - both fields present"
+    def test_row_fxn_prefix_number_and_street(self):
+        "Regex prefix_number and prefix_street - both fields present"
         c = { "conform": {
             "number": {
-                "function": "basic_number",
+                "function": "prefix_number",
                 "field": "ADDRESS"
             },
             "street": {
-                "function": "basic_street",
+                "function": "prefix_street",
                 "field": "ADDRESS"
             }
         } }
@@ -291,18 +291,18 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123", "OA:street": "MAPLE ST" })
 
-        d = row_fxn_basic_number(c, d, "number")
-        d = row_fxn_basic_street(c, d, "street")
+        d = row_fxn_prefix_number(c, d, "number")
+        d = row_fxn_prefix_street(c, d, "street")
         self.assertEqual(e, d)
 
-        "Regex basic_number and basic_street - no number"
+        "Regex prefix_number and prefix_street - no number"
         c = { "conform": {
             "number": {
-                "function": "basic_number",
+                "function": "prefix_number",
                 "field": "ADDRESS"
             },
             "street": {
-                "function": "basic_street",
+                "function": "prefix_street",
                 "field": "ADDRESS"
             }
         } }
@@ -310,18 +310,18 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "", "OA:street": "MAPLE ST" })
 
-        d = row_fxn_basic_number(c, d, "number")
-        d = row_fxn_basic_street(c, d, "street")
+        d = row_fxn_prefix_number(c, d, "number")
+        d = row_fxn_prefix_street(c, d, "street")
         self.assertEqual(e, d)
 
-        "Regex basic_number and basic_street - empty input"
+        "Regex prefix_number and prefix_street - empty input"
         c = { "conform": {
             "number": {
-                "function": "basic_number",
+                "function": "prefix_number",
                 "field": "ADDRESS"
             },
             "street": {
-                "function": "basic_street",
+                "function": "prefix_street",
                 "field": "ADDRESS"
             }
         } }
@@ -329,18 +329,18 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "", "OA:street": "" })
 
-        d = row_fxn_basic_number(c, d, "number")
-        d = row_fxn_basic_street(c, d, "street")
+        d = row_fxn_prefix_number(c, d, "number")
+        d = row_fxn_prefix_street(c, d, "street")
         self.assertEqual(e, d)
 
-        "Regex basic_number and basic_street - no spaces after number"
+        "Regex prefix_number and prefix_street - no spaces after number"
         c = { "conform": {
             "number": {
-                "function": "basic_number",
+                "function": "prefix_number",
                 "field": "ADDRESS"
             },
             "street": {
-                "function": "basic_street",
+                "function": "prefix_street",
                 "field": "ADDRESS"
             }
         } }
@@ -348,18 +348,18 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "", "OA:street": "123MAPLE ST" })
 
-        d = row_fxn_basic_number(c, d, "number")
-        d = row_fxn_basic_street(c, d, "street")
+        d = row_fxn_prefix_number(c, d, "number")
+        d = row_fxn_prefix_street(c, d, "street")
         self.assertEqual(e, d)
 
-        "Regex basic_number and basic_street - excess whitespace"
+        "Regex prefix_number and prefix_street - excess whitespace"
         c = { "conform": {
             "number": {
-                "function": "basic_number",
+                "function": "prefix_number",
                 "field": "ADDRESS"
             },
             "street": {
-                "function": "basic_street",
+                "function": "prefix_street",
                 "field": "ADDRESS"
             }
         } }
@@ -367,8 +367,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123", "OA:street": "MAPLE ST" })
 
-        d = row_fxn_basic_number(c, d, "number")
-        d = row_fxn_basic_street(c, d, "street")
+        d = row_fxn_prefix_number(c, d, "number")
+        d = row_fxn_prefix_street(c, d, "street")
         self.assertEqual(e, d)
 
 class TestConformCli (unittest.TestCase):

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -16,6 +16,7 @@ from ..conform import (
     csv_source_to_csv, find_source_path, row_transform_and_convert,
     row_fxn_regexp, row_smash_case, row_round_lat_lon, row_merge,
     row_extract_and_reproject, row_convert_to_out, row_fxn_join, row_fxn_format,
+    row_fxn_basic_number, row_fxn_basic_street,
     row_canonicalize_unit_and_number, conform_smash_case, conform_cli,
     csvopen, csvDictReader, convert_regexp_replace, conform_license,
     conform_attribution, conform_sharealike, normalize_ogr_filename_case,
@@ -273,6 +274,102 @@ class TestConformTransforms (unittest.TestCase):
         d = { "conform" : { "lon": "LONG_WGS84", "lat": "LAT_WGS84", "type": "csv" }, 'type': 'test' }
         r = row_extract_and_reproject(d, {"LONG_WGS84": "-21,77", "LAT_WGS84": "64,11"})
         self.assertEqual({Y_FIELDNAME: "64.11", X_FIELDNAME: "-21.77"}, r)
+
+    def test_row_fxn_basic_number_and_street(self):
+        "Regex basic_number and basic_street - both fields present"
+        c = { "conform": {
+            "number": {
+                "function": "basic_number",
+                "field": "ADDRESS"
+            },
+            "street": {
+                "function": "basic_street",
+                "field": "ADDRESS"
+            }
+        } }
+        d = { "ADDRESS": "123 MAPLE ST" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:number": "123", "OA:street": "MAPLE ST" })
+
+        d = row_fxn_basic_number(c, d, "number")
+        d = row_fxn_basic_street(c, d, "street")
+        self.assertEqual(e, d)
+
+        "Regex basic_number and basic_street - no number"
+        c = { "conform": {
+            "number": {
+                "function": "basic_number",
+                "field": "ADDRESS"
+            },
+            "street": {
+                "function": "basic_street",
+                "field": "ADDRESS"
+            }
+        } }
+        d = { "ADDRESS": "MAPLE ST" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:number": "", "OA:street": "MAPLE ST" })
+
+        d = row_fxn_basic_number(c, d, "number")
+        d = row_fxn_basic_street(c, d, "street")
+        self.assertEqual(e, d)
+
+        "Regex basic_number and basic_street - empty input"
+        c = { "conform": {
+            "number": {
+                "function": "basic_number",
+                "field": "ADDRESS"
+            },
+            "street": {
+                "function": "basic_street",
+                "field": "ADDRESS"
+            }
+        } }
+        d = { "ADDRESS": "" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:number": "", "OA:street": "" })
+
+        d = row_fxn_basic_number(c, d, "number")
+        d = row_fxn_basic_street(c, d, "street")
+        self.assertEqual(e, d)
+
+        "Regex basic_number and basic_street - no spaces after number"
+        c = { "conform": {
+            "number": {
+                "function": "basic_number",
+                "field": "ADDRESS"
+            },
+            "street": {
+                "function": "basic_street",
+                "field": "ADDRESS"
+            }
+        } }
+        d = { "ADDRESS": "123MAPLE ST" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:number": "", "OA:street": "123MAPLE ST" })
+
+        d = row_fxn_basic_number(c, d, "number")
+        d = row_fxn_basic_street(c, d, "street")
+        self.assertEqual(e, d)
+
+        "Regex basic_number and basic_street - excess whitespace"
+        c = { "conform": {
+            "number": {
+                "function": "basic_number",
+                "field": "ADDRESS"
+            },
+            "street": {
+                "function": "basic_street",
+                "field": "ADDRESS"
+            }
+        } }
+        d = { "ADDRESS": " \t 123 \t MAPLE ST" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:number": "123", "OA:street": "MAPLE ST" })
+
+        d = row_fxn_basic_number(c, d, "number")
+        d = row_fxn_basic_street(c, d, "street")
+        self.assertEqual(e, d)
 
 class TestConformCli (unittest.TestCase):
     "Test the command line interface creates valid output files from test input"


### PR DESCRIPTION
See openaddresses/openaddresses#2075

These 2 functions abstract the common `regexp` patterns in use for US (and other country) sources.  By internalizing these 2 commons patterns, modifications can be implemented without having to modify the many sources that use these patterns.

Its current implementation only covers a few basic scenarios:

- `number` is only defined as optional whitespace + 1 or more digits + at least one whitespace
- `street` is defined as anything after `number`

2 functions were used instead of a single function that writes both `number` and `street` fields in the event that the source already contains a separate `number` or `street` field.

*This is my first foray into python, my apologies if it's terrible*