### PR TITLE
Fixed confusion between run state "version" and "code version"

### DIFF
--- a/chef/openaddr-prereqs/recipes/default.rb
+++ b/chef/openaddr-prereqs/recipes/default.rb
@@ -9,6 +9,7 @@ package 'python3-dev'
 package 'libpq-dev'
 package 'memcached'
 package 'libffi-dev'
+package 'awscli'
 
 package 'gdal-bin' do
   version '1.11.2+dfsg-1~exp2~trusty'

--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -84,7 +84,8 @@ class RunState:
         'address count', 'version', 'fingerprint', 'cache time', 'processed',
         'output', 'process time', 'website', 'skipped', 'license',
         'share-alike', 'attribution required', 'attribution name',
-        'attribution flag', 'process hash', 'preview', 'source problem')}
+        'attribution flag', 'process hash', 'preview', 'source problem',
+        'code version')}
 
     def __init__(self, json_blob):
         blob_dict = dict(json_blob or {})
@@ -111,6 +112,7 @@ class RunState:
         self.attribution_name = blob_dict.get('attribution name')
         self.attribution_flag = blob_dict.get('attribution flag')
         self.source_problem = blob_dict.get('source problem')
+        self.code_version = blob_dict.get('code version')
 
         unexpected = ', '.join(set(self.keys) - set(RunState.key_attrs.keys()))
         assert len(unexpected) == 0, 'RunState should not have keys {}'.format(unexpected)
@@ -118,10 +120,6 @@ class RunState:
         assert self.source_problem in FAIL_REASONS, 'Uknown failure reason {}'.format(repr(self.source_problem))
     
     def get(self, json_key):
-        if json_key == 'code version':
-            # account for ci.webapi.CSV_HEADER mismatch
-            json_key = 'version'
-    
         return getattr(self, RunState.key_attrs[json_key])
         
     def to_json(self):
@@ -307,7 +305,7 @@ def set_run(db, run_id, filename, file_id, content_b64, run_state, run_status,
                   WHERE id = %s''',
                (filename, content_b64, file_id,
                run_state.to_json(), run_status, worker_id,
-               run_state.version, job_id, commit_sha, is_merged,
+               run_state.code_version, job_id, commit_sha, is_merged,
                set_id, run_id))
 
 def copy_run(db, run_id, job_id, commit_sha, set_id):

--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -11,7 +11,7 @@ from os import mkdir, rmdir, close, chmod
 from _thread import get_ident
 import tempfile, json, csv, sys
 
-from . import cache, conform, preview, CacheResult, ConformResult
+from . import cache, conform, preview, CacheResult, ConformResult, __version__
 from .compat import csvopen, csvwriter, PY2
 from .cache import DownloadError
 
@@ -228,6 +228,7 @@ def write_state(source, skipped, destination, log_handler, cache_result,
         ('attribution name', conform_result.attribution_name),
         ('share-alike', boolstr(conform_result.sharealike_flag)),
         ('source problem', source_problem),
+        ('code version', __version__),
         ]
                
     with csvopen(join(statedir, 'index.txt'), 'w', encoding='utf8') as file:

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -108,9 +108,9 @@ class TestObjects (unittest.TestCase):
 
         # special case for code version
         value = str(uuid4())
-        state = RunState({'version': value})
-        self.assertEqual(state.get('version'), value)
-        self.assertEqual(state.version, value)
+        state = RunState({'code version': value})
+        self.assertEqual(state.get('code version'), value)
+        self.assertEqual(state.code_version, value)
 
     def test_add_job(self):
         ''' Check behavior of objects.add_job()
@@ -355,7 +355,7 @@ class TestObjects (unittest.TestCase):
     def test_set_run(self):
         ''' Check behavior of objects.add_set()
         '''
-        set_run(self.db, 456, '', '', b'', RunState({'version': 'x.y.z'}), True, 'xyz', '', '', False, 123)
+        set_run(self.db, 456, '', '', b'', RunState({'code version': 'x.y.z'}), True, 'xyz', '', '', False, 123)
 
         self.db.execute.assert_called_once_with(
                '''UPDATE runs SET
@@ -365,7 +365,7 @@ class TestObjects (unittest.TestCase):
                   is_merged = %s, set_id = %s, datetime_tz = NOW()
                   WHERE id = %s''',
                   ('', b'', '',
-                   '{"version": "x.y.z"}', True, '',
+                   '{"code version": "x.y.z"}', True, '',
                    'x.y.z', 'xyz', '', False,
                    123, 456))
 
@@ -1900,7 +1900,7 @@ class TestHook (unittest.TestCase):
             'website': 'e', 'license': 'f', 'geometry type': 'g',
             'address count': 'h', 'version': 'i', 'fingerprint': 'j',
             'cache time': 'k', 'processed': 'l', 'process time': 'm',
-            'output': 'n'
+            'output': 'n', 'code version': 'o'
             }
         run_state1 = RunState(_run_state1)
         
@@ -1960,9 +1960,9 @@ class TestHook (unittest.TestCase):
             got_state2 = json.loads(runs[1].state.to_json())
             got_state3 = json.loads(runs[2].state.to_json())
             
-            self.assertEqual(runs[0].code_version, 'i')
-            self.assertEqual(runs[1].code_version, 'i')
-            self.assertEqual(runs[2].code_version, 'i')
+            self.assertEqual(runs[0].code_version, 'o')
+            self.assertEqual(runs[1].code_version, 'o')
+            self.assertEqual(runs[2].code_version, 'o')
         
             for key in ('source', 'cache', 'sample', 'geometry type', 'address count',
                         'version', 'fingerprint', 'cache time', 'processed', 'output',

--- a/setup.py
+++ b/setup.py
@@ -130,9 +130,6 @@ setup(
 
         # http://pythonhosted.org/itsdangerous/
         'itsdangerous == 0.24',
-        
-        # https://aws.amazon.com/cli/
-        'awscli == 1.11.22',
 
         ] + conditional_requirements
 )


### PR DESCRIPTION
In #462, I accidentally confused `code version` with `version` (an outdated cache-related property).