### PR TITLE
Fixing awscli/botocore dependency

### DIFF
--- a/chef/openaddr-prereqs/recipes/default.rb
+++ b/chef/openaddr-prereqs/recipes/default.rb
@@ -9,7 +9,6 @@ package 'python3-dev'
 package 'libpq-dev'
 package 'memcached'
 package 'libffi-dev'
-package 'awscli'
 
 package 'gdal-bin' do
   version '1.11.2+dfsg-1~exp2~trusty'

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(
         
         # https://aws.amazon.com/cli/
         'awscli == 1.11.22',
+        'botocore == 1.4.79',
 
         ] + conditional_requirements
 )

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,9 @@ setup(
 
         # http://pythonhosted.org/itsdangerous/
         'itsdangerous == 0.24',
+        
+        # https://aws.amazon.com/cli/
+        'awscli == 1.11.22',
 
         ] + conditional_requirements
 )


### PR DESCRIPTION
Seeing some weirdness and conflicts between apt-gotten `awscli` and pip-installed `awscli`.