### PR TITLE
Run tests on Travis and CircleCI using python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 python:
   - "2.7"
-  - "3.5"
+  - "3.4"
 cache:
   apt: true
 addons:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 3.5.1
+    version: 3.4.4
   environment:
     BOTO_CONFIG: /tmp/nowhere
     DATABASE_URL: postgres://openaddr:openaddr@localhost/openaddr


### PR DESCRIPTION
Since running the Chef cookbooks on Ubuntu 14.04 install python 3.4, it would be good to run the test suites using that version. 