### PR TITLE
Remove AWS key/secret args from openaddr-index-tiles

### DIFF
--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -98,8 +98,6 @@ LC_ALL=C.UTF-8
   -- \
     openaddr-index-tiles \
     -d "#{database_url}" \
-    -a "#{aws_access_id}" \
-    -s "#{aws_secret_key}" \
     -b "#{aws_s3_bucket}" \
     --sns-arn "#{aws_sns_arn}" \
     --verbose \

--- a/openaddr/ci/tileindex.py
+++ b/openaddr/ci/tileindex.py
@@ -89,11 +89,8 @@ parser.add_argument('-b', '--bucket', default=environ.get('AWS_S3_BUCKET', None)
 parser.add_argument('-d', '--database-url', default=environ.get('DATABASE_URL', None),
                     help='Optional connection string for database. Defaults to value of DATABASE_URL environment variable.')
 
-parser.add_argument('-a', '--access-key', default=environ.get('AWS_ACCESS_KEY_ID', None),
-                    help='Optional AWS access key name. Defaults to value of AWS_ACCESS_KEY_ID environment variable.')
-
-parser.add_argument('-s', '--secret-key', default=environ.get('AWS_SECRET_ACCESS_KEY', None),
-                    help='Optional AWS secret key name. Defaults to value of AWS_SECRET_ACCESS_KEY environment variable.')
+parser.add_argument('-a', '--access-key', help='Deprecated option provided for backwards compatibility.')
+parser.add_argument('-s', '--secret-key', help='Deprecated option provided for backwards compatibility.')
 
 parser.add_argument('--sns-arn', default=environ.get('AWS_SNS_ARN', None),
                     help='Optional AWS Simple Notification Service (SNS) resource. Defaults to value of AWS_SNS_ARN environment variable.')
@@ -111,8 +108,8 @@ def main():
     ''' Single threaded worker to serve the job queue.
     '''
     args = parser.parse_args()
-    setup_logger(args.access_key, args.secret_key, args.sns_arn, log_level=args.loglevel)
-    s3 = S3(args.access_key, args.secret_key, args.bucket)
+    setup_logger(None, None, args.sns_arn, log_level=args.loglevel)
+    s3 = S3(None, None, args.bucket)
     db_args = util.prepare_db_kwargs(args.database_url)
 
     with db_connect(**db_args) as conn:

--- a/openaddr/ci/tileindex.py
+++ b/openaddr/ci/tileindex.py
@@ -117,16 +117,14 @@ def main():
             set = read_latest_set(db, args.owner, args.repository)
             runs = read_completed_runs_to_date(db, set and set.id)
 
-    print([r.source_path for r in runs])
     dir = mkdtemp(prefix='tileindex-')
     
-    print(dir)
     addresses = iterate_runs_points(runs)
     point_blocks = iterate_point_blocks(addresses)
     tiles = populate_tiles(dir, point_blocks)
     
     for tile in tiles.values():
-        print(tile.key, '-', len(tile.results), 'sources')
+        _L.debug('Publishing tile {} with {} sources'.format(tile.key, len(tile.results)))
         tile.publish(s3.bucket)
 
 def lonlat_key(lon, lat):


### PR DESCRIPTION
- [x] Wait to see that `openaddr-collect-extracts` works after #473.

Part of #472.