### PR TITLE
Removed all uses of boto.s3.key.generate_url()

### DIFF
--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -1,7 +1,7 @@
 import logging; _L = logging.getLogger('openaddr.ci')
 
 from ..compat import standard_library, expand_uri
-from .. import jobs, render
+from .. import jobs, render, util
 
 from .objects import (
     add_job, write_job, read_job, complete_set, update_set_renders,
@@ -672,8 +672,6 @@ def _render_and_upload_maps(s3, good_sources, s3_prefix, dirname):
     urls = dict()
     areas = (render.WORLD, 'world'), (render.USA, 'usa'), (render.EUROPE, 'europe')
     
-    # Safe to force_http=False because we set boto.s3.connection.OrdinaryCallingFormat
-    url_kwargs = dict(expires_in=0, query_auth=False, force_http=False)
     key_kwargs = dict(policy='public-read', headers={'Content-Type': 'image/png'})
 
     for (area, area_name) in areas:
@@ -686,7 +684,7 @@ def _render_and_upload_maps(s3, good_sources, s3_prefix, dirname):
             render_key = s3.new_key(join(s3_prefix, png_basename))
             render_key.set_contents_from_string(file.read(), **key_kwargs)
 
-        urls[area_name] = render_key.generate_url(**url_kwargs)
+        urls[area_name] = util.s3_key_url(render_key)
     
     return urls['world'], urls['usa'], urls['europe']
 

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -166,7 +166,7 @@ class CollectorPublisher:
         zip_key = write_to_s3(self.s3.bucket, self.zip.filename, basename(self.zip.filename))
         _L.info(u'Uploaded {} to {}'.format(self.zip.filename, zip_key.name))
 
-        zip_url = zip_key.generate_url(expires_in=0, query_auth=False, force_http=True)
+        zip_url = util.s3_key_url(zip_key)
         length = stat(self.zip.filename).st_size if exists(self.zip.filename) else None
 
         db.execute('''DELETE FROM zips WHERE url = %s''', (zip_url, ))

--- a/openaddr/ci/work.py
+++ b/openaddr/ci/work.py
@@ -15,7 +15,7 @@ def upload_file(s3, keyname, filename):
 
     kwargs = dict(policy='public-read', reduced_redundancy=True)
     key.set_contents_from_filename(filename, **kwargs)
-    url = key.generate_url(expires_in=0, query_auth=False, force_http=True)
+    url = util.s3_key_url(key)
     
     return url, key.md5.decode('ascii')
 

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -1594,18 +1594,21 @@ class FakeS3 (S3):
     def new_key(self, name):
         return FakeKey(name, self)
 
+class FakeBucket:
+    '''
+    '''
+    name = 'fake-bucket'
+
 class FakeKey:
     ''' Just enough S3 to work for tests.
     '''
     md5 = b'0xDEADBEEF'
     
     def __init__(self, name, fake_s3):
+        self.bucket = FakeBucket()
         self.name = name
         self.s3 = fake_s3
     
-    def generate_url(self, **kwargs):
-        return 'http://fake-s3.local' + self.name
-
     def set_contents_from_string(self, string, **kwargs):
         self.s3._write_fake_key(self.name, string)
         

--- a/openaddr/tests/util.py
+++ b/openaddr/tests/util.py
@@ -168,3 +168,22 @@ class TestUtilities (unittest.TestCase):
                 else:
                     self.assertEqual(resp.status_code, 200)
                     self.assertEqual(resp.content, zip_bytes, 'Expected number of bytes')
+        
+    def test_s3_key_url(self):
+        '''
+        '''
+        key1 = Mock()
+        key1.name, key1.bucket.name = 'key1', 'bucket1'
+        self.assertEqual(util.s3_key_url(key1), 'https://s3.amazonaws.com/bucket1/key1')
+
+        key2 = Mock()
+        key2.name, key2.bucket.name = '/key2', 'bucket2'
+        self.assertEqual(util.s3_key_url(key2), 'https://s3.amazonaws.com/bucket2/key2')
+
+        key3 = Mock()
+        key3.name, key3.bucket.name = 'key/3', 'bucket3'
+        self.assertEqual(util.s3_key_url(key3), 'https://s3.amazonaws.com/bucket3/key/3')
+
+        key4 = Mock()
+        key4.name, key4.bucket.name = '/key/4', 'bucket4'
+        self.assertEqual(util.s3_key_url(key4), 'https://s3.amazonaws.com/bucket4/key/4')

--- a/openaddr/tests/util.py
+++ b/openaddr/tests/util.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Test suite. This code could be in a separate file
 
 from shutil import rmtree
@@ -187,3 +188,11 @@ class TestUtilities (unittest.TestCase):
         key4 = Mock()
         key4.name, key4.bucket.name = '/key/4', 'bucket4'
         self.assertEqual(util.s3_key_url(key4), 'https://s3.amazonaws.com/bucket4/key/4')
+
+        key5 = Mock()
+        key5.name, key5.bucket.name = u'kéy5', 'bucket5'
+        self.assertEqual(util.s3_key_url(key5), u'https://s3.amazonaws.com/bucket5/kéy5')
+
+        key6 = Mock()
+        key6.name, key6.bucket.name = u'/kéy6', 'bucket6'
+        self.assertEqual(util.s3_key_url(key6), u'https://s3.amazonaws.com/bucket6/kéy6')

--- a/openaddr/util/__init__.py
+++ b/openaddr/util/__init__.py
@@ -1,6 +1,6 @@
 import logging; _L = logging.getLogger('openaddr.util')
 
-from urllib.parse import urlparse, parse_qsl
+from urllib.parse import urlparse, parse_qsl, urljoin
 from datetime import datetime, timedelta, date
 from os.path import join, basename, splitext, dirname
 from operator import attrgetter
@@ -10,7 +10,7 @@ import ftplib, httmock
 import io, zipfile
 import json
 
-from ..compat import quote
+from .. import compat
 
 def get_version():
     ''' Prevent circular imports.
@@ -60,7 +60,7 @@ def _command_messages(command):
         message_failed = 'Failed {}'.format(command),
         )
     
-    return { k: quote(json.dumps(dict(text=v))) for (k, v) in strings.items() }
+    return { k: compat.quote(json.dumps(dict(text=v))) for (k, v) in strings.items() }
 
 def request_task_instance(ec2, autoscale, instance_type, chef_role, lifespan, command, bucket, slack_url):
     '''
@@ -76,13 +76,13 @@ def request_task_instance(ec2, autoscale, instance_type, chef_role, lifespan, co
     
     with open(join(dirname(__file__), 'templates', 'task-instance-userdata.sh')) as file:
         userdata_kwargs = dict(
-            role = quote(chef_role),
-            command = ' '.join(map(quote, command)),
-            lifespan = quote(str(lifespan)),
-            version = quote(get_version()),
-            log_prefix = quote('logs/{}-{}'.format(yyyymmdd, command[0])),
-            bucket = quote(bucket or 'data.openaddresses.io'),
-            slack_url = quote(slack_url or ''),
+            role = compat.quote(chef_role),
+            command = ' '.join(map(compat.quote, command)),
+            lifespan = compat.quote(str(lifespan)),
+            version = compat.quote(get_version()),
+            log_prefix = compat.quote('logs/{}-{}'.format(yyyymmdd, command[0])),
+            bucket = compat.quote(bucket or 'data.openaddresses.io'),
+            slack_url = compat.quote(slack_url or ''),
             **_command_messages(command[0])
             )
     
@@ -180,4 +180,10 @@ def request_ftp_file(url):
 def s3_key_url(key):
     '''
     '''
-    return 'https://s3.amazonaws.com/{}/{}'.format(key.bucket.name, key.name.lstrip('/'))
+    base = u'https://s3.amazonaws.com'
+    path = join(key.bucket.name, key.name.lstrip('/'))
+    
+    if compat.PY2 and type(path) is not unicode:
+        path = path.decode('utf8')
+    
+    return urljoin(base, path)

--- a/openaddr/util/__init__.py
+++ b/openaddr/util/__init__.py
@@ -176,3 +176,8 @@ def request_ftp_file(url):
 
     # Using mock response because HTTP responses are expected downstream
     return httmock.response(200, file.read(), headers={'Content-Type': 'application/octet-stream'})
+
+def s3_key_url(key):
+    '''
+    '''
+    return 'https://s3.amazonaws.com/{}/{}'.format(key.bucket.name, key.name.lstrip('/'))


### PR DESCRIPTION
When used with IAM Roles, `generate_url()` was appending tokens to generated URLs. Replaced with a dumber string-building function.