### PR TITLE
Add remove prefix and postfix functions

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -882,6 +882,10 @@ def row_transform_and_convert(sd, row):
                 row = row_fxn_prefixed_number(sd, row, k)
             elif c[k]["function"] == "postfixed_street":
                 row = row_fxn_postfixed_street(sd, row, k)
+            elif c[k]["function"] == "remove_prefix":
+                row = row_fxn_remove_prefix(sd, row, k)
+            elif c[k]["function"] == "remove_postfix":
+                row = row_fxn_remove_postfix(sd, row, k)
 
     if "advanced_merge" in c:
         raise ValueError('Found unsupported "advanced_merge" option in conform')
@@ -968,6 +972,24 @@ def row_fxn_postfixed_street(sd, row, key):
     row[attrib_types[key]] = ''.join(match.groups()) if match else '';
 
     return row
+
+def row_fxn_remove_prefix(sd, row, key):
+    "Remove a 'field_to_remove' from the beginning of 'field', if it is a prefix"
+    fxn = sd["conform"][key]
+
+    if row[fxn["field"]].startswith(row[fxn["field_to_remove"]]):
+        row[attrib_types[key]] = row[fxn["field"]][len(row[fxn["field_to_remove"]]):].lstrip(' ')
+    else:
+        row[attrib_types[key]] = row[fxn["field"]]
+
+def row_fxn_remove_postfix(sd, row, key):
+    "Remove a 'field_to_remove' from the end of 'field', if it is a postfix"
+    fxn = sd["conform"][key]
+
+    if row[fxn["field"]].endswith(row[fxn["field_to_remove"]]):
+        row[attrib_types[key]] = row[fxn["field"]][0:len(row[fxn["field_to_remove"]])].rstrip(' ')
+    else:
+        row[attrib_types[key]] = row[fxn["field"]]
 
 def row_fxn_format(sd, row, key):
     "Format multiple fields using a user-specified format string"

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -974,7 +974,7 @@ def row_fxn_postfixed_street(sd, row, key):
     return row
 
 def row_fxn_remove_prefix(sd, row, key):
-    "Remove a 'field_to_remove' from the beginning of 'field', if it is a prefix"
+    "Remove a 'field_to_remove' from the beginning of 'field' if it is a prefix"
     fxn = sd["conform"][key]
 
     if row[fxn["field"]].startswith(row[fxn["field_to_remove"]]):
@@ -982,14 +982,18 @@ def row_fxn_remove_prefix(sd, row, key):
     else:
         row[attrib_types[key]] = row[fxn["field"]]
 
+    return row
+
 def row_fxn_remove_postfix(sd, row, key):
-    "Remove a 'field_to_remove' from the end of 'field', if it is a postfix"
+    "Remove a 'field_to_remove' from the end of 'field' if it is a postfix"
     fxn = sd["conform"][key]
 
     if row[fxn["field"]].endswith(row[fxn["field_to_remove"]]):
-        row[attrib_types[key]] = row[fxn["field"]][0:len(row[fxn["field_to_remove"]])].rstrip(' ')
+        row[attrib_types[key]] = row[fxn["field"]][0:len(row[fxn["field_to_remove"]])*-1].rstrip(' ')
     else:
         row[attrib_types[key]] = row[fxn["field"]]
+
+    return row
 
 def row_fxn_format(sd, row, key):
     "Format multiple fields using a user-specified format string"

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -17,6 +17,7 @@ from ..conform import (
     row_fxn_regexp, row_smash_case, row_round_lat_lon, row_merge,
     row_extract_and_reproject, row_convert_to_out, row_fxn_join, row_fxn_format,
     row_fxn_prefixed_number, row_fxn_postfixed_street,
+    row_fxn_remove_prefix, row_fxn_remove_postfix,
     row_canonicalize_unit_and_number, conform_smash_case, conform_cli,
     csvopen, csvDictReader, convert_regexp_replace, conform_license,
     conform_attribution, conform_sharealike, normalize_ogr_filename_case,
@@ -369,6 +370,37 @@ class TestConformTransforms (unittest.TestCase):
 
         d = row_fxn_prefixed_number(c, d, "number")
         d = row_fxn_postfixed_street(c, d, "street")
+        self.assertEqual(e, d)
+    
+    def test_row_fxn_prefixed_number_and_postfixed_street(self):
+        #"remove_prefix - field_to_remove is a prefix"
+        c = { "conform": {
+            "street": {
+                "function": "remove_prefix",
+                "field": "ADDRESS",
+                "field_to_remove": "PREFIX"
+            }
+        } }
+        d = { "ADDRESS": "123 MAPLE ST", "PREFIX": "123" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:street": " MAPLE ST" })
+
+        d = row_fxn_remove_prefix(c, d, "street")
+        self.assertEqual(e, d)
+
+        "remove_prefix - field_to_remove is not a prefix"
+        c = { "conform": {
+            "street": {
+                "function": "remove_prefix",
+                "field": "ADDRESS",
+                "field_to_remove": "PREFIX"
+            }
+        } }
+        d = { "ADDRESS": "123 MAPLE ST", "PREFIX": "NOT THE PREFIX VALUE" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:street": "123 MAPLE ST" })
+
+        d = row_fxn_remove_prefix(c, d, "street")
         self.assertEqual(e, d)
 
 class TestConformCli (unittest.TestCase):

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -372,8 +372,8 @@ class TestConformTransforms (unittest.TestCase):
         d = row_fxn_postfixed_street(c, d, "street")
         self.assertEqual(e, d)
     
-    def test_row_fxn_prefixed_number_and_postfixed_street(self):
-        #"remove_prefix - field_to_remove is a prefix"
+    def test_row_fxn_remove_prefix(self):
+        "remove_prefix - field_to_remove is a prefix"
         c = { "conform": {
             "street": {
                 "function": "remove_prefix",
@@ -383,7 +383,7 @@ class TestConformTransforms (unittest.TestCase):
         } }
         d = { "ADDRESS": "123 MAPLE ST", "PREFIX": "123" }
         e = copy.deepcopy(d)
-        e.update({ "OA:street": " MAPLE ST" })
+        e.update({ "OA:street": "MAPLE ST" })
 
         d = row_fxn_remove_prefix(c, d, "street")
         self.assertEqual(e, d)
@@ -401,6 +401,37 @@ class TestConformTransforms (unittest.TestCase):
         e.update({ "OA:street": "123 MAPLE ST" })
 
         d = row_fxn_remove_prefix(c, d, "street")
+        self.assertEqual(e, d)
+
+    def test_row_fxn_remove_postfix(self):
+        "remove_postfix - field_to_remove is a postfix"
+        c = { "conform": {
+            "street": {
+                "function": "remove_postfix",
+                "field": "ADDRESS",
+                "field_to_remove": "POSTFIX"
+            }
+        } }
+        d = { "ADDRESS": "MAPLE ST UNIT 5", "POSTFIX": "UNIT 5" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:street": "MAPLE ST" })
+
+        d = row_fxn_remove_postfix(c, d, "street")
+        self.assertEqual(e, d)
+
+        "remove_postfix - field_to_remove is not a postfix"
+        c = { "conform": {
+            "street": {
+                "function": "remove_postfix",
+                "field": "ADDRESS",
+                "field_to_remove": "POSTFIX"
+            }
+        } }
+        d = { "ADDRESS": "123 MAPLE ST", "POSTFIX": "NOT THE POSTFIX VALUE" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:street": "123 MAPLE ST" })
+
+        d = row_fxn_remove_postfix(c, d, "street")
         self.assertEqual(e, d)
 
 class TestConformCli (unittest.TestCase):


### PR DESCRIPTION
Adds conform functions `remove_prefix` and `remove_postfix` that remove another fields' value from the beginning or end of a field.  

Fixes #479 (see for examples)

