### PR TITLE
Move periodic summing-up tasks

### DIFF
--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -638,6 +638,7 @@ def _update_expected_paths(db, expected_paths, the_set):
 def render_index_maps(s3, runs):
     ''' Render index maps and upload them to S3.
     '''
+    _L.info('Rendering index maps')
     dirname = mkdtemp(prefix='index-maps-')
 
     try:

--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -18,7 +18,7 @@ from shutil import rmtree
 from math import ceil, floor, sqrt
 
 from .objects import read_latest_set, read_completed_runs_to_date
-from . import db_connect, db_cursor, setup_logger, render_index_maps, log_function_errors, dashboard_stats
+from . import db_connect, db_cursor, setup_logger, log_function_errors
 from .. import S3, iterate_local_processed_files, util
 from ..conform import OPENADDR_CSV_SCHEMA
 from ..compat import PY2
@@ -66,10 +66,6 @@ def main():
         with db_cursor(conn) as db:
             set = read_latest_set(db, args.owner, args.repository)
             runs = read_completed_runs_to_date(db, set.id)
-            stats = dashboard_stats.make_stats(db)
-
-    render_index_maps(s3, runs)
-    dashboard_stats.upload_stats(s3, stats)
 
     dir = mkdtemp(prefix='collected-')
 

--- a/openaddr/ci/dashboard_stats.py
+++ b/openaddr/ci/dashboard_stats.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging; _L = logging.getLogger('openaddr.ci.dashboard_stats')
 
 "Python script to pull stats about OpenAddresses runs from the database and convert to JSON"
 
@@ -7,6 +8,7 @@ from .. import util
 
 def make_stats(cur):
     "Connect to the database and extract stats data, transforming into a JSON-friendly object"
+    _L.info('Making dashboard stats')
 
     ### JSON output data object
     data = {
@@ -87,6 +89,7 @@ def make_stats(cur):
     return data
 
 def upload_stats(s3, data):
+    _L.info('Uploading dashboard stats')
     stats_key = s3.new_key('machine-stats.json')
     stats_key.set_contents_from_string(json.dumps(data),
         policy='public-read', headers={'Content-Type': 'application/json'})

--- a/openaddr/ci/sum_up.py
+++ b/openaddr/ci/sum_up.py
@@ -1,0 +1,58 @@
+import logging; _L = logging.getLogger('openaddr.ci.collect')
+
+from ..compat import standard_library
+
+from argparse import ArgumentParser
+from urllib.parse import urlparse
+from datetime import date
+from os import environ
+
+from .objects import read_latest_set, read_completed_runs_to_date
+from . import db_connect, db_cursor, setup_logger, render_index_maps, log_function_errors, dashboard_stats
+from .. import S3, util
+
+parser = ArgumentParser(description='Run some source files.')
+
+parser.add_argument('-o', '--owner', default='openaddresses',
+                    help='Github repository owner. Defaults to "openaddresses".')
+
+parser.add_argument('-r', '--repository', default='openaddresses',
+                    help='Github repository name. Defaults to "openaddresses".')
+
+parser.add_argument('-b', '--bucket', default=environ.get('AWS_S3_BUCKET', None),
+                    help='S3 bucket name. Defaults to value of AWS_S3_BUCKET environment variable.')
+
+parser.add_argument('-d', '--database-url', default=environ.get('DATABASE_URL', None),
+                    help='Optional connection string for database. Defaults to value of DATABASE_URL environment variable.')
+
+parser.add_argument('--sns-arn', default=environ.get('AWS_SNS_ARN', None),
+                    help='Optional AWS Simple Notification Service (SNS) resource. Defaults to value of AWS_SNS_ARN environment variable.')
+
+parser.add_argument('-v', '--verbose', help='Turn on verbose logging',
+                    action='store_const', dest='loglevel',
+                    const=logging.DEBUG, default=logging.INFO)
+
+parser.add_argument('-q', '--quiet', help='Turn off most logging',
+                    action='store_const', dest='loglevel',
+                    const=logging.WARNING, default=logging.INFO)
+
+@log_function_errors
+def main():
+    ''' Single threaded worker to serve the job queue.
+    '''
+    args = parser.parse_args()
+    setup_logger(None, None, args.sns_arn, log_level=args.loglevel)
+    s3 = S3(None, None, args.bucket)
+    db_args = util.prepare_db_kwargs(args.database_url)
+
+    with db_connect(**db_args) as conn:
+        with db_cursor(conn) as db:
+            set = read_latest_set(db, args.owner, args.repository)
+            runs = read_completed_runs_to_date(db, set.id)
+            stats = dashboard_stats.make_stats(db)
+
+    render_index_maps(s3, runs)
+    dashboard_stats.upload_stats(s3, stats)
+
+if __name__ == '__main__':
+    exit(main())

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             'openaddr-index-tiles = openaddr.ci.tileindex:main',
             'openaddr-run-ec2-command = openaddr.run_ec2_ami:main',
             'openaddr-update-dotmap = openaddr.dotmap:main',
+            'openaddr-sum-up-data = openaddr.ci.sum_up:main',
         ]
     ),
     package_data = {


### PR DESCRIPTION
Map rendering and machine stats for dashboard should happen more frequently, and outside heavy zipfile collections. This will also be a place for GeoJSON rendered output for #480.