### PR TITLE
Fix GeoJSON render bugs

### DIFF
--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -670,13 +670,6 @@ def _render_and_upload_maps(s3, good_sources, s3_prefix, dirname):
     
     key_kwargs = dict(policy='public-read', headers={'Content-Type': 'image/png'})
 
-    geojson_filename = join(dirname, 'render-world.geojson')
-    render.render_geojson(dirname, good_sources, geojson_filename, render.WORLD)
-
-    with open(geojson_filename, 'rb') as file:
-        render_geojson_key = s3.new_key(join(s3_prefix, 'render-world.geojson'))
-        render_geojson_key.set_contents_from_string(file.read(), **key_kwargs)
-
     for (area, area_name) in areas:
         png_basename = 'render-{}.png'.format(area_name)
         png_filename = join(dirname, png_basename)
@@ -687,6 +680,15 @@ def _render_and_upload_maps(s3, good_sources, s3_prefix, dirname):
             render_png_key.set_contents_from_string(file.read(), **key_kwargs)
 
         urls[area_name] = util.s3_key_url(render_png_key)
+
+    key_kwargs.update(headers={'Content-Type': 'application/vnd.geo+json'})
+
+    geojson_filename = join(dirname, 'render-world.geojson')
+    render.render_geojson(dirname, good_sources, geojson_filename, render.WORLD)
+
+    with open(geojson_filename, 'rb') as file:
+        render_geojson_key = s3.new_key(join(s3_prefix, 'render-world.geojson'))
+        render_geojson_key.set_contents_from_string(file.read(), **key_kwargs)
     
     return urls['world'], urls['usa'], urls['europe']
 

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -698,18 +698,18 @@ def _prepare_render_sources(runs, dirname):
     good_sources = set()
     
     for run in runs:
-        filename = os.path.relpath(run.source_path, 'sources')
-        dirpath = os.path.dirname(join(dirname, filename))
+        filepath = join(dirname, run.source_path)
+        dirpath = os.path.dirname(filepath)
         
         if not os.path.exists(dirpath):
             os.makedirs(dirpath)
         
-        with open(join(dirname, filename), 'w+b') as file:
+        with open(filepath, 'w+b') as file:
             content = b64decode(run.source_data)
             file.write(content)
         
         if run.status is True:
-            good_sources.add(filename)
+            good_sources.add(run.source_path)
     
     return good_sources
 

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -698,7 +698,12 @@ def _prepare_render_sources(runs, dirname):
     good_sources = set()
     
     for run in runs:
-        filename = '{source_id}.json'.format(**run.__dict__)
+        filename = os.path.relpath(run.source_path, 'sources')
+        dirpath = os.path.dirname(join(dirname, filename))
+        
+        if not os.path.exists(dirpath):
+            os.makedirs(dirpath)
+        
         with open(join(dirname, filename), 'w+b') as file:
             content = b64decode(run.source_data)
             file.write(content)

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -670,18 +670,17 @@ def _render_and_upload_maps(s3, good_sources, s3_prefix, dirname):
     
     key_kwargs = dict(policy='public-read', headers={'Content-Type': 'image/png'})
 
-    for (area, area_name) in areas:
-        geojson_basename = 'render-{}.geojson'.format(area_name)
-        geojson_filename = join(dirname, geojson_basename)
-        render.render_geojson(dirname, good_sources, geojson_filename, area)
+    geojson_filename = join(dirname, 'render-world.geojson')
+    render.render_geojson(dirname, good_sources, geojson_filename, render.WORLD)
 
+    with open(geojson_filename, 'rb') as file:
+        render_geojson_key = s3.new_key(join(s3_prefix, 'render-world.geojson'))
+        render_geojson_key.set_contents_from_string(file.read(), **key_kwargs)
+
+    for (area, area_name) in areas:
         png_basename = 'render-{}.png'.format(area_name)
         png_filename = join(dirname, png_basename)
         render.render_png(dirname, good_sources, 960, 2, png_filename, area)
-
-        with open(geojson_filename, 'rb') as file:
-            render_geojson_key = s3.new_key(join(s3_prefix, geojson_basename))
-            render_geojson_key.set_contents_from_string(file.read(), **key_kwargs)
 
         with open(png_filename, 'rb') as file:
             render_png_key = s3.new_key(join(s3_prefix, png_basename))

--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -58,6 +58,8 @@ class Run:
         '''
         '''
         assert hasattr(state, 'to_json'), 'Run state should have to_json() method'
+        assert source_path.startswith('sources/'), '{} should start with "sources"'.format(repr(source_path))
+        assert source_path.endswith('.json'), '{} should end with ".json"'.format(repr(source_path))
         
         self.id = id
         self.source_path = source_path

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -392,8 +392,8 @@ class TestObjects (unittest.TestCase):
     def test_read_run_yes(self):
         ''' Check behavior of objects.read_run()
         '''
-        self.db.fetchone.return_value = (123, '', '', b'', None, {}, True, None,
-                                         'x.y.z', '', None, None, '', False)
+        self.db.fetchone.return_value = (123, 'sources/whatever.json', '', b'',
+            None, {}, True, None, 'x.y.z', '', None, None, '', False)
         
         run = read_run(self.db, 123)
         self.assertEqual(run.id, 123)
@@ -409,8 +409,8 @@ class TestObjects (unittest.TestCase):
     def test_read_run_yes_without_source_data(self):
         ''' Check behavior of objects.read_run()
         '''
-        self.db.fetchone.return_value = (123, '', '', None, None, {}, True, None,
-                                         'x.y.z', '', None, None, '', False)
+        self.db.fetchone.return_value = (123, 'sources/whatever.json', '', None,
+            None, {}, True, None, 'x.y.z', '', None, None, '', False)
         
         run = read_run(self.db, 123)
         self.assertEqual(run.id, 123)
@@ -524,12 +524,12 @@ class TestObjects (unittest.TestCase):
     def test_new_read_completed_set_runs(self):
         ''' Check behavior of objects.new_read_completed_set_runs()
         '''
-        self.db.fetchall.return_value = (('abc', 'pl', 'jkl', b'', None, {}, True,
-                                          None, '', '', 'mno', 123, 'abc', False), )
+        self.db.fetchall.return_value = (('abc', 'sources/whatever.json', 'jkl',
+            b'', None, {}, True, None, '', '', 'mno', 123, 'abc', False), )
         
         runs = new_read_completed_set_runs(self.db, 123)
         self.assertEqual(runs[0].id, 'abc')
-        self.assertEqual(runs[0].source_path, 'pl')
+        self.assertEqual(runs[0].source_path, 'sources/whatever.json')
         self.assertEqual(runs[0].source_data, b'')
         self.assertEqual(runs[0].status, True)
         self.assertFalse(runs[0].is_merged)
@@ -544,17 +544,19 @@ class TestObjects (unittest.TestCase):
     def test_read_completed_source_runs(self):
         ''' Check behavior of objects.read_completed_source_runs()
         '''
-        self.db.fetchall.return_value = (('abc', 'pl', 'jkl', b'', None, {}, True,
-                                          'def', '', '', 'mno', 123, 'abc', False),
-                                         ('def', 'pl', 'jkl', b'', None, {}, True,
-                                          None, '', '', 'mno', 123, 'abc', False),
-                                         ('ghi', 'pl', 'jkl', b'', None, {}, True,
-                                          None, '', '', 'mno', 123, 'abc', False), )
+        self.db.fetchall.return_value = (
+            ('abc', 'sources/whatever.json', 'jkl', b'', None, {}, True,
+             'def', '', '', 'mno', 123, 'abc', False),
+            ('def', 'sources/whatever.json', 'jkl', b'', None, {}, True,
+             None, '', '', 'mno', 123, 'abc', False),
+            ('ghi', 'sources/whatever.json', 'jkl', b'', None, {}, True,
+             None, '', '', 'mno', 123, 'abc', False),
+            )
         
-        runs = read_completed_source_runs(self.db, 'pl')
+        runs = read_completed_source_runs(self.db, 'sources/whatever.json')
         self.assertEqual(len(runs), 2)
         self.assertEqual(runs[0].id, 'abc')
-        self.assertEqual(runs[0].source_path, 'pl')
+        self.assertEqual(runs[0].source_path, 'sources/whatever.json')
         self.assertEqual(runs[0].source_data, b'')
         self.assertEqual(runs[0].status, True)
         self.assertFalse(runs[0].is_merged)
@@ -567,7 +569,7 @@ class TestObjects (unittest.TestCase):
                   WHERE source_path = %s AND status IS NOT NULL
                     AND (is_merged or is_merged is null)
                   ORDER BY id DESC''',
-                  ('pl', ))
+                  ('sources/whatever.json', ))
     
     def test_read_completed_runs_to_date_missing_set(self):
         ''' Check when read_completed_runs_to_date() called with missing set.
@@ -1901,8 +1903,8 @@ class TestHook (unittest.TestCase):
             None, None)
 
         run_state = RunState({'preview': 'http://s3.amazonaws.com/data-testpreviews.openaddresses.io/runs/10/preview.png'})
-        read_run.return_value = Run(-2, None, None, None, None, run_state, None,
-                                    None, None, None, None, None, None, None)
+        read_run.return_value = Run(-2, 'sources/whatever.json', None, None,
+            None, run_state, None, None, None, None, None, None, None, None)
 
         
         with HTTMock(self.response_content):
@@ -1918,8 +1920,8 @@ class TestHook (unittest.TestCase):
             None, None, None)
 
         run_state = RunState({'preview': 'http://s3.amazonaws.com/data-testpreviews.openaddresses.io/runs/10/preview.png'})
-        read_run.return_value = Run(-2, None, None, None, None, run_state, None,
-                                    None, None, None, None, None, None, None)
+        read_run.return_value = Run(-2, 'sources/whatever.json', None, None,
+            None, run_state, None, None, None, None, None, None, None, None)
 
         
         with HTTMock(self.response_content):
@@ -1936,8 +1938,8 @@ class TestHook (unittest.TestCase):
             None, None)
 
         run_state = RunState({'preview': 'http://s3.amazonaws.com/data-testpreviews.openaddresses.io/runs/10/preview.png'})
-        read_run.return_value = Run(-2, None, None, None, None, run_state, None,
-                                    None, None, None, None, None, None, None)
+        read_run.return_value = Run(-2, 'sources/whatever.json', None, None,
+            None, run_state, None, None, None, None, None, None, None, None)
 
         
         with HTTMock(self.response_content):

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -3357,8 +3357,6 @@ class TestBatch (unittest.TestCase):
             self.assertEqual(get('http://fake-s3.local/render-usa.png').status_code, 200)
             self.assertEqual(get('http://fake-s3.local/render-europe.png').status_code, 200)
             self.assertEqual(get('http://fake-s3.local/render-world.png').status_code, 200)
-            self.assertEqual(get('http://fake-s3.local/render-usa.geojson').status_code, 200)
-            self.assertEqual(get('http://fake-s3.local/render-europe.geojson').status_code, 200)
             self.assertEqual(get('http://fake-s3.local/render-world.geojson').status_code, 200)
 
 class TestQueue (unittest.TestCase):

--- a/openaddr/tests/summarize.py
+++ b/openaddr/tests/summarize.py
@@ -59,7 +59,7 @@ class TestSummarizeFunctions (unittest.TestCase):
         '''
         '''
         _ = None
-        make_run = lambda state: Run(_, _, _, b'', _, RunState(state), _, _, _, _, _, _, _, _)
+        make_run = lambda state: Run(_, 'sources/whatever.json', _, b'', _, RunState(state), _, _, _, _, _, _, _, _)
         
         runs = [
             make_run({}),


### PR DESCRIPTION
- Added `source paths` and `source count` fields to GeoJSON output
- Started using actual source paths instead of blob hashes
- Fixed GeoJSON mime-type in S3
- Introduced rules for Run.source_path values
- Stopped outputting unneeded U.S. and Europe GeoJSON

Part of #480.