### PR TITLE
Add South America collection

### DIFF
--- a/openaddr/ci/collect.py
+++ b/openaddr/ci/collect.py
@@ -73,7 +73,8 @@ def main():
     area_tests = {
         'global': (lambda result: True), 'us_northeast': is_us_northeast,
         'us_midwest': is_us_midwest, 'us_south': is_us_south,
-        'us_west': is_us_west, 'europe': is_europe, 'asia': is_asia
+        'us_west': is_us_west, 'europe': is_europe, 'asia': is_asia,
+        'south_america': is_south_america
         }
     sa_tests = {
         '': (lambda result: result.run_state.share_alike != 'true'),
@@ -391,6 +392,13 @@ def is_asia(result):
                 'as', 'au', 'nz', 'ck', 'fj', 'pf', 'gu', 'ki', 'mp', 'mh',
                 'fm', 'um', 'nr', 'nc', 'nz', 'nu', 'nf', 'pw', 'pg', 'mp',
                 'sb', 'tk', 'to', 'tv', 'vu', 'um', 'wf', 'ws', 'is'):
+        if _is_country(iso, result):
+            return True
+
+    return False
+
+def is_south_america(result):
+    for iso in ('ar', 'bo', 'br', 'cl', 'co', 'ec', 'gf', 'gy', 'pe', 'py', 'sr', 'uy', 've'):
         if _is_country(iso, result):
             return True
 

--- a/openaddr/ci/schema.pgsql
+++ b/openaddr/ci/schema.pgsql
@@ -65,7 +65,8 @@ CREATE TABLE runs
     is_merged           BOOLEAN
 );
 
-CREATE TYPE zip_collection AS ENUM ('global', 'us_northeast', 'us_midwest', 'us_south', 'us_west', 'europe', 'asia');
+CREATE TYPE zip_collection AS ENUM ('global', 'us_northeast', 'us_midwest',
+    'us_south', 'us_west', 'europe', 'asia', 'south_america');
 CREATE TYPE zip_licensing AS ENUM ('', 'sa');
 
 CREATE TABLE zips

--- a/openaddr/ci/templates/index.html
+++ b/openaddr/ci/templates/index.html
@@ -137,6 +137,12 @@
         <td>{% set key = ('asia', '') %}{% include "index-zip.html" %}</td>
         <td>{% set key = ('asia', 'sa') %}{% include "index-zip.html" %}</td>
     </tr>
+    <tr>
+        <td>South America</td>
+        <td><a href="https://www.countries-ofthe-world.com/countries-of-south-america.html">List of countries in South America</a></td>
+        <td>{% set key = ('south_america', '') %}{% include "index-zip.html" %}</td>
+        <td>{% set key = ('south_america', 'sa') %}{% include "index-zip.html" %}</td>
+    </tr>
 </table>
 <p>
     <button onclick="choosemap('https://s3.amazonaws.com/{{ s3_bucket }}/render-world.png')">Show World</button>

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -45,8 +45,8 @@ from ..ci.objects import (
 
 from ..ci.collect import (
     is_us_northeast, is_us_midwest, is_us_south, is_us_west, is_europe, is_asia,
-    add_source_to_zipfile, CollectorPublisher, prepare_collections,
-    add_csv_to_zipfile, write_to_s3, MULTIPART_CHUNK_SIZE
+    is_south_america, add_source_to_zipfile, CollectorPublisher,
+    prepare_collections, add_csv_to_zipfile, write_to_s3, MULTIPART_CHUNK_SIZE
     )
 
 from ..ci.tileindex import (
@@ -3605,7 +3605,7 @@ class TestCollect (unittest.TestCase):
         '''
         '''
         _ = None
-        test_funcs = is_us_northeast, is_us_midwest, is_us_south, is_us_west, is_europe, is_asia
+        test_funcs = is_us_northeast, is_us_midwest, is_us_south, is_us_west, is_europe, is_asia, is_south_america
         
         for abbr in ('ct', 'me', 'ma', 'nh', 'ri', 'vt', 'nj', 'ny', 'pa'):
             for source_base in ('us/{}'.format(abbr), 'us/{}.---'.format(abbr), 'us/{}/---'.format(abbr)):
@@ -3671,6 +3671,15 @@ class TestCollect (unittest.TestCase):
             
                 for test_func in test_funcs:
                     if test_func is not is_asia:
+                        self.assertFalse(test_func(result), '{}("{}") should be false'.format(test_func.__name__, source_base))
+
+        for iso in ('ar', 'bo', 'br', 'cl', 'co', 'ec', 'gf', 'gy', 'pe', 'py', 'sr', 'uy', 've'):
+            for source_base in (iso, '{}.---'.format(iso), '{}/---'.format(iso)):
+                result = LocalProcessedResult(source_base, None, RunState(None), None)
+                self.assertTrue(is_south_america(result), 'is_south_america("{}") should be true'.format(source_base))
+            
+                for test_func in test_funcs:
+                    if test_func is not is_south_america:
                         self.assertFalse(test_func(result), '{}("{}") should be false'.format(test_func.__name__, source_base))
 
     def test_add_source_to_zipfile(self):


### PR DESCRIPTION
- [x] Add code to generate South America collection
- [x] Add “south_america” to `zip_collection` type in Postgres.

Closes #519.