### PR TITLE
When processing GML, allow .xml file ending

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -210,7 +210,7 @@ class ZipDecompressTask(DecompressionTask):
 class ExcerptDataTask(object):
     ''' Task for sampling three rows of data from datasource.
     '''
-    known_types = ('.shp', '.json', '.geojson', '.csv', '.kml', '.gml', '.gdb')
+    known_types = ('.shp', '.json', '.geojson', '.csv', '.kml', '.gml', '.xml', '.gdb')
 
     def excerpt(self, source_paths, workdir, conform):
         '''
@@ -514,9 +514,9 @@ def find_source_path(source_definition, source_paths):
         else:
             for fn in source_paths:
                 _, ext = os.path.splitext(fn)
-                if ext == ".gml":
+                if ext in (".gml", ".xml"):
                     return fn
-            _L.warning("Could not find a .gml file")
+            _L.warning("Could not find a .gml or .xml file")
             return None
     else:
         _L.warning("Unknown source conform type %s", conform["type"])


### PR DESCRIPTION
In https://github.com/openaddresses/openaddresses/pull/1898 we're trying to download a GML dump from a WFS server. The server responds with a `Content-Type: text/xml` header, so the cacher saves the file with a `.xml` suffix, but the subsequent steps only look for `.gml` when processing a source with `type: xml` set.

This change makes it so we look for `.xml` AND `.gml`.
