### PR TITLE
Extended run time for extract collections

### DIFF
--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -68,6 +68,7 @@ LC_ALL=C.UTF-8
 # Archive collection, every other day at 11am UTC (4am PDT)
 0 11	*/2 * *	#{username}	\
   openaddr-run-ec2-command \
+  --hours 18 \
   -b "#{aws_s3_bucket}" \
   --sns-arn "#{aws_sns_arn}" \
   --slack-url "#{slack_url}" \


### PR DESCRIPTION
Timed out at 12 hours, so extended this limit to 18 hours.