### PR TITLE
Reduced sleep times in enqueue and dequeue loops

### DIFF
--- a/openaddr/ci/enqueue.py
+++ b/openaddr/ci/enqueue.py
@@ -90,7 +90,7 @@ def main():
                 except Exception as e:
                     _L.error('Problem during autoscale', exc_info=True)
                 if expected_count:
-                    sleep(5)
+                    sleep(3)
         
         with task_Q as db:
             _L.debug('Rendering that shit')

--- a/openaddr/ci/run_dequeue.py
+++ b/openaddr/ci/run_dequeue.py
@@ -58,7 +58,7 @@ def main():
             raise
         except:
             _L.error('Error in dequeue main()', exc_info=True)
-            sleep(5)
+            sleep(3)
 
 if __name__ == '__main__':
     exit(main())


### PR DESCRIPTION
Should have the effect of speeding up quick jobs near the end of a batch set.