### PR TITLE
Fix dotmaps temp space

### DIFF
--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -111,7 +111,7 @@ LC_ALL=C.UTF-8
   openaddr-run-ec2-command \
   --role dotmap \
   --hours 16 \
-  --instance-type r3.large \
+  --instance-type r3.xlarge \
   -b "#{aws_s3_bucket}" \
   --sns-arn "#{aws_sns_arn}" \
   --verbose \

--- a/openaddr/util/__init__.py
+++ b/openaddr/util/__init__.py
@@ -64,9 +64,9 @@ def request_task_instance(ec2, autoscale, instance_type, chef_role, lifespan, co
     (group, ) = autoscale.get_all_groups([group_name])
     (config, ) = autoscale.get_all_launch_configurations(names=[group.launch_config_name])
     (image, ) = ec2.get_all_images(image_ids=[config.image_id])
-    keypair = ec2.get_all_key_pairs()[0]
+    keypair = [kp for kp in ec2.get_all_key_pairs() if kp.name.startswith('oa-')][0]
 
-    yyyymmdd = datetime.now().strftime('%Y-%m-%d')
+    yyyymmdd = datetime.utcnow().strftime('%Y-%m-%d-%H-%M')
     
     with open(join(dirname(__file__), 'templates', 'task-instance-userdata.sh')) as file:
         userdata_kwargs = dict(

--- a/openaddr/util/templates/task-instance-userdata.sh
+++ b/openaddr/util/templates/task-instance-userdata.sh
@@ -32,6 +32,12 @@ function shutdown_with_log
 # Bail out when the timer reaches zero
 ( sleep {lifespan}; shutdown_with_log 2 ) &
 
+# Prepare temp volume, if applicable
+if [ -b /dev/xvdb ]; then
+    mkfs.ext3 /dev/xvdb
+    mount /dev/xvdb /tmp
+fi
+
 # (Re)install machine.
 cd /home/ubuntu/machine
 sudo -u ubuntu git fetch origin {version}


### PR DESCRIPTION
Use ephemeral instance storage to increase the tmp volume available to Tippecanoe. Another approach here would increase the size of the root volume, if this doesn't work.

- [x] Wait to see if new 64GB volume configuration helps

Closes #542.