### PR TITLE
Fix source test case-smashing

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -1290,9 +1290,10 @@ def conform_sharealike(license):
         if share_alike.lower() in ('y', 'yes', 't', 'true'):
             return True
 
-def check_source_tests(source):
+def check_source_tests(raw_source):
     ''' Return boolean status and a message if any tests failed.
     '''
+    source = conform_smash_case(raw_source)
     source_test = source.get('test', {})
     tests_enabled = source_test.get('enabled', True)
     acceptance_tests = source_test.get('acceptance-tests')

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -1293,7 +1293,13 @@ def conform_sharealike(license):
 def check_source_tests(raw_source):
     ''' Return boolean status and a message if any tests failed.
     '''
-    source = conform_smash_case(raw_source)
+    try:
+        # Convert all field names in the conform spec to lower case
+        source = conform_smash_case(raw_source)
+    except:
+        # There may be problems in the source spec - ignore them for now.
+        source = raw_source
+
     source_test = source.get('test', {})
     tests_enabled = source_test.get('enabled', True)
     acceptance_tests = source_test.get('acceptance-tests')

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -109,6 +109,9 @@ class TestOA (unittest.TestCase):
         if (host, path) == ('www.dropbox.com', '/s/fhopgbg4vkyoobr/czech_addresses_wgs84_12092016_MASTER.zip'):
             return response(404, 'Nobody here but us coats')
         
+        if (host, path) == ('s3.amazonaws.com', '/data.openaddresses.io/cache/uploads/migurski/d5add2/oregon_state_addresses.zip'):
+            return response(404, 'Nobody here but us coats')
+        
         if (host, path) == ('data.openoakland.org', '/sites/default/files/OakParcelsGeo2013_0.zip'):
             local_path = join(data_dirname, 'us-ca-oakland-excerpt.zip')
         
@@ -1516,6 +1519,25 @@ class TestOA (unittest.TestCase):
             state = RunState(dict(zip(*json.load(file))))
         
         self.assertIs(state.tests_passed, False)
+        self.assertIsNone(state.sample)
+        self.assertIsNone(state.processed)
+        self.assertEqual(state.source_problem, 'An acceptance test failed')
+
+    def test_single_or_curry(self):
+        ''' Test complete process_one.process on data.
+        '''
+        source = join(self.src_dir, 'us-or-curry.json')
+
+        with HTTMock(self.response_content):
+            state_path = process_one.process(source, self.testdir, False)
+
+        with open(state_path) as file:
+            state = RunState(dict(zip(*json.load(file))))
+        
+        with open(join(dirname(state_path), state.output)) as file:
+            print(file.read())
+        
+        self.assertTrue(state.tests_passed)
         self.assertIsNone(state.sample)
         self.assertIsNone(state.processed)
         self.assertEqual(state.source_problem, 'An acceptance test failed')

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -1534,13 +1534,10 @@ class TestOA (unittest.TestCase):
         with open(state_path) as file:
             state = RunState(dict(zip(*json.load(file))))
         
-        with open(join(dirname(state_path), state.output)) as file:
-            print(file.read())
-        
         self.assertTrue(state.tests_passed)
         self.assertIsNone(state.sample)
         self.assertIsNone(state.processed)
-        self.assertEqual(state.source_problem, 'An acceptance test failed')
+        self.assertEqual(state.source_problem, 'Could not download source data')
 
     def test_single_lake_man_gdb(self):
         ''' Test complete process_one.process on data.

--- a/openaddr/tests/sources/us-or-curry.json
+++ b/openaddr/tests/sources/us-or-curry.json
@@ -1,0 +1,69 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "41015",
+            "name": "Curry County",
+            "state": "Oregon"
+        },
+        "country": "us",
+        "state": "or",
+        "county": "Curry"
+    },
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/migurski/d5add2/oregon_state_addresses.zip",
+    "type": "http",
+    "compression": "zip",
+    "conform": {
+        "type": "gdb",
+        "file": "Delivery/addresses_oregon.gdb",
+        "layer": "Curry",
+        "number": {
+            "function": "prefixed_number",
+            "field": "SITUS_ONE"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SITUS_ONE",
+            "pattern": "^\\d+\\s+([^,]+)"
+        },
+        "unit": {
+            "function": "regexp",
+            "field": "SITUS_ONE",
+            "pattern": "(?:,\\s+(.+))$"
+        },
+        "city": {
+            "function": "regexp",
+            "field": "SITUS_TWO",
+            "pattern": "^(.+?)(?:,|\\d+)"
+        },
+        "region": {
+            "function": "regexp",
+            "field": "SITUS_TWO",
+            "pattern": "\\b(OR)\\b"
+        },
+        "postcode": {
+            "function": "regexp",
+            "field": "SITUS_TWO",
+            "pattern": "\\b(\\d+)$"
+        }
+    },
+    "test": {
+        "enabled": true,
+        "description": "these are the tests that exercise valid inputs for Curry County",
+        "acceptance-tests": [
+            {
+                "description": "address with no unit",
+                "inputs": {
+                    "SITUS_ONE": "98171 TUTTLE LN",
+                    "SITUS_TWO": "BROOKINGS, OR 97415"
+                },
+                "expected": {
+                    "street": "TUTTLE LN",
+                    "unit": "",
+                    "city": "BROOKINGS",
+                    "region": "OR",
+                    "postcode": "97415"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Curry, OR tests were incorrectly failing in https://github.com/openaddresses/openaddresses/pull/2562. This PR adds use of `conform_smash_case()` where it was missing.