### PR TITLE
Added link to slippy map previews

### DIFF
--- a/chef/webhooks/recipes/default.rb
+++ b/chef/webhooks/recipes/default.rb
@@ -10,6 +10,7 @@ memcache_server = local['memcache_server']
 aws_s3_bucket = local['aws_s3_bucket']
 aws_sns_arn = local['aws_sns_arn']
 aws_cloudwatch_ns = local['aws_cloudwatch_ns']
+dotmaps_base_url = local['dotmaps_base_url']
 webhook_secrets = local['webhook_secrets']
 
 gag_github_status = local['gag_github_status']
@@ -41,6 +42,7 @@ REJECT_NEW_JOBS=#{reject_new_jobs}
 AWS_SNS_ARN=#{aws_sns_arn}
 AWS_CLOUDWATCH_NS=#{aws_cloudwatch_ns}
 AWS_S3_BUCKET=#{aws_s3_bucket}
+DOTMAPS_BASE_URL=#{dotmaps_base_url}
 WEBHOOK_SECRETS=#{webhook_secrets}
 LC_ALL=C.UTF-8
 CONF

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -51,6 +51,7 @@ def load_config():
                 GITHUB_OAUTH_CALLBACK=os.environ.get('GITHUB_CALLBACK'),
                 MEMCACHE_SERVER=os.environ.get('MEMCACHE_SERVER'),
                 DATABASE_URL=os.environ['DATABASE_URL'],
+                DOTMAPS_BASE_URL=os.environ.get('DOTMAPS_BASE_URL'),
                 AWS_S3_BUCKET=os.environ.get('AWS_S3_BUCKET', 'data.openaddresses.io'),
                 WEBHOOK_SECRETS=webhook_secrets)
 

--- a/openaddr/ci/templates/job.html
+++ b/openaddr/ci/templates/job.html
@@ -20,7 +20,7 @@
 <table>
 {% for (sha, path) in job.task_files.items() %}
 
-    {% set file_result = job.file_results[path] %}
+    {% set file_runstate = job.file_runstates[path] %}
     {% set file_state = job.file_states[path] %}
 
     <tr>
@@ -35,23 +35,23 @@
         {{ path }}
         </td>
         <td>
-        {% if file_result and file_result.output and file_result.output['output'] %}
-            <a href="{{ file_result.output['output'] }}">log</a>
+        {% if file_runstate and file_runstate.output %}
+            <a href="{{ file_runstate.output }}">log</a>
         {% endif %}
         </td>
         <td>
-        {% if file_result and file_result.output and file_result.output['sample'] %}
-            <a href="{{ file_result.output['sample'] }}">sample</a>
+        {% if file_runstate and file_runstate.sample %}
+            <a href="{{ file_runstate.sample }}">sample</a>
         {% endif %}
         </td>
         <td>
-        {% if file_result and file_result.output and file_result.output['processed'] %}
-            <a href="{{ file_result.output['processed'] }}">data</a>
+        {% if file_runstate and file_runstate.processed %}
+            <a href="{{ file_runstate.processed }}">data</a>
         {% endif %}
         </td>
         <td>
-        {% if file_result and file_result.output and file_result.output['preview'] %}
-            <a href="{{ file_result.output['preview'] }}">preview</a>
+        {% if file_runstate and file_runstate.preview %}
+            <a href="{{ file_runstate.preview }}">preview</a>
         {% endif %}
         </td>
     </tr>

--- a/openaddr/ci/templates/job.html
+++ b/openaddr/ci/templates/job.html
@@ -51,9 +51,16 @@
         </td>
         <td>
         {% if file_runstate and file_runstate.preview %}
-            <a href="{{ file_runstate.preview }}">preview</a>
+            <a href="{{ file_runstate.preview }}">image preview</a>
         {% endif %}
         </td>
+        {% if dotmaps_base_url %}
+            <td>
+            {% if file_runstate and file_runstate.slippymap %}
+                <a href="{{ file_runstate.slippymap|slippymap_preview_url }}">slippy map preview</a>
+            {% endif %}
+            </td>
+        {% endif %}
     </tr>
 
 {% endfor %}

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -23,7 +23,7 @@ from . import (
     )
 
 from .objects import (
-    read_job, read_jobs, read_sets, read_set, read_latest_set,
+    read_job, read_jobs, read_sets, read_set, read_latest_set, RunState,
     read_run, new_read_completed_set_runs, read_completed_runs_to_date,
     load_collection_zips_dict, read_latest_run, read_completed_source_runs
     )
@@ -179,8 +179,13 @@ def app_get_job(job_id):
 
     ordered_files = OrderedDict(sorted(file_tuples, key=key_func))
     
+    file_runstates = {file_path: RunState(file_result['output'])
+                      for (file_path, file_result) in job.file_results.items()
+                      if (file_result and 'output' in file_result)}
+
     job = dict(status=job.status, task_files=ordered_files, file_states=job.states,
-               file_results=job.file_results, github_status_url=job.github_status_url)
+               file_results=job.file_results, github_status_url=job.github_status_url,
+               file_runstates=file_runstates)
     
     return render_template('job.html', job=job)
 


### PR DESCRIPTION
The experimental slippy map tile server now has a name at http://dotmaps.openaddresses.io thanks to @iandees. Closes #565.