### PR TITLE
Bump to pyesridump 1.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         'boto3 == 1.4.4',
 
         # https://github.com/openaddresses/pyesridump
-        'esridump == 1.4.1',
+        'esridump == 1.6.0',
 
         # Used in openaddr.parcels
         'Shapely == 1.5.17',


### PR DESCRIPTION
Use the more recent, faster version of pyesridump.