### PR TITLE
Use RunState objects

### DIFF
--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -968,7 +968,7 @@ def pop_task_from_taskqueue(s3, task_queue, done_queue, due_queue, heartbeat_que
         # Re-use result from the previous run.
         run_id, state, status = previous_run
         message = work.MAGIC_OK_MESSAGE if status else 'Re-using failed previous run'
-        result = dict(message=message, reused_run=run_id, output=state)
+        result = dict(message=message, reused_run=run_id, state=state)
 
     else:
         # Run the task.

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -1012,7 +1012,7 @@ def pop_task_from_donequeue(queue, github_auth):
         _L.info(u'Got file {} from done queue'.format(donedata.name))
         results = donedata.result
         message = results['message']
-        run_state = RunState(results.get('output', None))
+        run_state = RunState(results.get('state', None) or results.get('output', None)) # TODO: stop looking for old "output" here.
         content_b64 = donedata.content_b64
         commit_sha = donedata.commit_sha
         worker_id = donedata.worker_id

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -4,8 +4,8 @@ from .. import jobs, render, util
 
 from .objects import (
     add_job, write_job, read_job, complete_set, update_set_renders,
-    set_run, copy_run, read_completed_set_runs, RunState,
-    get_completed_run, new_read_completed_set_runs
+    set_run, read_completed_set_runs, RunState, get_completed_run,
+    new_read_completed_set_runs
     )
 
 from . import objects, work, queuedata
@@ -952,7 +952,7 @@ def pop_task_from_taskqueue(s3, task_queue, done_queue, due_queue, heartbeat_que
             # Make a copy of the previous run.
             previous_run_id, _, _ = previous_run
             copy_args = (passed_on_kwargs[k] for k in ('job_id', 'commit_sha', 'set_id'))
-            passed_on_kwargs['run_id'] = copy_run(db, previous_run_id, *copy_args)
+            passed_on_kwargs['run_id'] = objects.copy_run(db, previous_run_id, *copy_args)
             
             # Don't send a due task, since we will not be doing any actual work.
         

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -4,8 +4,8 @@ from .. import jobs, render, util
 
 from .objects import (
     add_job, write_job, read_job, complete_set, update_set_renders,
-    add_run, set_run, copy_run, read_completed_set_runs, RunState,
-    get_completed_file_run, get_completed_run, new_read_completed_set_runs
+    set_run, copy_run, read_completed_set_runs, RunState,
+    get_completed_run, new_read_completed_set_runs
     )
 
 from . import objects, work, queuedata
@@ -946,7 +946,7 @@ def pop_task_from_taskqueue(s3, task_queue, done_queue, due_queue, heartbeat_que
             previous_run = None
         else:
             interval = '{} seconds'.format(RUN_REUSE_TIMEOUT.seconds + RUN_REUSE_TIMEOUT.days * 86400)
-            previous_run = get_completed_file_run(db, taskdata.file_id, interval)
+            previous_run = objects.get_completed_file_run(db, taskdata.file_id, interval)
     
         if previous_run:
             # Make a copy of the previous run.
@@ -958,7 +958,7 @@ def pop_task_from_taskqueue(s3, task_queue, done_queue, due_queue, heartbeat_que
         
         else:
             # Reserve space for a new run.
-            passed_on_kwargs['run_id'] = add_run(db)
+            passed_on_kwargs['run_id'] = objects.add_run(db)
 
             # Send a Due task, possibly for later.
             due_task = queuedata.Due(**passed_on_kwargs)

--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -367,12 +367,13 @@ def get_completed_file_run(db, file_id, interval):
     
     previous_run = db.fetchone()
     
-    if previous_run:
-        _L.debug('Found previous run {0} ({2}) for file {file_id}'.format(*previous_run, **locals()))
-    else:
+    if previous_run is None:
         _L.debug('No previous run for file {file_id}'.format(**locals()))
+        return None
 
-    return previous_run
+    run_id, state_dict, status = previous_run
+    _L.debug('Found previous run {run_id} ({status}) for file {file_id}'.format(**locals()))
+    return run_id, RunState(state_dict), status
 
 def get_completed_run(db, run_id, min_dtz):
     '''

--- a/openaddr/ci/queuedata.py
+++ b/openaddr/ci/queuedata.py
@@ -53,6 +53,12 @@ class Done:
         if self.rerun is not None: data.update(rerun=self.rerun)
         if self.worker_id is not None: data.update(worker_id=self.worker_id)
         if self.set_id is not None: data.update(set_id=self.set_id)
+
+        # Convert RunState to a plain dictionary
+        if data['result'] and 'state' in data['result']:
+            state = data['result']['state']
+            data['result']['state'] = {k: state.get(k) for k in state.keys}
+    
         return data
 
 class Heartbeat:


### PR DESCRIPTION
Instead of passing around mysterious plain dictionaries, use `objects.RunState` class to more reliably move state data around. Adds substantial tests for `ci.pop_task_from_taskqueue()` and replaces `ci.work.assemble_output()` with `ci.work.assemble_runstate()`.