### PR TITLE
Add RunState.run_id property

### DIFF
--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -90,12 +90,13 @@ class RunState:
         'output', 'process time', 'website', 'skipped', 'license',
         'share-alike', 'attribution required', 'attribution name',
         'attribution flag', 'process hash', 'preview', 'slippymap',
-        'source problem', 'code version', 'tests passed')}
+        'source problem', 'code version', 'tests passed', 'run id')}
 
     def __init__(self, json_blob):
         blob_dict = dict(json_blob or {})
         self.keys = blob_dict.keys()
         
+        self.run_id = blob_dict.get('run id')
         self.source = blob_dict.get('source')
         self.cache = blob_dict.get('cache')
         self.sample = blob_dict.get('sample')

--- a/openaddr/ci/templates/job.html
+++ b/openaddr/ci/templates/job.html
@@ -57,7 +57,7 @@
         {% if dotmaps_base_url %}
             <td>
             {% if file_runstate and file_runstate.slippymap %}
-                <a href="{{ file_runstate.slippymap|slippymap_preview_url }}">slippy map preview</a>
+                <a href="{{ file_runstate|slippymap_preview_url }}">slippy map preview</a>
             {% endif %}
             </td>
         {% endif %}

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -373,12 +373,19 @@ def nice_size(size):
     else:
         return '{:.0f}{}'.format(size, suffix)
 
-def temporary_slippymap_preview_url(slippymap_mbtiles_url):
+def slippymap_preview_url(runstate):
     '''
     '''
-    # TODO: this is a hack-ass way to get the run ID
-    parsed_url = urlparse(slippymap_mbtiles_url)
-    run_id = os.path.basename(os.path.dirname(parsed_url.path))
+    if runstate.run_id:
+        run_id = str(runstate.run_id)
+
+    elif runstate.slippymap:
+        # Old hack-ass way to get the run ID
+        parsed_url = urlparse(runstate.slippymap)
+        run_id = os.path.basename(os.path.dirname(parsed_url.path))
+
+    else:
+        raise ValueError()
 
     return urljoin(current_app.config['DOTMAPS_BASE_URL'], run_id)
 
@@ -398,7 +405,7 @@ def apply_webhooks_blueprint(app):
         app.jinja_env.filters['breakstate'] = break_state
         app.jinja_env.filters['nice_size'] = nice_size
         
-        app.jinja_env.filters['slippymap_preview_url'] = temporary_slippymap_preview_url
+        app.jinja_env.filters['slippymap_preview_url'] = slippymap_preview_url
 
         setup_logger(None,
                      None,

--- a/openaddr/ci/work.py
+++ b/openaddr/ci/work.py
@@ -29,6 +29,7 @@ def assemble_runstate(s3, input, source_name, run_id, index_dirname):
     ''' Convert worker index dictionary to RunState.
     '''
     output = {k: v for (k, v) in input.items()}
+    output['run id'] = run_id
     
     if input['cache']:
         # e.g. /runs/0/cache.zip

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2270,19 +2270,36 @@ class TestHook (unittest.TestCase):
 
         with db_connect(self.database_url) as conn:
             with db_cursor(conn) as db:
-                state = RunState({
+                state1 = RunState({
+                    'output': 'http://example.com/998/log.txt',
+                    'sample': 'http://example.com/998/sample.json',
+                    'processed': 'http://example.com/998/stuff.zip',
+                    'preview': 'http://example.com/998/preview.png',
+                    'slippymap': 'http://example.com/998/tiles.mbtiles'
+                    })
+                state2 = RunState({
                     'output': 'http://example.com/999/log.txt',
                     'sample': 'http://example.com/999/sample.json',
                     'processed': 'http://example.com/999/stuff.zip',
                     'preview': 'http://example.com/999/preview.png',
-                    'slippymap': 'http://example.com/999/tiles.mbtiles',
+                    'slippymap': 'http://example.org/tiles.mbtiles',
                     'run id': 999
                     })
-                add_job(db, 'abc', True, {'0xWHATEVER': 'foo'}, {'foo': True}, {'foo': {'state': state}}, 'oa', 'oa', None, None)
+                add_job(db, 'abc', True, {'this': 'foo', 'that': 'bar'},
+                       {'foo': True, 'bar': True},
+                       {'foo': {'state': state1}, 'bar': {'state': state2}},
+                       'oa', 'oa', None, None)
 
         got2 = self.client.get('/jobs/abc')
         body2 = got2.data.decode('utf8')
         self.assertEqual(got2.status_code, 200)
+
+        self.assertIn('http://example.com/998/log.txt', body2)
+        self.assertIn('http://example.com/998/sample.json', body2)
+        self.assertIn('http://example.com/998/stuff.zip', body2)
+        self.assertIn('http://example.com/998/preview.png', body2)
+        self.assertIn('https://dotmaps.example.com/yo/998', body2)
+
         self.assertIn('http://example.com/999/log.txt', body2)
         self.assertIn('http://example.com/999/sample.json', body2)
         self.assertIn('http://example.com/999/stuff.zip', body2)

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -91,7 +91,8 @@ class TestObjects (unittest.TestCase):
         keys = ('source', 'cache', 'sample', 'geometry type', 'processed',
             'address count', 'version', 'fingerprint', 'cache time',
             'output', 'process time', 'website', 'skipped', 'license',
-            'share-alike', 'attribution required', 'attribution name')
+            'share-alike', 'attribution required', 'attribution name',
+            'run id')
         
         for key in keys:
             value = str(uuid4())
@@ -100,6 +101,12 @@ class TestObjects (unittest.TestCase):
             
             attr = key.replace(' ', '_').replace('-', '_')
             self.assertEqual(getattr(state, attr), value)
+
+        # special case for run id
+        value = str(uuid4())
+        state = RunState({'run id': value})
+        self.assertEqual(state.get('run id'), value)
+        self.assertEqual(state.run_id, value)
 
         # special case for source problem
         value = None
@@ -2917,6 +2924,7 @@ class TestWorker (unittest.TestCase):
         input1 = {'cache': False, 'sample': False, 'processed': False, 'output': False, 'preview': False, 'slippymap': False}
         state1 = assemble_runstate(s3, input1, 'xx/f', 1, 'dir')
 
+        self.assertEqual(state1.run_id, 1)
         self.assertEqual(state1.cache, input1['cache'])
         self.assertEqual(state1.sample, input1['sample'])
         self.assertEqual(state1.processed, input1['processed'])
@@ -2927,6 +2935,7 @@ class TestWorker (unittest.TestCase):
         input2 = {'cache': 'cache.csv', 'sample': False, 'processed': False, 'output': False, 'preview': False, 'slippymap': False}
         state2 = assemble_runstate(s3, input2, 'xx/f', 2, 'dir')
 
+        self.assertEqual(state2.run_id, 2)
         self.assertEqual(state2.cache, 'https://s3.amazonaws.com/a-bucket/a-key')
         self.assertEqual(state2.fingerprint, '0xWHATEVER')
         self.assertEqual(state2.sample, input2['sample'])
@@ -2939,6 +2948,7 @@ class TestWorker (unittest.TestCase):
         input3 = {'cache': False, 'sample': 'sample.json', 'processed': False, 'output': False, 'preview': False, 'slippymap': False}
         state3 = assemble_runstate(s3, input3, 'xx/f', 3, 'dir')
 
+        self.assertEqual(state3.run_id, 3)
         self.assertEqual(state3.cache, input3['cache'])
         self.assertEqual(state3.sample, 'https://s3.amazonaws.com/a-bucket/a-key')
         self.assertEqual(state3.processed, input3['processed'])
@@ -2950,6 +2960,7 @@ class TestWorker (unittest.TestCase):
         input4 = {'cache': False, 'sample': False, 'processed': False, 'output': 'out.txt', 'preview': False, 'slippymap': False}
         state4 = assemble_runstate(s3, input4, 'xx/f', 4, 'dir')
 
+        self.assertEqual(state4.run_id, 4)
         self.assertEqual(state4.cache, input4['cache'])
         self.assertEqual(state4.sample, input4['sample'])
         self.assertEqual(state4.processed, input4['processed'])
@@ -2963,6 +2974,7 @@ class TestWorker (unittest.TestCase):
             input5 = {'cache': False, 'sample': False, 'processed': 'data.zip', 'output': False, 'preview': False, 'slippymap': False}
             state5 = assemble_runstate(s3, input5, 'xx/f', 5, 'dir')
 
+        self.assertEqual(state5.run_id, 5)
         self.assertEqual(state5.cache, input5['cache'])
         self.assertEqual(state5.sample, input5['sample'])
         self.assertEqual(state5.processed, 'https://s3.amazonaws.com/a-bucket/a-key')
@@ -2975,6 +2987,7 @@ class TestWorker (unittest.TestCase):
         input6 = {'cache': False, 'sample': False, 'processed': False, 'output': False, 'preview': 'preview.png', 'slippymap': False}
         state6 = assemble_runstate(s3, input6, 'xx/f', 6, 'dir')
 
+        self.assertEqual(state6.run_id, 6)
         self.assertEqual(state6.cache, input6['cache'])
         self.assertEqual(state6.sample, input6['sample'])
         self.assertEqual(state6.processed, input6['processed'])
@@ -2986,6 +2999,7 @@ class TestWorker (unittest.TestCase):
         input7 = {'cache': False, 'sample': False, 'processed': False, 'output': False, 'preview': False, 'slippymap': 'slippymap.mbtiles'}
         state7 = assemble_runstate(s3, input7, 'xx/f', 7, 'dir')
 
+        self.assertEqual(state7.run_id, 7)
         self.assertEqual(state7.cache, input7['cache'])
         self.assertEqual(state7.sample, input7['sample'])
         self.assertEqual(state7.processed, input7['processed'])
@@ -3048,6 +3062,7 @@ class TestWorker (unittest.TestCase):
         self.assertTrue(result['state'].processed.endswith(u'/so/exalté.zip'))
         self.assertEqual(result['state'].website, 'http://example.com')
         self.assertEqual(result['state'].license, 'GPL')
+        self.assertEqual(result['state'].run_id, -1)
         
         zip_path = urlparse(result['state'].processed).path
         zip_bytes = self.s3._read_fake_key(zip_path[len('/fake-bucket'):])
@@ -3148,6 +3163,7 @@ class TestWorker (unittest.TestCase):
         self.assertIsNone(result['state'].sample)
         self.assertIsNone(result['state'].license)
         self.assertIsNone(result['state'].processed)
+        self.assertEqual(result['state'].run_id, -1)
 
 class TestBatch (unittest.TestCase):
 


### PR DESCRIPTION
For new runs, include the ID in the state so it’s easier to build URLs. Closes #567.