### PR TITLE
Added frameset with slippymap preview

### DIFF
--- a/openaddr/ci/templates/base.html
+++ b/openaddr/ci/templates/base.html
@@ -102,11 +102,11 @@
             </form>
             {% endif %}
         {% endif %}
-        <a href="http://openaddresses.io"> <img id="icon" src="{{ url_for('static', filename='17.png') }}">Home</a>
-        <a href="{{ url_for('webhooks.app_index') }}">Download Data</a>
-        <a href="{{ url_for('webhooks.app_get_sets') }}">All Batch Sets</a>
-        <a href="{{ url_for('webhooks.app_get_jobs') }}">All CI Jobs</a>
-        <a href="{{ url_for('webhooks.app_get_dashboard') }}">Dashboard</a>
+        <a target="_top" href="http://openaddresses.io"> <img id="icon" src="{{ url_for('static', filename='17.png') }}">Home</a>
+        <a target="_top" href="{{ url_for('webhooks.app_index') }}">Download Data</a>
+        <a target="_top" href="{{ url_for('webhooks.app_get_sets') }}">All Batch Sets</a>
+        <a target="_top" href="{{ url_for('webhooks.app_get_jobs') }}">All CI Jobs</a>
+        <a target="_top" href="{{ url_for('webhooks.app_get_dashboard') }}">Dashboard</a>
     </nav>
     <main>
         {% if error_org_membership %}
@@ -126,8 +126,8 @@
         {% block info %}
         <p>
             I am the OpenAddresses data service.
-            <a href="https://github.com/openaddresses/machine">Find me on Github</a> or
-            <a href="http://mike.teczno.com/notes/openaddresses-ci.html">read this blog post</a>
+            <a target="_top" href="https://github.com/openaddresses/machine">Find me on Github</a> or
+            <a target="_top" href="http://mike.teczno.com/notes/openaddresses-ci.html">read this blog post</a>
             to learn more.
         </p>
         {% endblock %}

--- a/openaddr/ci/templates/job-slippymap-frameset.html
+++ b/openaddr/ci/templates/job-slippymap-frameset.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"
+	"http://www.w3.org/TR/html4/frameset.dtd">
+<html lang="en">
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<title>OpenAddresses — Run {{ run.id }} Map Preview</title>
+</head>
+{% if job %}
+    <frameset rows="100,*" border="0">
+        <frame src="{{ url_for('webhooks.app_get_run_slippymap', frame='header', job_id=job.id, run_id=run.id) }}" scrolling="no">
+        <frame scrolling="no" src="{{ run.state|slippymap_preview_url }}">
+    </frameset>
+{% else %}
+    <frameset rows="60,*" border="0">
+        <frame src="{{ url_for('webhooks.app_get_run_slippymap', frame='header', run_id=run.id) }}" scrolling="no">
+        <frame scrolling="no" src="{{ run.state|slippymap_preview_url }}">
+    </frameset>
+{% endif %}
+</html>

--- a/openaddr/ci/templates/job-slippymap-header.html
+++ b/openaddr/ci/templates/job-slippymap-header.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block title %}Job {{ job.id }}{% endblock %}
+{% block main %}
+    {% if job %}
+        <a href="{{ url_for('webhooks.app_get_job', job_id=job.id) }}" target="_top">← Return to CI job page</a>
+    {% endif %}
+{% endblock main %}
+{% block info %}{% endblock %}

--- a/openaddr/ci/templates/job.html
+++ b/openaddr/ci/templates/job.html
@@ -57,7 +57,11 @@
         {% if dotmaps_base_url %}
             <td>
             {% if file_runstate and file_runstate.slippymap %}
-                <a href="{{ file_runstate|slippymap_preview_url }}">slippy map preview</a>
+                {% if file_runstate.run_id %}
+                    <a href="{{ url_for('webhooks.app_get_run_slippymap', frame='top', job_id=job.id, run_id=file_runstate.run_id) }}">slippy map preview</a>
+                {% else %}
+                    <a href="{{ file_runstate|slippymap_preview_url }}">slippy map preview</a>
+                {% endif %}
             {% endif %}
             </td>
         {% endif %}

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2298,13 +2298,13 @@ class TestHook (unittest.TestCase):
         self.assertIn('http://example.com/998/sample.json', body2)
         self.assertIn('http://example.com/998/stuff.zip', body2)
         self.assertIn('http://example.com/998/preview.png', body2)
-        self.assertIn('https://dotmaps.example.com/yo/998', body2)
+        self.assertIn('https://dotmaps.example.com/yo/998', body2, 'Should see the external URL for slippy map')
 
         self.assertIn('http://example.com/999/log.txt', body2)
         self.assertIn('http://example.com/999/sample.json', body2)
         self.assertIn('http://example.com/999/stuff.zip', body2)
         self.assertIn('http://example.com/999/preview.png', body2)
-        self.assertIn('https://dotmaps.example.com/yo/999', body2)
+        self.assertIn('/slippymaps/999/top/abc', body2, 'Should see the internal frameset URL for slippy map')
     
 class TestRuns (unittest.TestCase):
 


### PR DESCRIPTION
- [x] Put dotmap preview in a frame to stay in the same domain
- [x] Keep a useful header around when looking at the dotmap preview
- [ ] Was the URL hash useful, and should it be kept?