### PR TITLE
Measure resource usage in run logs

### DIFF
--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -158,7 +158,7 @@ def render_slippymap(csv_filename, temp_dir):
     else:
         return mbtiles_filename
 
-class LogFilter:
+class LogFilterCurrentThread:
     ''' Logging filter object to match only record in the current thread.
     '''
     def __init__(self):
@@ -169,7 +169,7 @@ class LogFilter:
         return record.thread == self.thread_id
 
 def get_log_handler(directory):
-    ''' Create a new file handler for the current thread and return it.
+    ''' Create a new file handler and return it.
     '''
     handle, filename = tempfile.mkstemp(dir=directory, suffix='.log')
     close(handle)
@@ -178,7 +178,9 @@ def get_log_handler(directory):
     handler = logging.FileHandler(filename)
     handler.setFormatter(logging.Formatter(u'%(asctime)s %(levelname)08s: %(message)s'))
     handler.setLevel(logging.DEBUG)
-    handler.addFilter(LogFilter())
+    
+    # # Limit log messages to the current thread
+    # handler.addFilter(LogFilterCurrentThread())
     
     return handler
 

--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -52,6 +52,9 @@ def process(source, destination, do_preview, mapzen_key=None, extras=dict()):
     
         Creates a new directory and files under destination.
     '''
+    # The main processing thread holds wait_lock until it is done.
+    # The logging thread periodically writes data in the background,
+    # then exits once the main thread releases the lock.
     wait_lock = threading.Lock()
     proc_wait = threading.Thread(target=util.log_process_usage, args=(wait_lock, ))
     

--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -8,8 +8,9 @@ from argparse import ArgumentParser
 from os import mkdir, rmdir, close, chmod
 from _thread import get_ident
 import tempfile, json, csv, sys, enum
+import threading
 
-from . import cache, conform, preview, slippymap, CacheResult, ConformResult, __version__
+from . import util, cache, conform, preview, slippymap, CacheResult, ConformResult, __version__
 from .cache import DownloadError
 from .conform import check_source_tests
 
@@ -51,6 +52,9 @@ def process(source, destination, do_preview, mapzen_key=None, extras=dict()):
     
         Creates a new directory and files under destination.
     '''
+    wait_lock = threading.Lock()
+    proc_wait = threading.Thread(target=util.log_process_usage, args=(wait_lock, ))
+    
     temp_dir = tempfile.mkdtemp(prefix='process_one-', dir=destination)
     temp_src = join(temp_dir, basename(source))
     copy(source, temp_src)
@@ -58,77 +62,80 @@ def process(source, destination, do_preview, mapzen_key=None, extras=dict()):
     log_handler = get_log_handler(temp_dir)
     logging.getLogger('openaddr').addHandler(log_handler)
     
-    cache_result, conform_result = CacheResult.empty(), ConformResult.empty()
-    preview_path, slippymap_path, skipped_source = None, None, False
-    tests_passed = None
+    with wait_lock:
+        proc_wait.start()
+        cache_result, conform_result = CacheResult.empty(), ConformResult.empty()
+        preview_path, slippymap_path, skipped_source = None, None, False
+        tests_passed = None
     
-    try:
-        with open(temp_src) as file:
-            if json.load(file).get('skip', None):
-                raise SourceSaysSkip()
-        
-        # Check tests in source data.
-        with open(temp_src) as file:
-            tests_passed, failure_details = check_source_tests(json.load(file))
-            if tests_passed is False:
-                raise SourceTestsFailed(failure_details)
-    
-        # Cache source data.
         try:
-            cache_result = cache(temp_src, temp_dir, extras)
-        except EsriDownloadError as e:
-            _L.warning('Could not download ESRI source data: {}'.format(e))
-            raise
-        except DownloadError as e:
-            _L.warning('Could not download source data')
-            raise
+            with open(temp_src) as file:
+                if json.load(file).get('skip', None):
+                    raise SourceSaysSkip()
+        
+            # Check tests in source data.
+            with open(temp_src) as file:
+                tests_passed, failure_details = check_source_tests(json.load(file))
+                if tests_passed is False:
+                    raise SourceTestsFailed(failure_details)
     
-        if not cache_result.cache:
-            _L.warning('Nothing cached')
-        else:
-            _L.info(u'Cached data in {}'.format(cache_result.cache))
-
-            # Conform cached source data.
-            conform_result = conform(temp_src, temp_dir, cache_result.todict())
+            # Cache source data.
+            try:
+                cache_result = cache(temp_src, temp_dir, extras)
+            except EsriDownloadError as e:
+                _L.warning('Could not download ESRI source data: {}'.format(e))
+                raise
+            except DownloadError as e:
+                _L.warning('Could not download source data')
+                raise
     
-            if not conform_result.path:
-                _L.warning('Nothing processed')
+            if not cache_result.cache:
+                _L.warning('Nothing cached')
             else:
-                _L.info('Processed data in {}'.format(conform_result.path))
-                
-                if do_preview and mapzen_key:
-                    preview_path = render_preview(conform_result.path, temp_dir, mapzen_key)
-                
-                if do_preview:
-                    slippymap_path = render_slippymap(conform_result.path, temp_dir)
+                _L.info(u'Cached data in {}'.format(cache_result.cache))
 
-                if not preview_path:
-                    _L.warning('Nothing previewed')
+                # Conform cached source data.
+                conform_result = conform(temp_src, temp_dir, cache_result.todict())
+    
+                if not conform_result.path:
+                    _L.warning('Nothing processed')
                 else:
-                    _L.info('Preview image in {}'.format(preview_path))
+                    _L.info('Processed data in {}'.format(conform_result.path))
+                
+                    if do_preview and mapzen_key:
+                        preview_path = render_preview(conform_result.path, temp_dir, mapzen_key)
+                
+                    if do_preview:
+                        slippymap_path = render_slippymap(conform_result.path, temp_dir)
+
+                    if not preview_path:
+                        _L.warning('Nothing previewed')
+                    else:
+                        _L.info('Preview image in {}'.format(preview_path))
     
-    except SourceSaysSkip:
-        _L.info('Source says to skip in process_one.process()')
-        skipped_source = True
+        except SourceSaysSkip:
+            _L.info('Source says to skip in process_one.process()')
+            skipped_source = True
 
-    except SourceTestsFailed as e:
-        _L.warning('A source test failed in process_one.process(): %s', str(e))
-        tests_passed = False
+        except SourceTestsFailed as e:
+            _L.warning('A source test failed in process_one.process(): %s', str(e))
+            tests_passed = False
 
-    except Exception:
-        _L.warning('Error in process_one.process()', exc_info=True)
+        except Exception:
+            _L.warning('Error in process_one.process()', exc_info=True)
     
-    finally:
-        # Make sure this gets done no matter what
-        logging.getLogger('openaddr').removeHandler(log_handler)
+        finally:
+            # Make sure this gets done no matter what
+            logging.getLogger('openaddr').removeHandler(log_handler)
 
-    # Write output
-    state_path = write_state(source, skipped_source, destination, log_handler,
-        tests_passed, cache_result, conform_result, preview_path, slippymap_path,
-        temp_dir)
+        # Write output
+        state_path = write_state(source, skipped_source, destination, log_handler,
+            tests_passed, cache_result, conform_result, preview_path, slippymap_path,
+            temp_dir)
 
-    log_handler.close()
-    rmtree(temp_dir)
+        log_handler.close()
+        rmtree(temp_dir)
+
     return state_path
 
 def render_preview(csv_filename, temp_dir, mapzen_key):

--- a/openaddr/util/__init__.py
+++ b/openaddr/util/__init__.py
@@ -18,9 +18,9 @@ from boto.ec2 import blockdevicemapping
 block_device_sizes = {'r3.large': 32, 'r3.xlarge': 80, 'r3.2xlarge': 160, 'r3.4xlarge': 320}
 
 RESOURCE_LOG_INTERVAL = timedelta(seconds=30)
-RESOURCE_LOG_FORMAT = 'Resource usage: {user:.0f}% user, {system:.0f}% system, ' \
-    '{memory:.0f}MB memory, {read:.0f}KB read, {written:.0f}KB written, ' \
-    '{sent:.0f}KB sent, {received:.0f}KB received, {elapsed:.0f}sec elapsed'
+RESOURCE_LOG_FORMAT = 'Resource usage: {{ user: {user:.0f}%, system: {system:.0f}%, ' \
+    'memory: {memory:.0f}MB, read: {read:.0f}KB, written: {written:.0f}KB, ' \
+    'sent: {sent:.0f}KB, received: {received:.0f}KB, elapsed: {elapsed:.0f}sec }}'
 
 def get_version():
     ''' Prevent circular imports.

--- a/openaddr/util/__init__.py
+++ b/openaddr/util/__init__.py
@@ -232,6 +232,10 @@ def get_cpu_times():
 def get_diskio_bytes():
     ''' Return bytes read and written.
     
+        This will measure all bytes read in the process, and so includes
+        reading in shared libraries, etc; not just our productive data
+        processing activity.
+    
         See http://stackoverflow.com/questions/3633286/understanding-the-counters-in-proc-pid-io
     '''
     if not exists('/proc/{}/io'.format(getpid())):
@@ -251,6 +255,9 @@ def get_diskio_bytes():
 
 def get_network_bytes():
     ''' Return bytes sent and received.
+        
+        TODO: This code measures network usage for the whole system.
+        It'll be better to do this measurement on a per-process basis later.
     '''
     if not exists('/proc/net/netstat'):
         return None, None
@@ -269,6 +276,9 @@ def get_network_bytes():
 
 def get_memory_usage():
     ''' Return Linux memory usage in megabytes.
+        
+        VMRSS is of interest here too; that's resident memory size.
+        It will matter if a machine runs out of RAM.
     
         See http://stackoverflow.com/questions/30869297/difference-between-memfree-and-memavailable
         and http://stackoverflow.com/questions/131303/how-to-measure-actual-memory-usage-of-an-application-or-process


### PR DESCRIPTION
Adds log lines for CPU, memory, disk, and network usage to all process logs. Output will look like this in 30 second increments:

```
2017-03-26 18:11:36,372     INFO: Resource usage: 4% user, 3% system, 438MB memory, 0KB read, 0KB written, 70KB sent, 2700KB received, 3sec elapsed
2017-03-26 18:11:39,389     INFO: Resource usage: 4% user, 9% system, 438MB memory, 0KB read, 0KB written, 72KB sent, 2699KB received, 6sec elapsed
2017-03-26 18:11:42,367     INFO: Resource usage: 11% user, 86% system, 439MB memory, 0KB read, 2036KB written, 2KB sent, 1KB received, 9sec elapsed
2017-03-26 18:11:45,394     INFO: Resource usage: 14% user, 85% system, 439MB memory, 0KB read, 2972KB written, 0KB sent, 0KB received, 12sec elapsed
2017-03-26 18:11:48,379     INFO: Resource usage: 15% user, 84% system, 439MB memory, 0KB read, 2880KB written, 0KB sent, 0KB received, 15sec elapsed
```

Addresses #65. @NelsonMinar, I’d love your feedback on whether I’m measuring these values sanely.