### PR TITLE
Generate source ids

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -43,7 +43,8 @@ gdal.PushErrorHandler(gdal_error_handler)
 
 # The canonical output schema for conform
 OPENADDR_CSV_SCHEMA = ['LON', 'LAT', 'NUMBER', 'STREET', 'UNIT', 'CITY',
-                       'DISTRICT', 'REGION', 'POSTCODE', 'ID', 'HASH']
+                       'DISTRICT', 'REGION', 'POSTCODE', 'ID', 'HASH',
+                       'SRC_HASH']
 
 # Field names for use in cached CSV files.
 # We add columns to the extracted CSV with our own data with these names.
@@ -894,6 +895,7 @@ def row_transform_and_convert(sd, row):
 
     # Some conform specs have fields named with a case different from the source
     row = row_smash_case(sd, row)
+    row = row_calculate_source_hash(row)
 
     c = sd["conform"]
     
@@ -927,10 +929,10 @@ def row_transform_and_convert(sd, row):
     # Make up a random fingerprint if none exists
     cache_fingerprint = sd.get('fingerprint', str(uuid4()))
     
-    row2 = row_convert_to_out(sd, row)
+    row2 = dict(row_convert_to_out(sd, row), SRC_HASH=row['SRC_HASH'])
     row3 = row_canonicalize_unit_and_number(sd, row2)
     row4 = row_round_lat_lon(sd, row3)
-    row5 = row_calculate_hash(cache_fingerprint, row4)
+    row5 = row_calculate_output_hash(cache_fingerprint, row4)
     return row5
 
 def conform_smash_case(source_definition):
@@ -1090,13 +1092,25 @@ def row_round_lat_lon(sd, row):
     row["LAT"] = _round_wgs84_to_7(row["LAT"])
     return row
 
-def row_calculate_hash(cache_fingerprint, row):
+def row_calculate_source_hash(row):
+    ''' Calculate row hash based on content.
+    
+        4 chars of SHA-1 gives a 16-bit value, probably okay for nearby addresses.
+    '''
+    hash = sha1(json.dumps(sorted(row.items()), separators=(',', ':')).encode('utf8'))
+    row.update(SRC_HASH=hash.hexdigest()[:4])
+    
+    return row
+
+def row_calculate_output_hash(cache_fingerprint, row):
     ''' Calculate row hash based on content and existing fingerprint.
     
         16 chars of SHA-1 gives a 64-bit value, plenty for all addresses.
     '''
+    hashed = sorted([(k, v) for (k, v) in row.items() if k != 'SRC_HASH'])
+    
     hash = sha1(cache_fingerprint.encode('utf8'))
-    hash.update(json.dumps(sorted(row.items()), separators=(',', ':')).encode('utf8'))
+    hash.update(json.dumps(hashed, separators=(',', ':')).encode('utf8'))
     row.update(HASH=hash.hexdigest()[:16])
     
     return row

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -4106,7 +4106,7 @@ class TestCollect (unittest.TestCase):
         output.writestr.side_effect = remember_writestr_contents
         
         # Addresses that should trigger expansion.
-        input1 = u'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH\n-122.2359742,37.7362507,85,MAITLAND DR,A,ALAMEDA,,,94502,74-1035-77,h4sh\n-122.2353881,37.7223605,1360,S LOOP RD,,ALAMEDA,,,94502,74-1339-11,h4sh\n-122.2385597,37.7284071,3508,CATALINA AV,,ALAMEDA,,,94502,74-1033-146,h4sh\n-122.2368942,37.7305041,3512,MCSHERRY WY,,ALAMEDA,,,94502,74-1033-122,h4sh\n-122.2349371,37.7357455,514,FLOWER LA,,ALAMEDA,,,94502,74-1036-26,h4sh\n-122.2367819,37.7342157,1014,HOLLY ST,,ALAMEDA,,,94502,74-1075-222,h4sh\n'
+        input1 = u'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH,SRC_HASH\n-122.2359742,37.7362507,85,MAITLAND DR,A,ALAMEDA,,,94502,74-1035-77,h4sh,s0rc\n-122.2353881,37.7223605,1360,S LOOP RD,,ALAMEDA,,,94502,74-1339-11,h4sh,s0rc\n-122.2385597,37.7284071,3508,CATALINA AV,,ALAMEDA,,,94502,74-1033-146,h4sh,s0rc\n-122.2368942,37.7305041,3512,MCSHERRY WY,,ALAMEDA,,,94502,74-1033-122,h4sh,s0rc\n-122.2349371,37.7357455,514,FLOWER LA,,ALAMEDA,,,94502,74-1036-26,h4sh,s0rc\n-122.2367819,37.7342157,1014,HOLLY ST,,ALAMEDA,,,94502,74-1075-222,h4sh,s0rc\n'
         add_csv_to_zipfile(output, u'us/ca/älameda.csv', BytesIO(input1.encode('utf8')))
 
         # Collections with missing columns and non-ASCII characters.
@@ -4120,7 +4120,7 @@ class TestCollect (unittest.TestCase):
         add_csv_to_zipfile(output, u'us/ca/älameda.csv', BytesIO(input4.encode('utf8')))
         
         # Collection with illegal lat/lon value.
-        input5 = u'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH\n-104.6843547,39.5793748,26050,E JAMISON CIR N,, CO,,,80016-2056,,629e0367e92b4c47\n-1.79769313486e+308,-1.79769313486e+308,26900,E COLFAX AVE,428,,,,,,8764a6de3c9f688c\n-104.1139093,39.6761295,2050,S PEORIA CROSSING RD,, CO,,,,,28b370f54c8e40ef\n'
+        input5 = u'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH,SRC_HASH\n-104.6843547,39.5793748,26050,E JAMISON CIR N,, CO,,,80016-2056,,629e0367e92b4c47,s0rc1\n-1.79769313486e+308,-1.79769313486e+308,26900,E COLFAX AVE,428,,,,,,8764a6de3c9f688c,s0rc2\n-104.1139093,39.6761295,2050,S PEORIA CROSSING RD,, CO,,,,,28b370f54c8e40ef,s0rc3\n'
         add_csv_to_zipfile(output, u'us/co/arapahoe.csv', BytesIO(input5.encode('utf8')))
         
         self.assertEqual(len(output.write.mock_calls), 10)
@@ -4142,13 +4142,13 @@ class TestCollect (unittest.TestCase):
         # input1
         self.assertEqual(output_write_contents[0],
             [
-            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH',
-            '-122.2359742,37.7362507,85,MAITLAND DR,A,ALAMEDA,,,94502,74-1035-77,h4sh',
-            '-122.2353881,37.7223605,1360,S LOOP RD,,ALAMEDA,,,94502,74-1339-11,h4sh',
-            '-122.2385597,37.7284071,3508,CATALINA AV,,ALAMEDA,,,94502,74-1033-146,h4sh',
-            '-122.2368942,37.7305041,3512,MCSHERRY WY,,ALAMEDA,,,94502,74-1033-122,h4sh',
-            '-122.2349371,37.7357455,514,FLOWER LA,,ALAMEDA,,,94502,74-1036-26,h4sh',
-            '-122.2367819,37.7342157,1014,HOLLY ST,,ALAMEDA,,,94502,74-1075-222,h4sh',
+            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH,SRC_HASH',
+            '-122.2359742,37.7362507,85,MAITLAND DR,A,ALAMEDA,,,94502,74-1035-77,h4sh,s0rc',
+            '-122.2353881,37.7223605,1360,S LOOP RD,,ALAMEDA,,,94502,74-1339-11,h4sh,s0rc',
+            '-122.2385597,37.7284071,3508,CATALINA AV,,ALAMEDA,,,94502,74-1033-146,h4sh,s0rc',
+            '-122.2368942,37.7305041,3512,MCSHERRY WY,,ALAMEDA,,,94502,74-1033-122,h4sh,s0rc',
+            '-122.2349371,37.7357455,514,FLOWER LA,,ALAMEDA,,,94502,74-1036-26,h4sh,s0rc',
+            '-122.2367819,37.7342157,1014,HOLLY ST,,ALAMEDA,,,94502,74-1075-222,h4sh,s0rc',
             ])
         self.assertEqual(output_write_contents[1],
             [
@@ -4159,22 +4159,22 @@ class TestCollect (unittest.TestCase):
         # input2
         self.assertEqual(output_write_contents[2],
             [
-            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH',
-            '-122.2359742,37.7362507,85,MAITLAND DR,,ALAMEDA,,,94502,,',
-            '-122.2353881,37.7223605,1360,S LOOP RD,,ALAMEDA,,,94502,,',
-            '-122.2385597,37.7284071,3508,CATALINA AV,,ALAMEDA,,,94502,,',
-            '-122.2368942,37.7305041,3512,MCSHERRY WY,,ALAMEDA,,,94502,,',
-            '-122.2349371,37.7357455,514,FLOWER LA,,ALAMEDA,,,94502,,',
-            '-122.2367819,37.7342157,1014,HOLLY ST,,ALAMEDA,,,94502,,',
+            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH,SRC_HASH',
+            '-122.2359742,37.7362507,85,MAITLAND DR,,ALAMEDA,,,94502,,,',
+            '-122.2353881,37.7223605,1360,S LOOP RD,,ALAMEDA,,,94502,,,',
+            '-122.2385597,37.7284071,3508,CATALINA AV,,ALAMEDA,,,94502,,,',
+            '-122.2368942,37.7305041,3512,MCSHERRY WY,,ALAMEDA,,,94502,,,',
+            '-122.2349371,37.7357455,514,FLOWER LA,,ALAMEDA,,,94502,,,',
+            '-122.2367819,37.7342157,1014,HOLLY ST,,ALAMEDA,,,94502,,,',
             ])
         self.assertEqual(output_write_contents[3], output_write_contents[1])
         
         # input3
         self.assertEqual(output_write_contents[4],
             [
-            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH',
-            '8.6885893,50.1042197,12,Abtsgäßchen,,Frankfurt am Main,,,60594,,',
-            '8.6885485,50.1041506,14,Abtsgäßchen,,Frankfurt am Main,,,60594,,',
+            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH,SRC_HASH',
+            '8.6885893,50.1042197,12,Abtsgäßchen,,Frankfurt am Main,,,60594,,,',
+            '8.6885485,50.1041506,14,Abtsgäßchen,,Frankfurt am Main,,,60594,,,',
             ])
         self.assertEqual(output_write_contents[5],
             [
@@ -4185,21 +4185,21 @@ class TestCollect (unittest.TestCase):
         # input4
         self.assertEqual(output_write_contents[6],
             [
-            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH',
-            '-122.2359742,37.7362507,85,MAITLAND DR,,ALAMEDA,,,94502,,',
-            '-122.2353881,37.7223605,1360,S LOOP RD,,ALAMEDA,,,94502,,',
-            '-122.2385597,37.7284071,3508,CATALINA AV,,ALAMEDA,,,94502,,',
-            '-122.2368942,37.7305041,3512,MCSHERRY WY,,ALAMEDA,,,94502,,',
-            '-122.2349371,37.7357455,514,FLOWER LA,,ALAMEDA,,,94502,,',
-            '-122.2367819,37.7342157,1014,HOLLY ST,,ALAMEDA,,,94502,,',
+            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH,SRC_HASH',
+            '-122.2359742,37.7362507,85,MAITLAND DR,,ALAMEDA,,,94502,,,',
+            '-122.2353881,37.7223605,1360,S LOOP RD,,ALAMEDA,,,94502,,,',
+            '-122.2385597,37.7284071,3508,CATALINA AV,,ALAMEDA,,,94502,,,',
+            '-122.2368942,37.7305041,3512,MCSHERRY WY,,ALAMEDA,,,94502,,,',
+            '-122.2349371,37.7357455,514,FLOWER LA,,ALAMEDA,,,94502,,,',
+            '-122.2367819,37.7342157,1014,HOLLY ST,,ALAMEDA,,,94502,,,',
             ])
         
         # input5
         self.assertEqual(output_write_contents[8],
             [
-            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH',
-            '-104.6843547,39.5793748,26050,E JAMISON CIR N,, CO,,,80016-2056,,629e0367e92b4c47',
-            '-104.1139093,39.6761295,2050,S PEORIA CROSSING RD,, CO,,,,,28b370f54c8e40ef'
+            'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH,SRC_HASH',
+            '-104.6843547,39.5793748,26050,E JAMISON CIR N,, CO,,,80016-2056,,629e0367e92b4c47,s0rc1',
+            '-104.1139093,39.6761295,2050,S PEORIA CROSSING RD,, CO,,,,,28b370f54c8e40ef,s0rc3'
             ])
         self.assertEqual(output_write_contents[9],
             [
@@ -4363,7 +4363,7 @@ class TestTileIndex (unittest.TestCase):
         self.assertEqual(names, ['addresses.csv', 'LICENSE.txt'])
         
         lines = zipfile.read('addresses.csv').decode('utf8').split()
-        self.assertEqual(lines[0], 'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH,OA:Source')
+        self.assertEqual(lines[0], 'LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH,SRC_HASH,OA:Source')
         
         license = zipfile.read('LICENSE.txt').decode('utf8')
         self.assertEqual(license, summarize_result_licenses.return_value)

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -185,19 +185,19 @@ class TestConformTransforms (unittest.TestCase):
         r = row_transform_and_convert(d, { "n": "123", "s1": "MAPLE", "s2": "ST", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3" })
         self.assertEqual({"STREET": "MAPLE ST", "UNIT": "", "NUMBER": "123", "LON": "-119.2", "LAT": "39.3",
                           "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None, "ID": None,
-                          'HASH': 'eee8eb535bb20a03'}, r)
+                          'HASH': 'eee8eb535bb20a03', 'SRC_HASH': '7e3c'}, r)
 
         d = { "conform": { "street": ["s1", "s2"], "number": "n", "lon": "y", "lat": "x" }, "fingerprint": "0000" }
         r = row_transform_and_convert(d, { "n": "123", "s1": "MAPLE", "s2": "ST", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3" })
         self.assertEqual({"STREET": "MAPLE ST", "UNIT": "", "NUMBER": "123", "LON": "-119.2", "LAT": "39.3",
                           "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None, "ID": None,
-                          'HASH': 'eee8eb535bb20a03'}, r)
+                          'HASH': 'eee8eb535bb20a03', 'SRC_HASH': '7e3c'}, r)
 
         d = { "conform": { "number": {"function": "regexp", "field": "s", "pattern": "^(\\S+)" }, "street": { "function": "regexp", "field": "s", "pattern": "^(?:\\S+ )(.*)" }, "lon": "y", "lat": "x" }, "fingerprint": "0000" }
         r = row_transform_and_convert(d, { "s": "123 MAPLE ST", X_FIELDNAME: "-119.2", Y_FIELDNAME: "39.3" })
         self.assertEqual({"STREET": "MAPLE ST", "UNIT": "", "NUMBER": "123", "LON": "-119.2", "LAT": "39.3",
                           "CITY": None, "REGION": None, "DISTRICT": None, "POSTCODE": None, "ID": None,
-                          'HASH': 'eee8eb535bb20a03'}, r)
+                          'HASH': 'eee8eb535bb20a03', 'SRC_HASH': 'f669'}, r)
 
     def test_row_canonicalize_unit_and_number(self):
         r = row_canonicalize_unit_and_number({}, {"NUMBER": "324 ", "STREET": " OAK DR.", "UNIT": "1"})

--- a/openaddr/tests/parcels.py
+++ b/openaddr/tests/parcels.py
@@ -32,14 +32,14 @@ class TestParcelsUtils (unittest.TestCase):
             header, row = next(rows), next(rows)
             scraped = utils.scrape_csv_metadata(row, header, 'us/ca/berkeley.json')
         
-        self.assertEqual(scraped, {'CITY': 'BERKELEY', 'ID': '055 183213100', 'REGION': None, 'STREET': 'DANA ST', 'NUMBER': '2550', 'DISTRICT': None, 'LON': None, 'LAT': None, 'UNIT': '', 'POSTCODE': '94704', 'HASH': 'a9bab15763bb9f03'})
+        self.assertEqual(scraped, {'CITY': 'BERKELEY', 'ID': '055 183213100', 'REGION': None, 'STREET': 'DANA ST', 'NUMBER': '2550', 'DISTRICT': None, 'LON': None, 'LAT': None, 'UNIT': '', 'POSTCODE': '94704', 'HASH': 'a9bab15763bb9f03', 'SRC_HASH': 'f172'})
     
     def test_scrape_fiona_metadata(self):
         with fiona.open(filename('parcels/data/us/ca/berkeley/Parcels.shp')) as data:
             obj = next(data)
             scraped = utils.scrape_fiona_metadata(obj, 'us/ca/berkeley.json')
         
-        self.assertEqual(scraped, {'CITY': 'BERKELEY', 'ID': '055 183213100', 'REGION': None, 'STREET': 'DANA ST', 'NUMBER': '2550', 'DISTRICT': None, 'LON': None, 'LAT': None, 'UNIT': '', 'POSTCODE': '94704', 'HASH': 'a9bab15763bb9f03'})
+        self.assertEqual(scraped, {'CITY': 'BERKELEY', 'ID': '055 183213100', 'REGION': None, 'STREET': 'DANA ST', 'NUMBER': '2550', 'DISTRICT': None, 'LON': None, 'LAT': None, 'UNIT': '', 'POSTCODE': '94704', 'HASH': 'a9bab15763bb9f03', 'SRC_HASH': 'cb58'})
     
     def test_to_shapely_obj(self):
         with fiona.open(filename('parcels/data/us/ca/berkeley/Parcels.shp')) as data:
@@ -130,9 +130,9 @@ class TestParcelsParse (unittest.TestCase):
         with httmock.HTTMock(self.response_content):
             shapes = parse.parse_source(['us/ca/berkeley.json', 'http://data.openaddresses.io/runs/89894/cache.zip', 'http://data.openaddresses.io/runs/89894/sample.json', 'Polygon', '28805', '', '657a5b1add615a9f286321eb537de710', '0:00:02.766633', 'http://data.openaddresses.io/runs/89894/us/ca/berkeley.zip', '0:00:29.974332', 'http://data.openaddresses.io/runs/89894/output.txt', 'true', 'City of Berkeley', '', '2.19.7'], 0, ['source', 'cache', 'sample', 'geometry type', 'address count', 'version', 'fingerprint', 'cache time', 'processed', 'process time', 'output', 'attribution required', 'attribution name', 'share-alike', 'code version'])
         
-        self.assertEqual(shapes[0], {'geom': 'POLYGON ((565011.5815000003203750 4190878.6357499994337559, 565007.0689000003039837 4190904.8820000011473894, 565044.6956500001251698 4190911.2990000005811453, 565049.5083999997004867 4190885.2125000003725290, 565011.5815000003203750 4190878.6357499994337559))', 'LAT': None, 'STREET': 'DANA ST', 'POSTCODE': '94704', 'REGION': None, 'DISTRICT': None, 'LON': None, 'CITY': 'BERKELEY', 'ID': '055 183213100', 'UNIT': '', 'NUMBER': '2550', 'HASH': 'a9bab15763bb9f03'})
-        self.assertEqual(shapes[1], {'geom': 'POLYGON ((562519.8118000002577901 4190028.8390999995172024, 562504.6751500004902482 4190024.9286000002175570, 562496.8604500005021691 4190054.9737500008195639, 562511.5466499999165535 4190058.6435000002384186, 562518.1233999999240041 4190034.9662999995052814, 562519.8118000002577901 4190028.8390999995172024))', 'LAT': None, 'STREET': 'GRAYSON ST', 'POSTCODE': '94710', 'REGION': None, 'DISTRICT': None, 'LON': None, 'CITY': 'BERKELEY', 'ID': '053 166004000', 'UNIT': 'A', 'NUMBER': '1012', 'HASH': 'd5099c28ab0e2626'})
-        self.assertEqual(shapes[2], {'geom': 'POLYGON ((562519.8118000002577901 4190028.8390999995172024, 562504.6751500004902482 4190024.9286000002175570, 562496.8604500005021691 4190054.9737500008195639, 562511.5466499999165535 4190058.6435000002384186, 562518.1233999999240041 4190034.9662999995052814, 562519.8118000002577901 4190028.8390999995172024))', 'LAT': None, 'STREET': 'GRAYSON ST', 'POSTCODE': '94710', 'REGION': None, 'DISTRICT': None, 'LON': None, 'CITY': 'BERKELEY', 'ID': '053 166004200', 'UNIT': 'C', 'NUMBER': '1012', 'HASH': '36d415c8e8e95711'})
+        self.assertEqual(shapes[0], {'geom': 'POLYGON ((565011.5815000003203750 4190878.6357499994337559, 565007.0689000003039837 4190904.8820000011473894, 565044.6956500001251698 4190911.2990000005811453, 565049.5083999997004867 4190885.2125000003725290, 565011.5815000003203750 4190878.6357499994337559))', 'LAT': None, 'STREET': 'DANA ST', 'POSTCODE': '94704', 'REGION': None, 'DISTRICT': None, 'LON': None, 'CITY': 'BERKELEY', 'ID': '055 183213100', 'UNIT': '', 'NUMBER': '2550', 'HASH': 'a9bab15763bb9f03', 'SRC_HASH': 'cb58'})
+        self.assertEqual(shapes[1], {'geom': 'POLYGON ((562519.8118000002577901 4190028.8390999995172024, 562504.6751500004902482 4190024.9286000002175570, 562496.8604500005021691 4190054.9737500008195639, 562511.5466499999165535 4190058.6435000002384186, 562518.1233999999240041 4190034.9662999995052814, 562519.8118000002577901 4190028.8390999995172024))', 'LAT': None, 'STREET': 'GRAYSON ST', 'POSTCODE': '94710', 'REGION': None, 'DISTRICT': None, 'LON': None, 'CITY': 'BERKELEY', 'ID': '053 166004000', 'UNIT': 'A', 'NUMBER': '1012', 'HASH': 'd5099c28ab0e2626', 'SRC_HASH': '7c7f'})
+        self.assertEqual(shapes[2], {'geom': 'POLYGON ((562519.8118000002577901 4190028.8390999995172024, 562504.6751500004902482 4190024.9286000002175570, 562496.8604500005021691 4190054.9737500008195639, 562511.5466499999165535 4190058.6435000002384186, 562518.1233999999240041 4190034.9662999995052814, 562519.8118000002577901 4190028.8390999995172024))', 'LAT': None, 'STREET': 'GRAYSON ST', 'POSTCODE': '94710', 'REGION': None, 'DISTRICT': None, 'LON': None, 'CITY': 'BERKELEY', 'ID': '053 166004200', 'UNIT': 'C', 'NUMBER': '1012', 'HASH': '36d415c8e8e95711', 'SRC_HASH': 'd78c'})
         self.assertEqual(len(shapes), 3)
     
     def test_parse_statefile(self):


### PR DESCRIPTION
Introduces a new SRC_HASH column in OA output that’s a short 16-bit hash of the input data, so that similar nearby points coming from identical columns can be deduped.

Closes #594.