### PR TITLE
Stopped dropping properties in dotmap call to Tippecanoe

### DIFF
--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -41,7 +41,7 @@ def call_tippecanoe(mbtiles_filename):
     '''
     '''
     cmd = 'tippecanoe', '-r', '2', '-l', 'openaddresses', \
-          '-X', '-n', 'OpenAddresses {}'.format(str(date.today())), '-f', \
+          '-n', 'OpenAddresses {}'.format(str(date.today())), '-f', \
           '-t', gettempdir(), '-o', mbtiles_filename
     
     _L.info('Running tippcanoe: {}'.format(' '.join(cmd)))


### PR DESCRIPTION
The homepage map shows dot density, but it could also be used to investigate the dots themselves. This PR starts uploading a much larger MBTiles file to Mapbox, per conversation with @ingalls this morning.