### PR TITLE
Expand temp space available to Dotmap instances

### DIFF
--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -180,6 +180,7 @@ LC_ALL=C.UTF-8
     -d "#{database_url}" \
     -b "#{aws_s3_bucket}" \
     --sns-arn "#{aws_sns_arn}" \
+    --quiet \
   >> /var/log/openaddr_crontab/sum-up-data.log 2>&1
 CRONTAB
 end

--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -88,10 +88,10 @@ file "/etc/cron.d/openaddr_crontab-index-tiles" do
     content <<-CRONTAB
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 LC_ALL=C.UTF-8
-# Index into tiles, every third day at 11am UTC (4am PDT)
-0 11	*/3 * *	#{username}	\
+# Index into tiles, every seventh day at 11am UTC (4am PDT)
+0 11	*/7 * *	#{username}	\
   openaddr-run-ec2-command \
-  --hours 12 \
+  --hours 16 \
   -b "#{aws_s3_bucket}" \
   --sns-arn "#{aws_sns_arn}" \
   --verbose \

--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -113,7 +113,8 @@ LC_ALL=C.UTF-8
   openaddr-run-ec2-command \
   --role dotmap \
   --hours 16 \
-  --instance-type r3.xlarge \
+  --instance-type r3.large \
+  --temp-size 256 \
   -b "#{aws_s3_bucket}" \
   --sns-arn "#{aws_sns_arn}" \
   --verbose \

--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -41,7 +41,7 @@ def call_tippecanoe(mbtiles_filename):
     '''
     '''
     cmd = 'tippecanoe', '-r', '2', '-l', 'openaddresses', \
-          '-n', 'OpenAddresses {}'.format(str(date.today())), '-f', \
+          '-X', '-n', 'OpenAddresses {}'.format(str(date.today())), '-f', \
           '-t', gettempdir(), '-o', mbtiles_filename
     
     _L.info('Running tippcanoe: {}'.format(' '.join(cmd)))

--- a/openaddr/run_ec2_ami.py
+++ b/openaddr/run_ec2_ami.py
@@ -31,6 +31,9 @@ parser.add_argument('--hours', default=12, type=float,
 parser.add_argument('--instance-type', default='m3.medium',
                     help='EC2 instance type. Defaults to "m3.medium".')
 
+parser.add_argument('--temp-size', default=0,
+                    help='Optional size of EBS volume to map to /tmp.')
+
 parser.add_argument('-v', '--verbose', help='Turn on verbose logging',
                     action='store_const', dest='loglevel',
                     const=logging.DEBUG, default=logging.INFO)
@@ -53,7 +56,8 @@ def main():
     autoscale = connect_autoscale(None, None)
     instance = request_task_instance(ec2, autoscale, args.instance_type,
                                      args.role, lifespan, args.command,
-                                     args.bucket, args.sns_arn)
+                                     args.bucket, args.sns_arn,
+                                     tempsize=args.temp_size)
     
     _L.info('instance {} is off to the races.'.format(instance))
 


### PR DESCRIPTION
Replaces EC2 instance storage knowledge with dumber `--temp-size` flag to `openaddr-run-ec2-command`.

- [ ] Wait for complete test run of `openaddr-update-dotmap` to complete.

Closes #604.