### PR TITLE
Switched to using Docker runs for cron-driven processes

### DIFF
--- a/openaddr/run_ec2_ami.py
+++ b/openaddr/run_ec2_ami.py
@@ -23,7 +23,7 @@ parser.add_argument('--sns-arn', default=environ.get('AWS_SNS_ARN', None),
                     help='Optional AWS Simple Notification Service (SNS) resource. Defaults to value of AWS_SNS_ARN environment variable.')
 
 parser.add_argument('--role', default='openaddr',
-                    help='Machine chef role to execute. Defaults to "openaddr".')
+                    help='Deprecated Machine chef role to execute. Defaults to "openaddr".')
 
 parser.add_argument('--hours', default=12, type=float,
                     help='Number of hours to allow before giving up. Defaults to 12 hours.')

--- a/openaddr/tests/util.py
+++ b/openaddr/tests/util.py
@@ -86,7 +86,6 @@ class TestUtilities (unittest.TestCase):
         group, config, image = Mock(), Mock(), Mock()
         keypair, reservation, instance = Mock(), Mock(), Mock()
         
-        chef_role = 'good-times'
         command = 'openaddr-good-times', '--yo', 'b', 'd\\d', 'a"a', "s's", 'a:a'
         
         expected_group_name = 'CI Workers {0}.x'.format(*__version__.split('.'))
@@ -100,7 +99,7 @@ class TestUtilities (unittest.TestCase):
         image.run.return_value = reservation
         reservation.instances = [instance]
         
-        util.request_task_instance(ec2, autoscale, 'm3.medium', chef_role, 60, command, 'bucket-name', 'arn:aws:sns:null-island:etc.')
+        util.request_task_instance(ec2, autoscale, 'm3.medium', None, 60, command, 'bucket-name', 'arn:aws:sns:null-island:etc.')
         
         autoscale.get_all_groups.assert_called_once_with([expected_group_name])
         autoscale.get_all_launch_configurations.assert_called_once_with(names=[group.launch_config_name])
@@ -112,7 +111,6 @@ class TestUtilities (unittest.TestCase):
         self.assertEqual(image_run_kwargs['instance_initiated_shutdown_behavior'], 'terminate')
         self.assertEqual(image_run_kwargs['key_name'], keypair.name)
         
-        self.assertIn('chef/run.sh {}'.format(quote(chef_role)), image_run_kwargs['user_data'])
         self.assertIn('s3://bucket-name/logs/', image_run_kwargs['user_data'])
         self.assertIn("notify_sns 'Starting openaddr-good-times...'", image_run_kwargs['user_data'])
         self.assertIn('aws --region null-island sns publish --topic-arn arn:aws:sns:null-island:etc.',

--- a/openaddr/util/templates/task-instance-userdata.sh
+++ b/openaddr/util/templates/task-instance-userdata.sh
@@ -39,13 +39,9 @@ if [ -b /dev/xvdb ]; then
 fi
 
 # (Re)install machine.
-cd /home/ubuntu/machine
-sudo -u ubuntu git fetch origin {version}
-sudo -u ubuntu git checkout FETCH_HEAD
-
-chef/run.sh prereqs
-aws s3 cp s3://{bucket}/config/databag-4.json chef/data/local.json
-chef/run.sh {role}
+docker pull openaddr/machine:{version}
+aws s3 cp s3://data.openaddresses.io/config/environment-5.txt /tmp/environment
 
 # Run the actual command
-LC_ALL="C.UTF-8" {command} && shutdown_with_log 0 || shutdown_with_log 1 2>&1
+docker run --env-file /tmp/environment --volume /tmp:/tmp --net="host" openaddr/machine:{version} \
+    {command} && shutdown_with_log 0 || shutdown_with_log 1 2>&1


### PR DESCRIPTION
When starting an EC2 task instance, run under Docker instead of Chef. Keep Chef around for the moment for the Cronbox itself for now.