### PR TITLE
Throttle Cloudwatch logs

### DIFF
--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -27,9 +27,8 @@ from requests import get, post, ConnectionError
 from uritemplate import expand as expand_uri
 from dateutil.tz import tzutc
 from psycopg2 import connect
-from boto import connect_sns
-from boto import connect_logs
 from pq import PQ
+import boto
 
 # Ask Python 2 to get real unicode from the database.
 # http://initd.org/psycopg/docs/usage.html#unicode-handling
@@ -1131,7 +1130,7 @@ class SnsHandler(logging.Handler):
     '''
     def __init__(self, arn, *args, **kwargs):
         super(SnsHandler, self).__init__(*args, **kwargs)
-        self.arn, self.sns = arn, connect_sns()
+        self.arn, self.sns = arn, boto.connect_sns()
 
     def emit(self, record):
         subject = u'OpenAddr: {}: {}'.format(record.levelname, record.name)
@@ -1147,7 +1146,7 @@ class CloudwatchHandler(logging.Handler):
     def __init__(self, group_name, stream_name, *args, **kwargs):
         super(CloudwatchHandler, self).__init__(*args, **kwargs)
         self.group, self.stream = group_name, stream_name
-        self.logs, self.token = connect_logs(), None
+        self.logs, self.token = boto.connect_logs(), None
         self.logs.create_log_stream(self.group, self.stream)
     
     def _send(self, message):

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -31,7 +31,7 @@ from ..ci import (
     is_merged_to_master, get_commit_info, HEARTBEAT_QUEUE, flush_heartbeat_queue,
     get_recent_workers, load_config, get_batch_run_times, webauth, webcoverage,
     process_github_payload, skip_payload, is_rerun_payload, update_job_comments,
-    reset_logger
+    reset_logger, CloudwatchHandler
     )
 
 from ..ci.objects import (
@@ -4367,6 +4367,18 @@ class TestTileIndex (unittest.TestCase):
         
         license = zipfile.read('LICENSE.txt').decode('utf8')
         self.assertEqual(license, summarize_result_licenses.return_value)
+
+class TestLogging (unittest.TestCase):
+    
+    def test_cloudwatch(self):
+        with patch('boto.connect_logs') as connect_logs:
+            handler = CloudwatchHandler('group', 'stream')
+            logs = connect_logs.return_value
+        
+        logs.create_log_stream.assert_called_once_with('group', 'stream')
+        handler._send('Yo')
+        
+        print(logs.put_log_events.mock_calls)
 
 if __name__ == '__main__':
     unittest.main()

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -4376,9 +4376,19 @@ class TestLogging (unittest.TestCase):
             logs = connect_logs.return_value
         
         logs.create_log_stream.assert_called_once_with('group', 'stream')
+        logs.put_log_events.return_value = {'nextSequenceToken': 'token'}
+
         handler._send('Yo')
+        handler._send('Again')
         
-        print(logs.put_log_events.mock_calls)
+        send1, send2 = logs.put_log_events.mock_calls[-2:]
+        self.assertEqual(send1[1][:2], ('group', 'stream'))
+        self.assertEqual(send1[1][2][0]['message'], 'Yo')
+        self.assertIsNone(send1[1][3])
+        
+        self.assertEqual(send2[1][:2], ('group', 'stream'))
+        self.assertEqual(send2[1][2][0]['message'], 'Again')
+        self.assertEqual(send2[1][3], 'token')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -35,7 +35,7 @@ from openaddr.tests.coverage import TestCalculate
 
 from openaddr.tests.ci import (
     TestHook, TestRuns, TestWorker, TestBatch, TestObjects, TestCollect,
-    TestAPI, TestQueue, TestAuth, TestTileIndex
+    TestAPI, TestQueue, TestAuth, TestTileIndex, TestLogging
     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
When a rate limit exception is raised, save the log message and try again later.

Closes #612.