### PR TITLE
Move one EC2 task from cronbox to lambda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+  - master
 sudo: required
 services:
   - docker

--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -30,10 +30,6 @@ rotation = <<-ROTATION
 }
 ROTATION
 
-file "/etc/logrotate.d/openaddr_crontab-collect-extracts" do
-    content "/var/log/openaddr_crontab/collect-extracts.log\n#{rotation}\n"
-end
-
 file "/etc/logrotate.d/openaddr_crontab-index-tiles" do
     content "/var/log/openaddr_crontab/index-tiles.log\n#{rotation}\n"
 end
@@ -62,26 +58,6 @@ directory '/etc/cron.d'
 directory "/var/log/openaddr_crontab" do
   owner username
   mode "0755"
-end
-
-file "/etc/cron.d/openaddr_crontab-collect-extracts" do
-    content <<-CRONTAB
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-LC_ALL=C.UTF-8
-# Archive collection, every other day at 11am UTC (4am PDT)
-0 11	*/2 * *	#{username}	\
-  openaddr-run-ec2-command \
-  --hours 18 \
-  -b "#{aws_s3_bucket}" \
-  --sns-arn "#{aws_sns_arn}" \
-  --verbose \
-  -- \
-    openaddr-collect-extracts \
-    -d "#{database_url}" \
-    -b "#{aws_s3_bucket}" \
-    --sns-arn "#{aws_sns_arn}" \
-  >> /var/log/openaddr_crontab/collect-extracts.log 2>&1
-CRONTAB
 end
 
 file "/etc/cron.d/openaddr_crontab-index-tiles" do

--- a/openaddr/ci/coverage/calculate.py
+++ b/openaddr/ci/coverage/calculate.py
@@ -311,7 +311,7 @@ def calculate(DATABASE_URL):
                 summarize_country_coverage(db, iso_a2)
 
             for (index, usps_code) in enumerate(sorted(usps_codes)):
-                print('Counting up US:{} ({}/{})...'.format(usps_code, index+1, len(usps_codes)))
+                _L.info('Counting up US:{} ({}/{})...'.format(usps_code, index+1, len(usps_codes)))
                 summarize_us_state_coverage(db, usps_code)
 
     os.remove(filename)

--- a/ops/.gitignore
+++ b/ops/.gitignore
@@ -1,0 +1,2 @@
+run-ec2-command.zip
+temp-boto

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -1,0 +1,9 @@
+run-ec2-command.zip: run-ec2-command.py
+	rm -f $@
+	zip -j $@ ../openaddr/VERSION run-ec2-command.py \
+		../openaddr/util/templates/task-instance-userdata.sh
+
+	rm -rf temp-boto
+	pip3 install -t temp-boto 'boto == 2.43.0'
+	find temp-boto -name __pycache__ | xargs rm -rf
+	cd temp-boto && zip -r ../$@ boto

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -6,4 +6,4 @@ run-ec2-command.zip: run-ec2-command.py
 	rm -rf temp-boto
 	pip3 install -t temp-boto 'boto == 2.43.0'
 	find temp-boto -name __pycache__ | xargs rm -rf
-	cd temp-boto && zip -r ../$@ boto
+	cd temp-boto && zip -qr ../$@ boto

--- a/ops/run-ec2-command.py
+++ b/ops/run-ec2-command.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+import logging; _L = logging.getLogger(__name__)
+
+import boto, shlex
+from boto.ec2 import blockdevicemapping
+from os.path import join, dirname
+from datetime import datetime
+
+def get_version():
+    '''
+    '''
+    path = join(dirname(__file__), 'VERSION')
+    with open(path) as file:
+        return next(file).strip()
+
+def request_task_instance(ec2, autoscale, instance_type, lifespan, command, bucket, aws_sns_arn, tempsize=None):
+    '''
+    '''
+    group_name = 'CI Workers {0}.x'.format(*get_version().split('.'))
+
+    (group, ) = autoscale.get_all_groups([group_name])
+    (config, ) = autoscale.get_all_launch_configurations(names=[group.launch_config_name])
+    (image, ) = ec2.get_all_images(image_ids=[config.image_id])
+    keypair = [kp for kp in ec2.get_all_key_pairs() if kp.name.startswith('oa-')][0]
+
+    yyyymmdd = datetime.utcnow().strftime('%Y-%m-%d-%H-%M')
+    
+    with open(join(dirname(__file__), 'task-instance-userdata.sh')) as file:
+        userdata_kwargs = dict(
+            command = ' '.join(map(shlex.quote, command)),
+            lifespan = shlex.quote(str(lifespan)),
+            version = shlex.quote(get_version()),
+            log_prefix = shlex.quote('logs/{}-{}'.format(yyyymmdd, command[0])),
+            bucket = shlex.quote(bucket or 'data.openaddresses.io'),
+            aws_sns_arn = '', aws_region = '',
+            command_name = command[0]
+            )
+        
+        if aws_sns_arn:
+            try:
+                _, _, _, aws_region, _ = aws_sns_arn.split(':', 4)
+            except ValueError:
+                pass
+            else:
+                if aws_sns_arn.startswith('arn:aws:sns:'):
+                    userdata_kwargs.update(aws_sns_arn = shlex.quote(aws_sns_arn),
+                                           aws_region = shlex.quote(aws_region))
+    
+        device_map = blockdevicemapping.BlockDeviceMapping()
+
+        if tempsize:
+            dev_sdb = blockdevicemapping.BlockDeviceType(delete_on_termination=True)
+            dev_sdb.size = tempsize
+            device_map['/dev/sdb'] = dev_sdb
+
+        run_kwargs = dict(instance_type=instance_type, security_groups=['default'],
+                          instance_initiated_shutdown_behavior='terminate',
+                          user_data=file.read().format(**userdata_kwargs),
+                          # TODO: use current role from http://169.254.169.254/latest/meta-data/iam/info
+                          instance_profile_name='machine-communication',
+                          key_name=keypair.name, block_device_map=device_map)
+        
+    reservation = image.run(**run_kwargs)
+    (instance, ) = reservation.instances
+    
+    try:
+        instance.add_tag('Name', 'Scheduled {} {}'.format(yyyymmdd, command[0]))
+    except EC2ResponseError:
+        time.sleep(10)
+        try:
+            instance.add_tag('Name', 'Scheduled {} {}'.format(yyyymmdd, command[0]))
+        except EC2ResponseError:
+            time.sleep(10)
+            instance.add_tag('Name', 'Scheduled {} {}'.format(yyyymmdd, command[0]))
+    
+    _L.info('Started EC2 instance {} from AMI {}'.format(instance, image))
+    
+    return instance
+
+def main():
+    kwargs = dict(
+        ec2 = boto.connect_ec2(),
+        autoscale = boto.connect_autoscale(),
+        instance_type = 't2.nano',
+        lifespan = 600,
+        command = 'sleep 600'.split(),
+        bucket = 'data.openaddresses.io',
+        aws_sns_arn = 'arn:aws:sns:us-east-1:847904970422:CI-Events',
+        )
+    
+    return request_task_instance(**kwargs)
+
+def lambda_func(event, context):
+    return main()
+
+if __name__ == '__main__':
+    exit(main())

--- a/ops/update-scheduled-tasks.py
+++ b/ops/update-scheduled-tasks.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import boto3, json, sys
+
+COLLECT_RULE = 'OA-Collect-Extracts'
+COLLECT_RULE_TARGET_ID = 'OA-EC2-Run-Task'
+
+def main():
+    client = boto3.client('events')
+    
+    print('Updating rule', COLLECT_RULE, 'with target', COLLECT_RULE_TARGET_ID, '...', file=sys.stderr)
+    rule = client.describe_rule(Name=COLLECT_RULE)
+
+    client.put_rule(
+        Name = COLLECT_RULE,
+        Description = 'Archive collection, every other day at 11am UTC (4am PDT)',
+        ScheduleExpression = 'cron(0 11 */2 * ? *)', State = 'ENABLED',
+        )
+    
+    client.put_targets(
+        Rule = COLLECT_RULE,
+        Targets = [{
+            'Id': COLLECT_RULE_TARGET_ID,
+            'Arn': 'arn:aws:lambda:us-east-1:847904970422:function:OA-EC2-Run-Task',
+            'Input': json.dumps({
+                "command": ["openaddr-collect-extracts"], 
+                "hours": 18, "bucket": "data.openaddresses.io",
+                "sns-arn": "arn:aws:sns:us-east-1:847904970422:CI-Events"
+                })
+            }]
+        )
+
+if __name__ == '__main__':
+    exit(main())


### PR DESCRIPTION
Moved `openaddr-collect-extracts` task to a new equivalent `OA-Collect-Extracts` Cloudwatch rule and Lambda function `OA-EC2-Run-Task`. Part of #617.