### PR TITLE
Switched worker ID from uuid.getnode() to socket.gethostname()

### DIFF
--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -11,7 +11,7 @@ from . import objects, work, queuedata
 
 from os.path import relpath, splitext, join, basename
 from datetime import timedelta, datetime
-from uuid import uuid4, getnode
+from uuid import uuid4
 from urllib.parse import urljoin
 from base64 import b64decode
 from tempfile import mkdtemp
@@ -904,7 +904,7 @@ def is_merged_to_master(db, set_id, job_id, commit_sha, github_auth):
         return None
 
 def _worker_id():
-    return hex(getnode()).rstrip('L')
+    return socket.gethostname()
 
 def _wait_for_work_lock(lock, heartbeat_queue):
     ''' Wait around for worker while sending heartbeat pings.

--- a/openaddr/ci/schema.pgsql
+++ b/openaddr/ci/schema.pgsql
@@ -58,7 +58,7 @@ CREATE TABLE runs
     copy_of             INTEGER REFERENCES runs(id) NULL,
 
     code_version        VARCHAR(8) NULL,
-    worker_id           VARCHAR(16) NULL,
+    worker_id           VARCHAR(32) NULL,
     job_id              VARCHAR(40) REFERENCES jobs(id) NULL,
     set_id              INTEGER REFERENCES sets(id) NULL,
     commit_sha          VARCHAR(40) NULL,


### PR DESCRIPTION
The old way was creating duplicate worker IDs under Docker. This should be slightly smarter.