### PR TITLE
Move second EC2 task from cronbox to lambda

### DIFF
--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -42,10 +42,6 @@ file "/etc/logrotate.d/openaddr_crontab-enqueue-sources" do
     content "/var/log/openaddr_crontab/enqueue-sources.log\n#{rotation}\n"
 end
 
-file "/etc/logrotate.d/openaddr_crontab-calculate-coverage" do
-    content "/var/log/openaddr_crontab/calculate-coverage.log\n#{rotation}\n"
-end
-
 file "/etc/logrotate.d/openaddr_crontab-sum-up-data" do
     content "/var/log/openaddr_crontab/sum-up-data.log\n#{rotation}\n"
 end
@@ -123,26 +119,6 @@ LC_ALL=C.UTF-8
     --sns-arn "#{aws_sns_arn}" \
     --cloudwatch-ns "#{aws_cloudwatch_ns}" \
   >> /var/log/openaddr_crontab/enqueue-sources.log 2>&1
-CRONTAB
-end
-
-file "/etc/cron.d/openaddr_crontab-calculate-coverage" do
-    content <<-CRONTAB
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-LC_ALL=C.UTF-8
-# Update coverage page data, every third day at 11am UTC (4am PDT)
-0 11	*/3 * *	#{username}	\
-  openaddr-run-ec2-command \
-  --hours 3 \
-  --instance-type t2.nano \
-  -b "#{aws_s3_bucket}" \
-  --sns-arn "#{aws_sns_arn}" \
-  --verbose \
-  -- \
-    openaddr-calculate-coverage \
-    -d "#{database_url}" \
-    --sns-arn "#{aws_sns_arn}" \
-  >> /var/log/openaddr_crontab/calculate-coverage.log 2>&1
 CRONTAB
 end
 

--- a/ops/update-scheduled-tasks.py
+++ b/ops/update-scheduled-tasks.py
@@ -2,12 +2,12 @@
 import boto3, json, sys
 
 COLLECT_RULE = 'OA-Collect-Extracts'
-COLLECT_RULE_TARGET_ID = 'OA-EC2-Run-Task'
+EC2_RUN_TARGET_ID = 'OA-EC2-Run-Task'
 
 def main():
     client = boto3.client('events')
     
-    print('Updating rule', COLLECT_RULE, 'with target', COLLECT_RULE_TARGET_ID, '...', file=sys.stderr)
+    print('Updating rule', COLLECT_RULE, 'with target', EC2_RUN_TARGET_ID, '...', file=sys.stderr)
     rule = client.describe_rule(Name=COLLECT_RULE)
 
     client.put_rule(
@@ -18,15 +18,15 @@ def main():
     
     client.put_targets(
         Rule = COLLECT_RULE,
-        Targets = [{
-            'Id': COLLECT_RULE_TARGET_ID,
-            'Arn': 'arn:aws:lambda:us-east-1:847904970422:function:OA-EC2-Run-Task',
-            'Input': json.dumps({
+        Targets = [dict(
+            Id = EC2_RUN_TARGET_ID,
+            Arn = 'arn:aws:lambda:us-east-1:847904970422:function:OA-EC2-Run-Task',
+            Input = json.dumps({
                 "command": ["openaddr-collect-extracts"], 
                 "hours": 18, "bucket": "data.openaddresses.io",
                 "sns-arn": "arn:aws:sns:us-east-1:847904970422:CI-Events"
                 })
-            }]
+            )]
         )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Moved `openaddr-calculate-coverage` task to a new equivalent `OA-Calculate-Coverage` Cloudwatch rule. Added version support to `OA-EC2-Run-Task ` function. Part of #617.