### PR TITLE
Move third EC2 task from cronbox to lambda

### DIFF
--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -34,10 +34,6 @@ file "/etc/logrotate.d/openaddr_crontab-index-tiles" do
     content "/var/log/openaddr_crontab/index-tiles.log\n#{rotation}\n"
 end
 
-file "/etc/logrotate.d/openaddr_crontab-dotmap" do
-    content "/var/log/openaddr_crontab/dotmap.log\n#{rotation}\n"
-end
-
 file "/etc/logrotate.d/openaddr_crontab-enqueue-sources" do
     content "/var/log/openaddr_crontab/enqueue-sources.log\n#{rotation}\n"
 end
@@ -73,29 +69,6 @@ LC_ALL=C.UTF-8
     -b "#{aws_s3_bucket}" \
     --sns-arn "#{aws_sns_arn}" \
   >> /var/log/openaddr_crontab/index-tiles.log 2>&1
-CRONTAB
-end
-
-file "/etc/cron.d/openaddr_crontab-dotmap" do
-    content <<-CRONTAB
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-LC_ALL=C.UTF-8
-# Generate OpenAddresses dot map, every fifth day at 11am UTC (4am PDT)
-0 11	*/5 * *	#{username}	\
-  openaddr-run-ec2-command \
-  --role dotmap \
-  --hours 16 \
-  --instance-type r3.large \
-  --temp-size 256 \
-  -b "#{aws_s3_bucket}" \
-  --sns-arn "#{aws_sns_arn}" \
-  --verbose \
-  -- \
-    openaddr-update-dotmap \
-    -d "#{database_url}" \
-    -m "#{mapbox_key}" \
-    --sns-arn "#{aws_sns_arn}" \
-  >> /var/log/openaddr_crontab/dotmap.log 2>&1
 CRONTAB
 end
 

--- a/ops/run-ec2-command.py
+++ b/ops/run-ec2-command.py
@@ -19,7 +19,7 @@ def get_version():
     with open(first_file(version_paths)) as file:
         return next(file).strip()
 
-def request_task_instance(ec2, autoscale, instance_type, lifespan, command, bucket, aws_sns_arn, version, tempsize=None):
+def request_task_instance(ec2, autoscale, instance_type, lifespan, command, bucket, aws_sns_arn, version, tempsize):
     '''
     '''
     group_name = 'CI Workers {0}.x'.format(*version.split('.'))
@@ -97,6 +97,7 @@ def main():
         bucket = 'data.openaddresses.io',
         aws_sns_arn = 'arn:aws:sns:us-east-1:847904970422:CI-Events',
         version = get_version(),
+        tempsize = None,
         )
     
     return request_task_instance(ec2, autoscale, **kwargs)
@@ -112,6 +113,7 @@ def lambda_func(event, context):
         bucket = event.get('bucket', os.environ.get('AWS_S3_BUCKET')),
         aws_sns_arn = event.get('sns-arn', os.environ.get('AWS_SNS_ARN')),
         version = event.get('version', get_version()),
+        tempsize = event.get('temp_size', None),
         )
     
     return str(request_task_instance(ec2, autoscale, **kwargs))

--- a/ops/update-scheduled-tasks.py
+++ b/ops/update-scheduled-tasks.py
@@ -3,6 +3,7 @@ import boto3, json, sys
 
 COLLECT_RULE = 'OA-Collect-Extracts'
 CALCULATE_RULE = 'OA-Calculate-Coverage'
+DOTMAP_RULE = 'OA-Update-Dotmap'
 EC2_RUN_TARGET_ID = 'OA-EC2-Run-Task'
 EC2_RUN_TARGET_ARN = 'arn:aws:lambda:us-east-1:847904970422:function:OA-EC2-Run-Task'
 SNS_ARN = "arn:aws:sns:us-east-1:847904970422:CI-Events"
@@ -48,6 +49,28 @@ def main():
             Input = json.dumps({
                 "command": ["openaddr-calculate-coverage"],
                 "hours": 3, "instance-type": "t2.nano",
+                "bucket": "data.openaddresses.io", "sns-arn": SNS_ARN
+                })
+            )]
+        )
+
+    print('Updating rule', DOTMAP_RULE, 'with target', EC2_RUN_TARGET_ID, '...', file=sys.stderr)
+    rule = client.describe_rule(Name=DOTMAP_RULE)
+
+    client.put_rule(
+        Name = DOTMAP_RULE,
+        Description = 'Generate OpenAddresses dot map, every fifth day at 11am UTC (4am PDT)',
+        ScheduleExpression = 'cron(0 11 */5 * ? *)', State = 'ENABLED',
+        )
+    
+    client.put_targets(
+        Rule = DOTMAP_RULE,
+        Targets = [dict(
+            Id = EC2_RUN_TARGET_ID,
+            Arn = EC2_RUN_TARGET_ARN,
+            Input = json.dumps({
+                "command": ["openaddr-update-dotmap"],
+                "hours": 16, "instance-type": "r3.large", "temp-size": 256,
                 "bucket": "data.openaddresses.io", "sns-arn": SNS_ARN
                 })
             )]


### PR DESCRIPTION
Moved `openaddr-update-dotmap` task to a new equivalent `OA-Update-Dotmap` Cloudwatch rule. Added temp-size support to `OA-EC2-Run-Task ` function. Part of #617.