### PR TITLE
Move fifth EC2 task from cronbox to lambda

### DIFF
--- a/chef/crontab/recipes/default.rb
+++ b/chef/crontab/recipes/default.rb
@@ -30,10 +30,6 @@ rotation = <<-ROTATION
 }
 ROTATION
 
-file "/etc/logrotate.d/openaddr_crontab-enqueue-sources" do
-    content "/var/log/openaddr_crontab/enqueue-sources.log\n#{rotation}\n"
-end
-
 file "/etc/logrotate.d/openaddr_crontab-sum-up-data" do
     content "/var/log/openaddr_crontab/sum-up-data.log\n#{rotation}\n"
 end
@@ -46,29 +42,6 @@ directory '/etc/cron.d'
 directory "/var/log/openaddr_crontab" do
   owner username
   mode "0755"
-end
-
-file "/etc/cron.d/openaddr_crontab-enqueue-sources" do
-    content <<-CRONTAB
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-LC_ALL=C.UTF-8
-# Enqueue sources, Fridays 11pm UTC (4pm PDT)
-0 23	* * fri	#{username}	\
-  openaddr-run-ec2-command \
-  --hours 60 \
-  --instance-type t2.nano \
-  -b "#{aws_s3_bucket}" \
-  --sns-arn "#{aws_sns_arn}" \
-  --verbose \
-  -- \
-    openaddr-enqueue-sources \
-    -d "#{database_url}" \
-    -t "#{github_token}" \
-    -b "#{aws_s3_bucket}" \
-    --sns-arn "#{aws_sns_arn}" \
-    --cloudwatch-ns "#{aws_cloudwatch_ns}" \
-  >> /var/log/openaddr_crontab/enqueue-sources.log 2>&1
-CRONTAB
 end
 
 file "/etc/cron.d/openaddr_crontab-sum-up-data" do

--- a/ops/update-scheduled-tasks.py
+++ b/ops/update-scheduled-tasks.py
@@ -2,6 +2,7 @@
 import boto3, json, sys
 from os.path import join, dirname, exists
 
+ENQUEUE_RULE = 'OA-Enqueue-Sources'
 COLLECT_RULE = 'OA-Collect-Extracts'
 CALCULATE_RULE = 'OA-Calculate-Coverage'
 DOTMAP_RULE = 'OA-Update-Dotmap'
@@ -25,6 +26,14 @@ def main():
     print('Found version', version)
 
     rules = {
+        ENQUEUE_RULE: dict(
+            cron = 'cron(0 23 ? * fri *)',
+            description = 'Enqueue sources, Fridays 11pm UTC (4pm PDT)',
+            input = {
+                "command": ["openaddr-enqueue-sources"],
+                "hours": 60, "instance-type": "t2.nano",
+                "bucket": LOG_BUCKET, "sns-arn": SNS_ARN, "version": version
+                }),
         COLLECT_RULE: dict(
             cron = 'cron(0 11 */2 * ? *)',
             description = 'Archive collection, every other day at 11am UTC (4am PDT)',


### PR DESCRIPTION
Moved `openaddr-enqueue-sources` task to a new equivalent `OA-Enqueue-Sources` Cloudwatch rule. Added explicit version number to `update-scheduled-tasks.py` to a loop. Part of #617.