### PR TITLE
Creating two Tippecanoe tilesets and merging them

### DIFF
--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -200,10 +200,9 @@ def main():
     results = iterate_local_processed_files(runs)
     
     for feature in stream_all_features(results):
-        tippecanoe_hi.stdin.write(json.dumps(feature).encode('utf8'))
-        tippecanoe_lo.stdin.write(json.dumps(feature).encode('utf8'))
-        tippecanoe_hi.stdin.write(b'\n')
-        tippecanoe_lo.stdin.write(b'\n')
+        line = json.dumps(feature).encode('utf8') + b'\n'
+        tippecanoe_hi.stdin.write(line)
+        tippecanoe_lo.stdin.write(line)
     
     tippecanoe_hi.stdin.close()
     tippecanoe_lo.stdin.close()

--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -40,17 +40,21 @@ def connect_db(dsn):
 def call_tippecanoe(mbtiles_filename, include_properties=True):
     '''
     '''
-    cmd = 'tippecanoe', '-r', '2', '-l', 'openaddresses', \
-          '-n', 'OpenAddresses {}'.format(str(date.today())), '-f', \
-          '-t', gettempdir(), '-o', mbtiles_filename
+    zoom = 14
+    
+    cmd = 'tippecanoe', '--drop-rate', '2', '--layer', 'openaddresses', \
+          '--name', 'OpenAddresses {}'.format(str(date.today())), '--force', \
+          '--temporary-directory', gettempdir(), '--output', mbtiles_filename
     
     if include_properties:
         full_cmd = cmd + (
             '--include', 'NUMBER', '--include', 'STREET', '--include', 'UNIT',
-            '--maximum-zoom', '14', '--minimum-zoom', '14'
+            '--maximum-zoom', str(zoom), '--minimum-zoom', str(zoom)
             )
     else:
-        full_cmd = cmd + ('--exclude-all', '--maximum-zoom', '13')
+        full_cmd = cmd + (
+            '--exclude-all', '--maximum-zoom', str(zoom - 1), '--base-zoom', str(zoom)
+            )
     
     _L.info('Running tippcanoe: {}'.format(' '.join(full_cmd)))
     

--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -210,6 +210,8 @@ def _mapbox_wait_for_upload(id, username, api_key):
 
 parser = ArgumentParser(description='Make a dot map.')
 
+parser.add_argument('-t', '--tileset-id', help='Deprecated option kept for backward-compatibility.')
+
 parser.add_argument('-o', '--owner', default='openaddresses',
                     help='Github repository owner. Defaults to "openaddresses".')
 

--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -66,6 +66,9 @@ def join_tilesets(out_filename, in1_filename, in2_filename):
     proc = subprocess.Popen(cmd, bufsize=1)
     proc.wait()
 
+    if proc.returncode != 0:
+        raise RuntimeError('Tile-join command returned {}'.format(proc.returncode))
+
 def mapbox_upload(mbtiles_path, tileset, username, api_key):
     ''' Upload MBTiles file to a tileset on Mapbox API.
     
@@ -202,6 +205,11 @@ def main():
     tippecanoe_lo.stdin.close()
     tippecanoe_hi.wait()
     tippecanoe_lo.wait()
+    
+    if tippecanoe_hi.returncode != 0:
+        raise RuntimeError('High-zoom Tippecanoe command returned {}'.format(tippecanoe_hi.returncode))
+    elif tippecanoe_lo.returncode != 0:
+        raise RuntimeError('Low-zoom Tippecanoe command returned {}'.format(tippecanoe_lo.returncode))
 
     join_tilesets(mbtiles_filename, mbtiles_filename_hi, mbtiles_filename_lo)
     mapbox_upload(mbtiles_filename, args.tileset_id, args.mapbox_user, args.mapbox_key)

--- a/openaddr/tests/dotmap.py
+++ b/openaddr/tests/dotmap.py
@@ -83,12 +83,14 @@ class TestDotmap (unittest.TestCase):
         
         self.assertEqual('tippecanoe', cmd1[0])
         self.assertEqual('tippecanoe', cmd2[0])
-        self.assertEqual(('-o', 'oa.mbtiles'), cmd1[10:12])
-        self.assertEqual(('-o', 'oa.mbtiles'), cmd2[10:12])
+        self.assertEqual(('--output', 'oa.mbtiles'), cmd1[10:12])
+        self.assertEqual(('--output', 'oa.mbtiles'), cmd2[10:12])
         self.assertIn('OpenAddresses {}'.format(str(date.today())), cmd1)
         self.assertIn('OpenAddresses {}'.format(str(date.today())), cmd2)
         
-        self.assertEqual(cmd1[-3:], ('--exclude-all', '--maximum-zoom', '13'))
+        self.assertEqual(cmd1[-5:], (
+            '--exclude-all', '--maximum-zoom', '13', '--base-zoom', '14'
+            ))
         self.assertEqual(cmd2[-10:], (
             '--include', 'NUMBER', '--include', 'STREET', '--include', 'UNIT',
             '--maximum-zoom', '14', '--minimum-zoom', '14'

--- a/openaddr/tests/dotmap.py
+++ b/openaddr/tests/dotmap.py
@@ -73,15 +73,26 @@ class TestDotmap (unittest.TestCase):
         '''
         '''
         with mock.patch('subprocess.Popen') as Popen:
-            call_tippecanoe('oa.mbtiles')
+            call_tippecanoe('oa.mbtiles', False)
+            call_tippecanoe('oa.mbtiles', True)
         
-        self.assertEqual(len(Popen.mock_calls), 1)
+        self.assertEqual(len(Popen.mock_calls), 2)
         
-        cmd = Popen.mock_calls[0][1][0]
+        cmd1 = Popen.mock_calls[0][1][0]
+        cmd2 = Popen.mock_calls[1][1][0]
         
-        self.assertEqual('tippecanoe', cmd[0])
-        self.assertEqual(('-o', 'oa.mbtiles'), cmd[-2:])
-        self.assertIn('OpenAddresses {}'.format(str(date.today())), cmd)
+        self.assertEqual('tippecanoe', cmd1[0])
+        self.assertEqual('tippecanoe', cmd2[0])
+        self.assertEqual(('-o', 'oa.mbtiles'), cmd1[10:12])
+        self.assertEqual(('-o', 'oa.mbtiles'), cmd2[10:12])
+        self.assertIn('OpenAddresses {}'.format(str(date.today())), cmd1)
+        self.assertIn('OpenAddresses {}'.format(str(date.today())), cmd2)
+        
+        self.assertEqual(cmd1[-3:], ('--exclude-all', '--maximum-zoom', '13'))
+        self.assertEqual(cmd2[-10:], (
+            '--include', 'NUMBER', '--include', 'STREET', '--include', 'UNIT',
+            '--maximum-zoom', '14', '--minimum-zoom', '14'
+            ))
     
     def response_content(self, url, request):
         '''

--- a/openaddr/tests/dotmap.py
+++ b/openaddr/tests/dotmap.py
@@ -89,11 +89,11 @@ class TestDotmap (unittest.TestCase):
         self.assertIn('OpenAddresses {}'.format(str(date.today())), cmd2)
         
         self.assertEqual(cmd1[-5:], (
-            '--exclude-all', '--maximum-zoom', '13', '--base-zoom', '14'
+            '--exclude-all', '--maximum-zoom', '14', '--base-zoom', '15'
             ))
         self.assertEqual(cmd2[-10:], (
             '--include', 'NUMBER', '--include', 'STREET', '--include', 'UNIT',
-            '--maximum-zoom', '14', '--minimum-zoom', '14'
+            '--maximum-zoom', '15', '--minimum-zoom', '15'
             ))
     
     def response_content(self, url, request):

--- a/ops/update-scheduled-tasks.py
+++ b/ops/update-scheduled-tasks.py
@@ -58,11 +58,11 @@ def main():
                 "bucket": LOG_BUCKET, "sns-arn": SNS_ARN, "version": version
                 }),
         DOTMAP_RULE: dict(
-            cron = 'cron(0 11 */5 * ? *)',
-            description = 'Generate OpenAddresses dot map, every fifth day at 11am UTC (4am PDT)',
+            cron = 'cron(0 11 1-30/10 * ? *)',
+            description = 'Generate OpenAddresses dot map, every tenth day at 11am UTC (4am PDT)',
             input = {
                 "command": ["openaddr-update-dotmap"],
-                "hours": 16, "instance-type": "r3.large", "temp-size": 256,
+                "hours": 48, "instance-type": "r3.large", "temp-size": 256,
                 "bucket": LOG_BUCKET, "sns-arn": SNS_ARN, "version": version
                 }),
         TILEINDEX_RULE: dict(


### PR DESCRIPTION
We added properties to the dotmap output in https://github.com/openaddresses/machine/pull/620, and then removed them again in https://github.com/openaddresses/machine/commit/b45f73a251bbb6ebdc1ccba517b717f791d49e37 when the output cracked the 500KB-per-tile limit. This change attempts to introduce properties only at the highest zoom level, 14, per advice from @ericfischer on using `tile-join` to combine tilesets built with different property settings.

- [x] Get feedback on this approach
- [x] Figure out what to do about the missing tileset name (if anything)
- [x] Wait for test run to complete, hopefully successfully

Closes #626.