### PR TITLE
"chain" conform function

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -1072,9 +1072,25 @@ def row_fxn_format(sd, row, key, fxn):
 
 def row_fxn_chain(sd, row, key, fxn):
     functions = fxn["functions"]
+    var = fxn.get("variable")
+
+    original_key = key
+
+    if var and var not in attrib_types and var.lstrip('OA:') not in attrib_types and var not in row:
+        attrib_types[var] = var
+        row[attrib_types[var]] = u''
+        key = var
+    else:
+        var = None
 
     for func in functions:
         row = row_function(sd, row, key, func)
+
+    row[attrib_types[original_key]] = row[attrib_types[key]]
+
+    if var:
+        row.pop(attrib_types[var])
+        attrib_types.pop(var)
 
     return row
 

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -18,7 +18,7 @@ from ..conform import (
     row_fxn_regexp, row_smash_case, row_round_lat_lon, row_merge,
     row_extract_and_reproject, row_convert_to_out, row_fxn_join, row_fxn_format,
     row_fxn_prefixed_number, row_fxn_postfixed_street,
-    row_fxn_remove_prefix, row_fxn_remove_postfix,
+    row_fxn_remove_prefix, row_fxn_remove_postfix, row_fxn_chain,
     row_canonicalize_unit_and_number, conform_smash_case, conform_cli,
     convert_regexp_replace, conform_license,
     conform_attribution, conform_sharealike, normalize_ogr_filename_case,
@@ -75,14 +75,14 @@ class TestConformTransforms (unittest.TestCase):
         d = { "a1": "va1", "b1": "vb1", "b2": "vb2" }
         e = copy.deepcopy(d)
         e.update({ "OA:number": "va1", "OA:street": "vb1-vb2" })
-        d = row_fxn_join(c, d, "number")
-        d = row_fxn_join(c, d, "street")
+        d = row_fxn_join(c, d, "number", c["conform"]["number"])
+        d = row_fxn_join(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
         d = { "a1": "va1", "b1": "vb1", "b2": None}
         e = copy.deepcopy(d)
         e.update({ "OA:number": "va1", "OA:street": "vb1" })
-        d = row_fxn_join(c, d, "number")
-        d = row_fxn_join(c, d, "street")
+        d = row_fxn_join(c, d, "number", c["conform"]["number"])
+        d = row_fxn_join(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
     def test_row_fxn_format(self):
@@ -101,18 +101,47 @@ class TestConformTransforms (unittest.TestCase):
 
         d = {"a1": "12", "a2": "34", "a3": "56", "b1": "1", "b2": "B", "b3": "3"}
         e = copy.deepcopy(d)
-        d = row_fxn_format(c, d, "number")
-        d = row_fxn_format(c, d, "street")
+        d = row_fxn_format(c, d, "number", c["conform"]["number"])
+        d = row_fxn_format(c, d, "street", c["conform"]["street"])
         self.assertEqual(d.get("OA:number", ""), "12-34-56")
         self.assertEqual(d.get("OA:street", ""), "foo 1B-3 bar")
 
         d = copy.deepcopy(e)
         d["a2"] = None
         d["b3"] = None
-        d = row_fxn_format(c, d, "number")
-        d = row_fxn_format(c, d, "street")
+        d = row_fxn_format(c, d, "number", c["conform"]["number"])
+        d = row_fxn_format(c, d, "street", c["conform"]["street"])
         self.assertEqual(d.get("OA:number", ""), "12-56")
         self.assertEqual(d.get("OA:street", ""), "foo 1B bar")
+
+    def test_row_fxn_chain(self):
+        c = { "conform": {
+            "number": {
+                "function": "chain",
+                "functions": [
+                    {
+                        "function": "format",
+                        "fields": ["a1", "a2", "a3"],
+                        "format": "$1-$2-$3"
+                    },
+                    {
+                        "function": "remove_postfix",
+                        "field": "OA:number",
+                        "field_to_remove": "b1"
+                    }
+                ]
+            }
+        } }
+
+        d = {"a1": "12", "a2": "34", "a3": "56 UNIT 5", "b1": "UNIT 5"}
+        e = copy.deepcopy(d)
+        d = row_fxn_chain(c, d, "number", c["conform"]["number"])
+        self.assertEqual(d.get("OA:number", ""), "12-34-56")
+
+        d = copy.deepcopy(e)
+        d["a2"] = None
+        d = row_fxn_chain(c, d, "number", c["conform"]["number"])
+        self.assertEqual(d.get("OA:number", ""), "12-56")
 
     def test_row_fxn_regexp(self):
         "Regex split - replace"
@@ -134,8 +163,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123", "OA:street": "MAPLE ST" })
         
-        d = row_fxn_regexp(c, d, "number")
-        d = row_fxn_regexp(c, d, "street")
+        d = row_fxn_regexp(c, d, "number", c["conform"]["number"])
+        d = row_fxn_regexp(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
         
         "Regex split - no replace - good match"
@@ -155,8 +184,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123", "OA:street": "MAPLE ST" })
         
-        d = row_fxn_regexp(c, d, "number")
-        d = row_fxn_regexp(c, d, "street")
+        d = row_fxn_regexp(c, d, "number", c["conform"]["number"])
+        d = row_fxn_regexp(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "regex split - no replace - bad match"
@@ -176,8 +205,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123", "OA:street": "" })
         
-        d = row_fxn_regexp(c, d, "number")
-        d = row_fxn_regexp(c, d, "street")
+        d = row_fxn_regexp(c, d, "number", c["conform"]["number"])
+        d = row_fxn_regexp(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
         
     def test_transform_and_convert(self):
@@ -293,8 +322,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123", "OA:street": "MAPLE ST" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "Regex prefixed_number and postfixed_street - no number"
@@ -312,8 +341,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "", "OA:street": "MAPLE ST" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "Regex prefixed_number and postfixed_street - empty input"
@@ -331,8 +360,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "", "OA:street": "" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "Regex prefixed_number and postfixed_street - no spaces after number"
@@ -350,8 +379,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "", "OA:street": "123MAPLE ST" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "Regex prefixed_number and postfixed_street - excess whitespace"
@@ -369,8 +398,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123", "OA:street": "MAPLE ST" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
     
         "Regex prefixed_number and postfixed_number - ordinal street w/house number"
@@ -388,8 +417,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "12", "OA:street": "3RD ST" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "Regex prefixed_number and postfixed_number - ordinal street w/o house number"
@@ -407,8 +436,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "", "OA:street": "3RD ST" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "Regex prefixed_number and postfixed_number - combined house number and suffix"
@@ -426,8 +455,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123A", "OA:street": "3RD ST" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "Regex prefixed_number and postfixed_number - hyphenated house number and suffix"
@@ -445,8 +474,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123-A", "OA:street": "3RD ST" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "Regex prefixed_number and postfixed_number - queens-style house number"
@@ -464,8 +493,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123-45", "OA:street": "3RD ST" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "Regex prefixed_number and postfixed_number - should be case-insenstive"
@@ -483,8 +512,8 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:number": "123-a", "OA:street": "3rD St" })
 
-        d = row_fxn_prefixed_number(c, d, "number")
-        d = row_fxn_postfixed_street(c, d, "street")
+        d = row_fxn_prefixed_number(c, d, "number", c["conform"]["number"])
+        d = row_fxn_postfixed_street(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
     def test_row_fxn_remove_prefix(self):
@@ -500,7 +529,7 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:street": "MAPLE ST" })
 
-        d = row_fxn_remove_prefix(c, d, "street")
+        d = row_fxn_remove_prefix(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "remove_prefix - field_to_remove is not a prefix"
@@ -515,7 +544,7 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:street": "123 MAPLE ST" })
 
-        d = row_fxn_remove_prefix(c, d, "street")
+        d = row_fxn_remove_prefix(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "remove_prefix - field_to_remove value is empty string"
@@ -530,7 +559,7 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:street": "123 MAPLE ST" })
 
-        d = row_fxn_remove_prefix(c, d, "street")
+        d = row_fxn_remove_prefix(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
     def test_row_fxn_remove_postfix(self):
@@ -546,7 +575,7 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:street": "MAPLE ST" })
 
-        d = row_fxn_remove_postfix(c, d, "street")
+        d = row_fxn_remove_postfix(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "remove_postfix - field_to_remove is not a postfix"
@@ -561,7 +590,7 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:street": "123 MAPLE ST" })
 
-        d = row_fxn_remove_postfix(c, d, "street")
+        d = row_fxn_remove_postfix(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
         "remove_postfix - field_to_remove value is empty string"
@@ -576,7 +605,7 @@ class TestConformTransforms (unittest.TestCase):
         e = copy.deepcopy(d)
         e.update({ "OA:street": "123 MAPLE ST" })
 
-        d = row_fxn_remove_postfix(c, d, "street")
+        d = row_fxn_remove_postfix(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
 class TestConformCli (unittest.TestCase):

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -143,6 +143,48 @@ class TestConformTransforms (unittest.TestCase):
         d = row_fxn_chain(c, d, "number", c["conform"]["number"])
         self.assertEqual(d.get("OA:number", ""), "12-56")
 
+
+    def test_row_fxn_chain_nested(self):
+        c = { "conform": {
+            "number": {
+                "function": "chain",
+                "variable": "foo",
+                "functions": [
+                    {
+                        "function": "format",
+                        "fields": ["a1", "a2"],
+                        "format": "$1-$2"
+                    },
+                    {
+                        "function": "chain",
+                        "variable": "bar",
+                        "functions": [
+                            {
+                                "function": "format",
+                                "fields": ["foo", "a3"],
+                                "format": "$1-$2"
+                            },
+                            {
+                                "function": "remove_postfix",
+                                "field": "bar",
+                                "field_to_remove": "b1"
+                            }
+                        ]
+                    }
+                ]
+            }
+        } }
+
+        d = {"a1": "12", "a2": "34", "a3": "56 UNIT 5", "b1": "UNIT 5"}
+        e = copy.deepcopy(d)
+        d = row_fxn_chain(c, d, "number", c["conform"]["number"])
+        self.assertEqual(d.get("OA:number", ""), "12-34-56")
+
+        d = copy.deepcopy(e)
+        d["a2"] = None
+        d = row_fxn_chain(c, d, "number", c["conform"]["number"])
+        self.assertEqual(d.get("OA:number", ""), "12-56")
+
     def test_row_fxn_regexp(self):
         "Regex split - replace"
         c = { "conform": {


### PR DESCRIPTION
Hey all -  finally found a minute to implement this.

In some cases it would be useful to have the ability to apply more than a single standard conform function to a given field. One example is the city of Wichita, KS in https://github.com/openaddresses/openaddresses/pull/2423, where there's a "Prop_Addr" field which contains number, street, and sometimes unit, and also a separate unit field which needs to be removed from the street name. Ideally we could run a "postfixed_street" to separate the street (+unit) from the initial house number, and then remove the unit suffix with a "remove_postix". However, the conform only allows running a single function per field. It might be possible to devise a (nasty) regex to handle all of the cases, but said regex might be brittle if e.g. the data source is updated with a pattern that wasn't initially handled.

This PR allows the chaining of multiple primitive functions from the OpenAddresses conforms. Here's an example for the Wichita case:

```json
{
    "coverage": {
        "geometry": {
            "type": "Point",
            "coordinates": [
                -97.34,
                37.68
            ]
        },
        "US Census": {
            "geoid": "2079000",
            "name": "City of Witchita",
            "state": "Kansas"
        },
        "country": "us",
        "state": "ks",
        "city": "Witchita"
    },
    "data": "http://gismaps.wichita.gov/agsweb/rest/services/COWGIS/Property_and_Location/MapServer/4",
    "type": "ESRI",
    "conform": {
        "type": "geojson",
        "number": {
            "function": "prefixed_number",
            "field": "Prop_Addr"
        },
        "street": {
            "function": "chain",
            "variable": "street_wip",
            "functions": [
                {
                    "function": "postfixed_street",
                    "field": "Prop_Addr"
                },
                {
                    "function": "remove_postfix",
                    "field": "street_wip",
                    "field_to_remove": "Prop_Addr_Unit"
                }
            ]
        },
        "postcode": "Prop_zip",
        "city": "Prop_City"
    }
}
```

Notice that the field we operate on in the second chained function is the user-defined variable "street_wip". This field is added to the current row and stores the computed result between function calls. As far as the inner steps in the chain are concerned, they're simply storing their output in the "street_wip" field instead of "OA:street". Each step in a conform chain works exactly the way it did before, but in the context of a chain, there's this extra variable that can be referenced along with source fields. Note that chains can be nested, so one could, for example, run various regexes on different source fields and then combine their output in a specific format. I include a very simple example of a nested config in the tests for this new function.

The only requirement for the user-specified variable names is that they should not conflict with the source fields or the standard field names like "street", "number", etc.

Note that there was some refactoring of the current row functions required to make this work. Namely, each row function needs to be passed its local config dictionary instead of just the top-level config and a key (which assumes that the function dictionaries can be referenced shallowly with a single string key).

Also related: https://github.com/openaddresses/openaddresses/pull/2909