### PR TITLE
Publish latest docker tag for images on Docker Hub

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,11 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker tag openaddr/prereqs:`cut -f1 -d. openaddr/VERSION`.x openaddr/prereqs:`cat openaddr/VERSION`
       - docker tag openaddr/machine:`cut -f1 -d. openaddr/VERSION`.x openaddr/machine:`cat openaddr/VERSION`
+      - docker tag openaddr/prereqs:`cat openaddr/VERSION` openaddr/prereqs:latest
+      - docker tag openaddr/machine:`cat openaddr/VERSION` openaddr/machine:latest
       - docker push openaddr/prereqs:`cut -f1 -d. openaddr/VERSION`.x
       - docker push openaddr/machine:`cut -f1 -d. openaddr/VERSION`.x
       - docker push openaddr/prereqs:`cat openaddr/VERSION`
       - docker push openaddr/machine:`cat openaddr/VERSION`
+      - docker push openaddr/prereqs:latest
+      - docker push openaddr/machine:latest

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,8 +10,8 @@ Run a single source without installing Python or other packages locally
 using [OpenAddresses from Docker Hub](https://hub.docker.com/r/openaddr/).
 
 1.  Get the latest [OpenAddresses image from Docker Hub](https://hub.docker.com/r/openaddr/machine/tags/):
-    
-        docker pull openaddr/machine:6.x
+
+        docker pull openaddr/machine
 
 2.  Download a source from [OpenAdresses/openaddresses on Github](https://github.com/openaddresses/openaddresses). [Berkeley, California](https://results.openaddresses.io/sources/us/ca/berkeley) is a small, reliable source that’s good to test with:
 
@@ -37,36 +37,36 @@ This process should take 5-10 minutes depending on download speed.
     run `apt-get install docker.io` or follow [Docker’s own directions](https://docs.docker.com/engine/installation/linux/ubuntu/).
 
 2.  Build the required image, which includes binary packages like GDAL and Postgres.
-    
+
         VERSION=`cut -f1 -d. openaddr/VERSION`.x
         docker build -f Dockerfile-machine -t openaddr/machine:$VERSION .
-    
+
 3.  Run everything in detached mode:
-    
+
         docker-compose up -d
-    
+
     Run `docker ps -a` to see output like this:
-    
+
             IMAGE                STATUS                        NAMES
         ... openaddr/machine ... Exited (0) 44 seconds ago ... openaddressesmachine_machine_1
             mdillon/postgis      Up 45 seconds                 openaddressesmachine_postgres_1
 
 4.  Connect to the OpenAddresses image `openaddr/machine` with a bash shell
     and the current working directory mapped to `/vol`:
-    
+
         docker-compose run machine bash
-    
+
 5.  Build the OpenAddresses packages using
     [virtualenv](https://packaging.python.org/installing/#creating-virtual-environments)
     and [pip](https://packaging.python.org/installing/#use-pip-for-installing).
     The `-e` flag to `pip install` insures that your local copy of OpenAddresses
     is used, so that you can test changes to the code made in your own editor:
-    
+
         pip3 install virtualenv
         virtualenv -p python3 --system-site-packages venv
         source venv/bin/activate
         pip3 install -e file:///vol
-    
+
 You should now be able to make changes and test them.
 If you exit the Docker container, changes made in step 5 above will be lost.
 Use [Docker commit](https://docs.docker.com/engine/reference/commandline/commit/)


### PR DESCRIPTION
This is in response to #641

* Adds command for CircleCI to tag the `prereq` and `machine` images with `latest` tag
* Pushes `latest` tag to Docker Hub
* Updates docs for consistency to avoid issues reported in #641 

And my editor deleted a bunch of whitespace in the `install.md`. 

From an ✈️ :)