### PR TITLE
Fiddle docker tags

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,10 +4,11 @@ machine:
 
 dependencies:
   pre:
-    - docker pull openaddr/prereqs:`cut -f1 -d. openaddr/VERSION`.x || true
+    - cut -f1 -d. openaddr/VERSION > /tmp/MAJOR
+    - docker pull openaddr/prereqs:`cat /tmp/MAJOR`.x || true
   override:
-    - docker build -f Dockerfile-prereqs -t openaddr/prereqs:`cut -f1 -d. openaddr/VERSION`.x .
-    - docker build -f Dockerfile-machine -t openaddr/machine:`cut -f1 -d. openaddr/VERSION`.x .
+    - docker build -f Dockerfile-prereqs -t openaddr/prereqs:`cat /tmp/MAJOR`.x .
+    - docker build -f Dockerfile-machine -t openaddr/machine:`cat /tmp/MAJOR`.x .
 
 test:
   override:
@@ -20,12 +21,12 @@ deployment:
     branch: [6.x]
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker tag openaddr/prereqs:`cut -f1 -d. openaddr/VERSION`.x openaddr/prereqs:`cat openaddr/VERSION`
-      - docker tag openaddr/machine:`cut -f1 -d. openaddr/VERSION`.x openaddr/machine:`cat openaddr/VERSION`
+      - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:`cat openaddr/VERSION`
+      - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:`cat openaddr/VERSION`
       - docker tag openaddr/prereqs:`cat openaddr/VERSION` openaddr/prereqs:latest
       - docker tag openaddr/machine:`cat openaddr/VERSION` openaddr/machine:latest
-      - docker push openaddr/prereqs:`cut -f1 -d. openaddr/VERSION`.x
-      - docker push openaddr/machine:`cut -f1 -d. openaddr/VERSION`.x
+      - docker push openaddr/prereqs:`cat /tmp/MAJOR`.x
+      - docker push openaddr/machine:`cat /tmp/MAJOR`.x
       - docker push openaddr/prereqs:`cat openaddr/VERSION`
       - docker push openaddr/machine:`cat openaddr/VERSION`
       - docker push openaddr/prereqs:latest

--- a/circle.yml
+++ b/circle.yml
@@ -31,3 +31,13 @@ deployment:
       - docker push openaddr/machine:`cat openaddr/VERSION`
       - docker push openaddr/prereqs:latest
       - docker push openaddr/machine:latest
+  fiddling:
+    branch: [migurski/fiddle-docker-tags]
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:`cat openaddr/VERSION`
+      - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:`cat openaddr/VERSION`
+      - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:`cat /tmp/MAJOR`
+      - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:`cat /tmp/MAJOR`
+      - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:latest
+      - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:latest

--- a/circle.yml
+++ b/circle.yml
@@ -23,21 +23,15 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:`cat openaddr/VERSION`
       - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:`cat openaddr/VERSION`
-      - docker tag openaddr/prereqs:`cat openaddr/VERSION` openaddr/prereqs:latest
-      - docker tag openaddr/machine:`cat openaddr/VERSION` openaddr/machine:latest
-      - docker push openaddr/prereqs:`cat /tmp/MAJOR`.x
-      - docker push openaddr/machine:`cat /tmp/MAJOR`.x
-      - docker push openaddr/prereqs:`cat openaddr/VERSION`
-      - docker push openaddr/machine:`cat openaddr/VERSION`
-      - docker push openaddr/prereqs:latest
-      - docker push openaddr/machine:latest
-  fiddling:
-    branch: [migurski/fiddle-docker-tags]
-    commands:
-      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:`cat openaddr/VERSION`
-      - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:`cat openaddr/VERSION`
       - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:`cat /tmp/MAJOR`
       - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:`cat /tmp/MAJOR`
       - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:latest
       - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:latest
+      - docker push openaddr/prereqs:`cat /tmp/MAJOR`.x
+      - docker push openaddr/machine:`cat /tmp/MAJOR`.x
+      - docker push openaddr/prereqs:`cat openaddr/VERSION`
+      - docker push openaddr/machine:`cat openaddr/VERSION`
+      - docker push openaddr/prereqs:`cat /tmp/MAJOR`
+      - docker push openaddr/machine:`cat /tmp/MAJOR`
+      - docker push openaddr/prereqs:latest
+      - docker push openaddr/machine:latest


### PR DESCRIPTION
Add numeric tags for major versions, like `openaddr/machine:6` instead of confusing `openaddr/machine:6.x`. First followup to #642.