### PR TITLE
Fiddle Docker tags more

### DIFF
--- a/Dockerfile-machine
+++ b/Dockerfile-machine
@@ -1,4 +1,4 @@
-FROM openaddr/prereqs:6.x
+FROM openaddr/prereqs:6
 
 # From chef/openaddr/recipes/default.rb
 COPY . /usr/local/src/openaddr

--- a/circle.yml
+++ b/circle.yml
@@ -5,10 +5,10 @@ machine:
 dependencies:
   pre:
     - cut -f1 -d. openaddr/VERSION > /tmp/MAJOR
-    - docker pull openaddr/prereqs:`cat /tmp/MAJOR`.x || true
+    - docker pull openaddr/prereqs:`cat /tmp/MAJOR` || true
   override:
-    - docker build -f Dockerfile-prereqs -t openaddr/prereqs:`cat /tmp/MAJOR`.x .
-    - docker build -f Dockerfile-machine -t openaddr/machine:`cat /tmp/MAJOR`.x .
+    - docker build -f Dockerfile-prereqs -t openaddr/prereqs:`cat /tmp/MAJOR` .
+    - docker build -f Dockerfile-machine -t openaddr/machine:`cat /tmp/MAJOR` .
 
 test:
   override:
@@ -21,12 +21,12 @@ deployment:
     branch: [6.x]
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:`cat openaddr/VERSION`
-      - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:`cat openaddr/VERSION`
-      - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:`cat /tmp/MAJOR`
-      - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:`cat /tmp/MAJOR`
-      - docker tag openaddr/prereqs:`cat /tmp/MAJOR`.x openaddr/prereqs:latest
-      - docker tag openaddr/machine:`cat /tmp/MAJOR`.x openaddr/machine:latest
+      - docker tag openaddr/prereqs:`cat /tmp/MAJOR` openaddr/prereqs:`cat openaddr/VERSION`
+      - docker tag openaddr/machine:`cat /tmp/MAJOR` openaddr/machine:`cat openaddr/VERSION`
+      - docker tag openaddr/prereqs:`cat /tmp/MAJOR` openaddr/prereqs:`cat /tmp/MAJOR`.x
+      - docker tag openaddr/machine:`cat /tmp/MAJOR` openaddr/machine:`cat /tmp/MAJOR`.x
+      - docker tag openaddr/prereqs:`cat /tmp/MAJOR` openaddr/prereqs:latest
+      - docker tag openaddr/machine:`cat /tmp/MAJOR` openaddr/machine:latest
       - docker push openaddr/prereqs:`cat /tmp/MAJOR`.x
       - docker push openaddr/machine:`cat /tmp/MAJOR`.x
       - docker push openaddr/prereqs:`cat openaddr/VERSION`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 machine:
-  image: openaddr/machine:6.x
+  image: openaddr/machine:6
   environment:
     - DATABASE_URL=postgresql://openaddr:openaddr@postgres/openaddr
   links:

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,8 +38,7 @@ This process should take 5-10 minutes depending on download speed.
 
 2.  Build the required image, which includes binary packages like GDAL and Postgres.
 
-        VERSION=`cut -f1 -d. openaddr/VERSION`.x
-        docker build -f Dockerfile-machine -t openaddr/machine:$VERSION .
+        docker build -f Dockerfile-machine -t openaddr/machine:`cut -f1 -d. openaddr/VERSION` .
 
 3.  Run everything in detached mode:
 


### PR DESCRIPTION
Remove pre-numeric tags for major versions, like `openaddr/machine:6.x` and use newer ones like `openaddr/machine:6`. Second followup to #642.