### PR TITLE
strip out '.0' suffix in format component fields

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -1072,6 +1072,14 @@ def row_fxn_format(sd, row, key, fxn):
                 parts.append(format_str[idx:start])
 
             if field:
+                # if the value being added ends with '.0', remove it
+                # certain fields ending with '.0' are normalized by removing that 
+                #  suffix in row_canonicalize_unit_and_number but this isn't 
+                #  possible when not-the-last component fields submitted to the format 
+                #  function end with '.0'
+                if field.endswith(".0"):
+                    field = field[:-2]
+
                 parts.append(field)
                 num_fields_added += 1
 

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -99,7 +99,7 @@ class TestConformTransforms (unittest.TestCase):
             }
         } }
 
-        d = {"a1": "12", "a2": "34", "a3": "56", "b1": "1", "b2": "B", "b3": "3"}
+        d = {"a1": "12.0", "a2": "34", "a3": "56", "b1": "1", "b2": "B", "b3": "3"}
         e = copy.deepcopy(d)
         d = row_fxn_format(c, d, "number", c["conform"]["number"])
         d = row_fxn_format(c, d, "street", c["conform"]["street"])


### PR DESCRIPTION
This functionality is required for sources that utilize the `format` function but have floating point field values referenced as not-the-last field.  For example, if the final `number` field value is `349.0`, then `row_canonicalize_unit_and_number` removes the `.0` suffix.  However, `format` can reference multiple fields and if one of any but the last field is a floating point number, then the `.0` is embedded and cannot be removed, for example `576.0` and `B` are concatenated to `576.0B`.  This fix applies the same if-the field-value-ends-with-`.0`-then-remove-it-before-appending to the individual field values of the `format` function.  

Fixes openaddresses/openaddresses#3009