### PR TITLE
Added "v6" style Docker image tags

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,10 +25,14 @@ deployment:
       - docker tag openaddr/machine:`cat /tmp/MAJOR` openaddr/machine:`cat openaddr/VERSION`
       - docker tag openaddr/prereqs:`cat /tmp/MAJOR` openaddr/prereqs:`cat /tmp/MAJOR`.x
       - docker tag openaddr/machine:`cat /tmp/MAJOR` openaddr/machine:`cat /tmp/MAJOR`.x
+      - docker tag openaddr/prereqs:`cat /tmp/MAJOR` openaddr/prereqs:v`cat /tmp/MAJOR`
+      - docker tag openaddr/machine:`cat /tmp/MAJOR` openaddr/machine:v`cat /tmp/MAJOR`
       - docker tag openaddr/prereqs:`cat /tmp/MAJOR` openaddr/prereqs:latest
       - docker tag openaddr/machine:`cat /tmp/MAJOR` openaddr/machine:latest
       - docker push openaddr/prereqs:`cat /tmp/MAJOR`.x
       - docker push openaddr/machine:`cat /tmp/MAJOR`.x
+      - docker push openaddr/prereqs:v`cat /tmp/MAJOR`
+      - docker push openaddr/machine:v`cat /tmp/MAJOR`
       - docker push openaddr/prereqs:`cat openaddr/VERSION`
       - docker push openaddr/machine:`cat openaddr/VERSION`
       - docker push openaddr/prereqs:`cat /tmp/MAJOR`


### PR DESCRIPTION
Switching to numeric tags in https://github.com/openaddresses/machine/pull/643 and https://github.com/openaddresses/machine/pull/642 seems to be confusing Circle or Docker, and leading to lengthy rebuilds in CI. I think this might be because "6" is a valid truncated image tag, while "v6" might not be? Add "v6" tags to test this idea.