### PR TITLE
update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         'pq == 1.4',
         
         # http://initd.org/psycopg/
-        'psycopg2 == 2.6.2',
+        'psycopg2 == 2.7.3.2',
         
         # http://docs.python-requests.org/en/master/
         'requests == 2.11.1',
@@ -108,7 +108,7 @@ setup(
         'itsdangerous == 0.24',
 
         # https://pypi.python.org/pypi/python-memcached
-        'python3-memcached == 1.51',
+        'python-memcached == 1.59',
 
         ]
 )


### PR DESCRIPTION
1. Replace python3-memcached with python-memcached as per https://github.com/eguven/python3-memcached it is deprecated and python-memcached now supports python3.

Without this I can't install on Debian unstable due to:

```
  File "/tmp/easy_install-emPLrH/python3-memcached-1.51/memcache.py", line 1251
    print("Testing set/get {'%s': %s} ..." % (to_s(key), to_s(val)), end=' ')
                                                                        ^
SyntaxError: invalid syntax
```

2. Updated psycopy due to https://github.com/psycopg/psycopg2/issues/594 again which was uninstallable on Debian unstable.