### PR TITLE
ensure compound functions are conform smash cased

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -1014,6 +1014,19 @@ def conform_smash_case(source_definition):
             if "field_to_remove" in conform[k]:
                 conform[k]["field_to_remove"] = conform[k]["field_to_remove"].lower()
 
+            if "functions" in conform[k]:
+                if type(conform[k]["functions"]) is list:
+                    for i in range(len(conform[k]["functions"])):
+                        if type(conform[k]["functions"][i]) is dict:
+                            if "field" in conform[k]["functions"][i]:
+                                conform[k]["functions"][i]["field"] = conform[k]["functions"][i]["field"].lower()
+
+                            if "fields" in conform[k]["functions"][i]:
+                                conform[k]["functions"][i]["fields"] = [s.lower() for s in conform[k]["functions"][i]["fields"]]
+
+                            if "field_to_remove" in conform[k]["functions"][i]:
+                                conform[k]["functions"][i]["field_to_remove"] = conform[k]["functions"][i]["field_to_remove"].lower()
+
     if "advanced_merge" in conform:
         raise ValueError('Found unsupported "advanced_merge" option in conform')
     return new_sd

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -1016,16 +1016,16 @@ def conform_smash_case(source_definition):
 
             if "functions" in conform[k]:
                 if type(conform[k]["functions"]) is list:
-                    for i in range(len(conform[k]["functions"])):
-                        if type(conform[k]["functions"][i]) is dict:
-                            if "field" in conform[k]["functions"][i]:
-                                conform[k]["functions"][i]["field"] = conform[k]["functions"][i]["field"].lower()
+                    for function in conform[k]["functions"]:
+                        if type(function) is dict:
+                            if "field" in function:
+                                function["field"] = function["field"].lower()
 
-                            if "fields" in conform[k]["functions"][i]:
-                                conform[k]["functions"][i]["fields"] = [s.lower() for s in conform[k]["functions"][i]["fields"]]
+                            if "fields" in function:
+                                function["fields"] = [s.lower() for s in function["fields"]]
 
-                            if "field_to_remove" in conform[k]["functions"][i]:
-                                conform[k]["functions"][i]["field_to_remove"] = conform[k]["functions"][i]["field_to_remove"].lower()
+                            if "field_to_remove" in function:
+                                function["field_to_remove"] = function["field_to_remove"].lower()
 
     if "advanced_merge" in conform:
         raise ValueError('Found unsupported "advanced_merge" option in conform')

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -1014,18 +1014,17 @@ def conform_smash_case(source_definition):
             if "field_to_remove" in conform[k]:
                 conform[k]["field_to_remove"] = conform[k]["field_to_remove"].lower()
 
-            if "functions" in conform[k]:
-                if type(conform[k]["functions"]) is list:
-                    for function in conform[k]["functions"]:
-                        if type(function) is dict:
-                            if "field" in function:
-                                function["field"] = function["field"].lower()
+            if "functions" in conform[k] and type(conform[k]["functions"]) is list:
+                for function in conform[k]["functions"]:
+                    if type(function) is dict:
+                        if "field" in function:
+                            function["field"] = function["field"].lower()
 
-                            if "fields" in function:
-                                function["fields"] = [s.lower() for s in function["fields"]]
+                        if "fields" in function:
+                            function["fields"] = [s.lower() for s in function["fields"]]
 
-                            if "field_to_remove" in function:
-                                function["field_to_remove"] = function["field_to_remove"].lower()
+                        if "field_to_remove" in function:
+                            function["field_to_remove"] = function["field_to_remove"].lower()
 
     if "advanced_merge" in conform:
         raise ValueError('Found unsupported "advanced_merge" option in conform')


### PR DESCRIPTION
https://github.com/openaddresses/machine/blob/20e0f515653456ce3cff0519530771736eb352e5/openaddr/conform.py#L998 smashes case of the conform object however it fails to do this for [compound functions](https://github.com/openaddresses/openaddresses/blob/master/ATTRIBUTE_FUNCTIONS.md#compound-functions).

This leads to confusing error messages to the user when it fails when both the conform object and source use CAPS.

Workaround is for users to use lowercase in their conform object until this is merged.

PS. I'm not a python coder, so feel free to refactor this code if you need to.