### PR TITLE
Removed additional remaining references to Mapzen

### DIFF
--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -925,7 +925,7 @@ def _wait_for_work_lock(lock, heartbeat_queue):
             next_put += HEARTBEAT_INTERVAL.seconds + HEARTBEAT_INTERVAL.days * 86400
 
 def pop_task_from_taskqueue(s3, task_queue, done_queue, due_queue, heartbeat_queue,
-                            output_dir, mapzen_key):
+                            output_dir, mapbox_key):
     '''
     '''
     with task_queue as db:
@@ -987,7 +987,7 @@ def pop_task_from_taskqueue(s3, task_queue, done_queue, due_queue, heartbeat_que
             result = work.do_work(s3, passed_on_kwargs['run_id'], source_name,
                                   passed_on_kwargs['content_b64'],
                                   taskdata.render_preview, output_dir,
-                                  mapzen_key)
+                                  mapbox_key)
         
         work_wait.join()
 

--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -47,7 +47,7 @@ def boolstr(value):
     
     raise ValueError(repr(value))
 
-def process(source, destination, do_preview, mapzen_key=None, extras=dict()):
+def process(source, destination, do_preview, mapbox_key=None, extras=dict()):
     ''' Process a single source and destination, return path to JSON state file.
     
         Creates a new directory and files under destination.
@@ -105,8 +105,8 @@ def process(source, destination, do_preview, mapzen_key=None, extras=dict()):
                 else:
                     _L.info('Processed data in {}'.format(conform_result.path))
                 
-                    if do_preview and mapzen_key:
-                        preview_path = render_preview(conform_result.path, temp_dir, mapzen_key)
+                    if do_preview and mapbox_key:
+                        preview_path = render_preview(conform_result.path, temp_dir, mapbox_key)
                 
                     if do_preview:
                         slippymap_path = render_slippymap(conform_result.path, temp_dir)
@@ -141,11 +141,11 @@ def process(source, destination, do_preview, mapzen_key=None, extras=dict()):
 
     return state_path
 
-def render_preview(csv_filename, temp_dir, mapzen_key):
+def render_preview(csv_filename, temp_dir, mapbox_key):
     '''
     '''
     png_filename = join(temp_dir, 'preview.png')
-    preview.render(csv_filename, png_filename, 668, 2, mapzen_key)
+    preview.render(csv_filename, png_filename, 668, 2, mapbox_key)
 
     return png_filename
 
@@ -328,8 +328,8 @@ parser.add_argument('--skip-preview', help="Don't render a map preview",
                     action='store_const', dest='render_preview',
                     const=False, default=False)
 
-parser.add_argument('--mapzen-key', dest='mapzen_key',
-                    help='Mapzen API Key. See: https://mapzen.com/documentation/overview/')
+parser.add_argument('--mapbox-key', dest='mapbox_key',
+                    help='Mapbox API Key. See: https://mapbox.com/')
 
 parser.add_argument('-l', '--logfile', help='Optional log file name.')
 
@@ -353,7 +353,7 @@ def main():
     csv.field_size_limit(sys.maxsize)
     
     try:
-        file_path = process(args.source, args.destination, args.render_preview, mapzen_key=args.mapzen_key)
+        file_path = process(args.source, args.destination, args.render_preview, mapbox_key=args.mapbox_key)
     except Exception as e:
         _L.error(e, exc_info=True)
         return 1

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -95,12 +95,6 @@ class TestOA (unittest.TestCase):
         if host == 'fake-s3.local':
             return response(200, self.s3._read_fake_key(path))
         
-        if host == 'tile.mapzen.com' and path.startswith('/mapzen/vector/v1'):
-            if 'api_key=mapzen-XXXX' not in url.query:
-                raise ValueError('Missing or wrong API key')
-            data = b'{"landuse": {"features": []}, "water": {"features": []}, "roads": {"features": []}}'
-            return response(200, data, headers={'Content-Type': 'application/json'})
-
         if (host, path) == ('data.acgov.org', '/api/geospatial/8e4s-7f4v'):
             local_path = join(data_dirname, 'us-ca-alameda_county-excerpt.zip')
         
@@ -348,7 +342,7 @@ class TestOA (unittest.TestCase):
              mock.patch('openaddr.slippymap.generate') as slippymap_gen:
             preview_ren.side_effect = touch_second_arg_file
             slippymap_gen.side_effect = touch_first_arg_file
-            state_path = process_one.process(source, self.testdir, True, mapzen_key='mapzen-XXXX')
+            state_path = process_one.process(source, self.testdir, True, mapbox_key='mapbox-XXXX')
         
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
         self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
@@ -404,7 +398,7 @@ class TestOA (unittest.TestCase):
              mock.patch('openaddr.slippymap.generate') as slippymap_gen:
             preview_ren.side_effect = touch_second_arg_file
             slippymap_gen.side_effect = touch_first_arg_file
-            state_path = process_one.process(source, self.testdir, True, mapzen_key='mapzen-XXXX')
+            state_path = process_one.process(source, self.testdir, True, mapbox_key='mapbox-XXXX')
         
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
         self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
@@ -456,7 +450,7 @@ class TestOA (unittest.TestCase):
              mock.patch('openaddr.slippymap.generate') as slippymap_gen:
             preview_ren.side_effect = touch_second_arg_file
             slippymap_gen.side_effect = touch_first_arg_file
-            state_path = process_one.process(source, self.testdir, True, mapzen_key='mapzen-XXXX')
+            state_path = process_one.process(source, self.testdir, True, mapbox_key='mapbox-XXXX')
         
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
         self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))
@@ -511,7 +505,7 @@ class TestOA (unittest.TestCase):
              mock.patch('openaddr.slippymap.generate') as slippymap_gen:
             preview_ren.side_effect = touch_second_arg_file
             slippymap_gen.side_effect = touch_first_arg_file
-            state_path = process_one.process(source, self.testdir, True, mapzen_key='mapzen-XXXX')
+            state_path = process_one.process(source, self.testdir, True, mapbox_key='mapbox-XXXX')
         
         self.assertTrue(slippymap_gen.mock_calls[0][1][0].endswith('.mbtiles'))
         self.assertTrue(slippymap_gen.mock_calls[0][1][1].endswith('.csv'))


### PR DESCRIPTION
`openaddr-process-one` was still expecting a Mapzen key.