### PR TITLE
added first_non_empty helper function

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -956,6 +956,8 @@ def row_function(sd, row, key, fxn):
         row = row_fxn_remove_postfix(sd, row, key, fxn)
     elif function == "chain":
         row = row_fxn_chain(sd, row, key, fxn)
+    elif function == "first_non_empty":
+        row = row_fxn_first_non_empty(sd, row, key, fxn)
 
     return row
 
@@ -1173,6 +1175,15 @@ def row_fxn_chain(sd, row, key, fxn):
 
     row[var_types[original_key]] = row[var_types[key]]
 
+    return row
+
+def row_fxn_first_non_empty(sd, row, key, fxn):
+    "Iterate all fields looking for first that has a non-empty value"
+    for field in fxn.get('fields', []):
+        if row[field] and row[field].strip():
+            row[var_types[key]] = row[field]
+            break
+            
     return row
 
 def row_canonicalize_unit_and_number(sd, row):

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -20,6 +20,7 @@ from ..conform import (
     row_fxn_prefixed_number, row_fxn_postfixed_street,
     row_fxn_postfixed_unit,
     row_fxn_remove_prefix, row_fxn_remove_postfix, row_fxn_chain,
+    row_fxn_first_non_empty,
     row_canonicalize_unit_and_number, conform_smash_case, conform_cli,
     convert_regexp_replace, conform_license,
     conform_attribution, conform_sharealike, normalize_ogr_filename_case,
@@ -1289,6 +1290,91 @@ class TestConformTransforms (unittest.TestCase):
         e.update({ "OA:street": "123 MAPLE ST" })
 
         d = row_fxn_remove_postfix(c, d, "street", c["conform"]["street"])
+        self.assertEqual(e, d)
+
+    def test_row_first_non_empty(self):
+        "first_non_empty - fields array is empty"
+        c = { "conform": {
+            "street": {
+                "function": "first_non_empty",
+                "fields": []
+            }
+        } }
+        d = { }
+        e = copy.deepcopy(d)
+        e.update({ })
+
+        d = row_fxn_first_non_empty(c, d, "street", c["conform"]["street"])
+        self.assertEqual(e, d)
+        
+        "first_non_empty - both fields are non-empty"
+        c = { "conform": {
+            "street": {
+                "function": "first_non_empty",
+                "fields": ["FIELD1", "FIELD2"]
+            }
+        } }
+        d = { "FIELD1": "field1 value", "FIELD2": "field2 value" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:street": "field1 value" })
+
+        d = row_fxn_first_non_empty(c, d, "street", c["conform"]["street"])
+        self.assertEqual(e, d)
+        
+        "first_non_empty - first field is null"
+        c = { "conform": {
+            "street": {
+                "function": "first_non_empty",
+                "fields": ["FIELD1", "FIELD2"]
+            }
+        } }
+        d = { "FIELD1": None, "FIELD2": "field2 value" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:street": "field2 value" })
+        
+        d = row_fxn_first_non_empty(c, d, "street", c["conform"]["street"])
+        self.assertEqual(e, d)
+        
+        "first_non_empty - first field is 0-length string"
+        c = { "conform": {
+            "street": {
+                "function": "first_non_empty",
+                "fields": ["FIELD1", "FIELD2"]
+            }
+        } }
+        d = { "FIELD1": "", "FIELD2": "field2 value" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:street": "field2 value" })
+        
+        d = row_fxn_first_non_empty(c, d, "street", c["conform"]["street"])
+        self.assertEqual(e, d)
+        
+        "first_non_empty - first field is trimmable to a 0-length string"
+        c = { "conform": {
+            "street": {
+                "function": "first_non_empty",
+                "fields": ["FIELD1", "FIELD2"]
+            }
+        } }
+        d = { "FIELD1": " \t ", "FIELD2": "field2 value" }
+        e = copy.deepcopy(d)
+        e.update({ "OA:street": "field2 value" })
+        
+        d = row_fxn_first_non_empty(c, d, "street", c["conform"]["street"])
+        self.assertEqual(e, d)
+        
+        "first_non_empty - all field values are trimmable to a 0-length string"
+        c = { "conform": {
+            "street": {
+                "function": "first_non_empty",
+                "fields": ["FIELD1", "FIELD2"]
+            }
+        } }
+        d = { "FIELD1": " \t ", "FIELD2": " \t " }
+        e = copy.deepcopy(d)
+        e.update({ })
+        
+        d = row_fxn_first_non_empty(c, d, "street", c["conform"]["street"])
         self.assertEqual(e, d)
 
 class TestConformCli (unittest.TestCase):


### PR DESCRIPTION
This PR adds a function called `first_non_empty` that takes a string array in `fields` to return the first value that's not empty or trimmable to a zero-length string.  A use case for this is the latest [SEMCOG, TX data](https://services5.arcgis.com/8DjE4f6iFLArDhsU/arcgis/rest/services/AddressPoints_Jan2016/FeatureServer/0) where both `MUNICIPAL` and `POSTAL_COM` can contain city names.  In some cases only one of these is populated and in some cases both are populated.  One should be preferred but there's currently no way to only include one value.  I'll add to the [attribute functions](https://github.com/openaddresses/openaddresses/blob/master/ATTRIBUTE_FUNCTIONS.md) once released, but an example usage of this would be:

```json
{
    "city": {
        "function": "first_non_empty",
        "fields": ["MUNICIPAL", "POSTAL_COM"]
    }
}
```