### PR TITLE
Suppress one more dumb error

### DIFF
--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -150,7 +150,10 @@ def app_get_jobs():
     with db_connect(current_app.config['DATABASE_URL']) as conn:
         with db_cursor(conn) as db:
             past_id = request.args.get('past', '')
-            jobs = read_jobs(db, past_id)
+            try:
+                jobs = read_jobs(db, past_id)
+            except ValueError:
+                return Response('Invalid past {}'.format(repr(request.args.get('past', ''))), 400)
     
     
     try:


### PR DESCRIPTION
Missed on in #684: catch badly-formatted input and return an HTTP 400 so it doesn't generate an alert.