### PR TITLE
Update graph ranges to suit latest statistics better

### DIFF
--- a/openaddr/ci/templates/dashboard.html
+++ b/openaddr/ci/templates/dashboard.html
@@ -212,11 +212,11 @@ d3.json('https://s3.amazonaws.com/data.openaddresses.io/machine-stats.json', fun
     var dateRange = d3.extent(timeseries, function(d) { return d.ts; });
 
     graphTimeSeries(d3.select("#addresses"), timeseries, function(d) { return d.addresses; }, dateRange, [60000000, 500000000]);
-    graphTimeSeries(d3.select('#sources'), timeseries, function(d) { return d.successful_sources; }, dateRange, [400, 1500]);
+    graphTimeSeries(d3.select('#sources'), timeseries, function(d) { return d.successful_sources; }, dateRange, [400, 2000]);
     graphTimeSeries(d3.select('#cache'), timeseries, function(d) { return d.average_cache_time; }, dateRange, [0, 300]);
     graphTimeSeries(d3.select('#process'), timeseries, function(d) { return d.average_process_time; }, dateRange, [0, 400]);
 
-    graphHistogram(d3.select('#addressesHistogram'), data['last_address_counts'], [0, 200000])
+    graphHistogram(d3.select('#addressesHistogram'), data['last_address_counts'], [0, 400000])
     graphHistogram(d3.select('#cacheHistogram'), data['last_cache_times'], [0, 600])
     graphHistogram(d3.select('#processHistogram'), data['last_process_times'], [0, 600])
 


### PR DESCRIPTION
Graphs on [dashboard](http://results.openaddresses.io/dashboard) were not suit for the latest statistics:
* Successful Sources was out of range, increasing max from 1500 to 2000, before/after: 
![image](https://user-images.githubusercontent.com/319826/38766899-015e2d48-3fd9-11e8-81e3-52abd6da762a.png)

* Address counts per source histogram had a large spike at right, doubled max from 200,000 to 400,000 for a better fit: before/after: 
![image](https://user-images.githubusercontent.com/319826/38766889-e6ae5a5e-3fd8-11e8-9b64-aca6e46d5481.png)
