### PR TITLE
Add new runs.for_index_page column and keep it updated

### DIFF
--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -566,6 +566,23 @@ def read_completed_runs_to_date(db, starting_set_id):
     _L.warning('7) results 3 {:.0f}'.format(time.time()))
 
     return runs
+
+def mark_runs_for_index_page(db, runs):
+    ''' Update runs.for_index_page boolean column from list of provided runs.
+    '''
+    run_ids = tuple([run.id for run in runs])
+    
+    db.execute('''
+        UPDATE runs SET for_index_page = false
+        WHERE for_index_page
+          AND id NOT IN %s
+        ''', (run_ids, ))
+    
+    db.execute('''
+        UPDATE runs SET for_index_page = true
+        WHERE NOT for_index_page
+          AND id IN %s
+        ''', (run_ids, ))
     
 def read_latest_run(db, source_path):
     '''

--- a/openaddr/ci/schema.pgsql
+++ b/openaddr/ci/schema.pgsql
@@ -84,6 +84,7 @@ CREATE TABLE zips
 
 CREATE INDEX runs_set_ids ON runs (set_id);
 CREATE INDEX runs_source_paths ON runs (source_path);
+CREATE INDEX runs_for_index_page ON runs (for_index_page);
 
 CREATE TABLE heartbeats
 (

--- a/openaddr/ci/schema.pgsql
+++ b/openaddr/ci/schema.pgsql
@@ -62,7 +62,8 @@ CREATE TABLE runs
     job_id              VARCHAR(40) REFERENCES jobs(id) NULL,
     set_id              INTEGER REFERENCES sets(id) NULL,
     commit_sha          VARCHAR(40) NULL,
-    is_merged           BOOLEAN
+    is_merged           BOOLEAN,
+    for_index_page      BOOLEAN NOT NULL DEFAULT false
 );
 
 CREATE TYPE zip_collection AS ENUM ('global', 'us_northeast', 'us_midwest',

--- a/openaddr/ci/sum_up.py
+++ b/openaddr/ci/sum_up.py
@@ -6,7 +6,7 @@ from datetime import date
 from time import sleep
 from os import environ
 
-from .objects import read_latest_set, read_completed_runs_to_date
+from .objects import read_latest_set, read_completed_runs_to_date, mark_runs_for_index_page
 from . import db_connect, db_cursor, setup_logger, render_index_maps, log_function_errors, dashboard_stats
 from .. import S3, util
 
@@ -52,6 +52,7 @@ def main():
             with db_cursor(conn) as db:
                 set = read_latest_set(db, args.owner, args.repository)
                 runs = read_completed_runs_to_date(db, set.id)
+                mark_runs_for_index_page(db, runs)
                 stats = dashboard_stats.make_stats(db)
 
         render_index_maps(s3, runs)


### PR DESCRIPTION
Start keeping index page inclusion in an explicit column using hourly `openaddr-sum-up-data` process.

Part of #710.