### PR TITLE
Switch from "type" tags to "format" and "protocol"

### DIFF
--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -94,7 +94,7 @@ def cache(data_source_name, data_source, destdir, extras):
     if not isinstance(source_urls, list):
         source_urls = [source_urls]
 
-    task = DownloadTask.from_type_string(data_source.get('type'), data_source_name)
+    task = DownloadTask.from_protocol_string(data_source.get('protocol'), data_source_name)
     downloaded_files = task.download(source_urls, workdir, data_source.get('conform'))
 
     # FIXME: I wrote the download stuff to assume multiple files because
@@ -151,7 +151,7 @@ def conform(data_source_name, data_source, destdir, extras):
     downloaded_path = task1.download(source_urls, workdir)
     _L.info("Downloaded to %s", downloaded_path)
 
-    task2 = DecompressionTask.from_type_string(data_source.get('compression'))
+    task2 = DecompressionTask.from_format_string(data_source.get('compression'))
     names = elaborate_filenames(data_source.get('conform', {}).get('file', None))
     decompressed_paths = task2.decompress(downloaded_path, workdir, names)
     _L.info("Decompressed to %d files", len(decompressed_paths))

--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -94,7 +94,10 @@ def cache(data_source_name, data_source, destdir, extras):
     if not isinstance(source_urls, list):
         source_urls = [source_urls]
 
-    task = DownloadTask.from_protocol_string(data_source.get('protocol'), data_source_name)
+    # TODO: "type" is a deprecated tag
+    protocol_string = data_source.get('protocol') or data_source.get('type')
+
+    task = DownloadTask.from_protocol_string(protocol_string, data_source_name)
     downloaded_files = task.download(source_urls, workdir, data_source.get('conform'))
 
     # FIXME: I wrote the download stuff to assume multiple files because

--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -132,15 +132,15 @@ class DownloadTask(object):
 
 
     @classmethod
-    def from_type_string(clz, type_string, source_prefix=None):
-        if type_string.lower() == 'http':
+    def from_protocol_string(clz, protocol_string, source_prefix=None):
+        if protocol_string.lower() == 'http':
             return URLDownloadTask(source_prefix)
-        elif type_string.lower() == 'ftp':
+        elif protocol_string.lower() == 'ftp':
             return URLDownloadTask(source_prefix)
-        elif type_string.lower() == 'esri':
+        elif protocol_string.lower() == 'esri':
             return EsriRestDownloadTask(source_prefix)
         else:
-            raise KeyError("I don't know how to extract for type {}".format(type_string))
+            raise KeyError("I don't know how to extract for protocol {}".format(protocol_string))
 
     def download(self, source_urls, workdir, conform):
         raise NotImplementedError()

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -334,8 +334,11 @@ class ExcerptDataTask(object):
         if data_ext in ('.geojson', '.json'):
             data_path = ExcerptDataTask._sample_geojson_file(data_path)
 
+        # TODO: "type" is a deprecated tag
+        format_string = conform.get('format') or conform.get('type')
+    
         # GDAL has issues with weird input CSV data, so use Python instead.
-        if conform.get('format') == 'csv':
+        if format_string == 'csv':
             return ExcerptDataTask._excerpt_csv_file(data_path, encoding, csvsplit)
 
         ogr_data_path = normalize_ogr_filename_case(data_path)
@@ -377,12 +380,15 @@ class ExcerptDataTask(object):
 
     @staticmethod
     def _get_known_paths(source_paths, workdir, conform, known_types):
-        if conform.get('format') != 'csv' or 'file' not in conform:
+        # TODO: "type" is a deprecated tag
+        format_string = conform.get('format') or conform.get('type')
+    
+        if format_string != 'csv' or 'file' not in conform:
             paths = [source_path for source_path in source_paths
                      if os.path.splitext(source_path)[1].lower() in known_types]
 
             # If nothing was found or named but we expect a CSV, return first file.
-            if not paths and conform.get('format') == 'csv' and 'file' not in conform:
+            if not paths and format_string == 'csv' and 'file' not in conform:
                 return source_paths[:1]
 
             return paths
@@ -476,7 +482,11 @@ def find_source_path(source_definition, source_paths):
         _L.warning('Source is missing a conform object')
         raise
 
-    if conform["format"] in ("shapefile", "shapefile-polygon"):
+    # TODO: "type" is a deprecated tag
+    format_string = conform.get('format') or conform.get('type')
+    protocol_string = source_definition.get('protocol') or source_definition.get('type')
+    
+    if format_string in ("shapefile", "shapefile-polygon"):
         # TODO this code is too complicated; see XML variant below for simpler option
         # Shapefiles are named *.shp
         candidates = []
@@ -501,7 +511,7 @@ def find_source_path(source_definition, source_paths):
                     return c
             _L.warning("Source names file %s but could not find it", source_file_name)
             return None
-    elif conform["format"] == "geojson" and source_definition["protocol"] != "ESRI":
+    elif format_string == "geojson" and protocol_string != "ESRI":
         candidates = []
         for fn in source_paths:
             basename, ext = os.path.splitext(fn)
@@ -517,10 +527,10 @@ def find_source_path(source_definition, source_paths):
             _L.warning("Found more than one JSON file in source, can't pick one")
             # geojson spec currently doesn't include a file attribute. Maybe it should?
             return None
-    elif conform["format"] == "geojson" and source_definition["protocol"] == "ESRI":
+    elif format_string == "geojson" and protocol_string == "ESRI":
         # Old style ESRI conform: ESRI downloader should only give us a single cache.csv file
         return source_paths[0]
-    elif conform["format"] == "csv":
+    elif format_string == "csv":
         # Return file if it's specified, else return the first file we find
         if "file" in conform:
             for fn in source_paths:
@@ -535,7 +545,7 @@ def find_source_path(source_definition, source_paths):
                 return fn
         # Nothing else worked so just return the first one.
         return source_paths[0]
-    elif conform["format"] == "gdb":
+    elif format_string == "gdb":
         candidates = []
         for fn in source_paths:
             fn = re.sub('\.gdb.*', '.gdb', fn)
@@ -559,7 +569,7 @@ def find_source_path(source_definition, source_paths):
                     return c
             _L.warning("Source names file %s but could not find it", source_file_name)
             return None
-    elif conform["format"] == "xml":
+    elif format_string == "xml":
         # Return file if it's specified, else return the first .gml file we find
         if "file" in conform:
             for fn in source_paths:
@@ -576,7 +586,7 @@ def find_source_path(source_definition, source_paths):
             _L.warning("Could not find a .gml file")
             return None
     else:
-        _L.warning("Unknown source conform format %s", conform["format"])
+        _L.warning("Unknown source conform format %s", format_string)
         return None
 
 class ConvertToCsvTask(object):
@@ -792,8 +802,11 @@ def csv_source_to_csv(source_definition, source_path, dest_path):
         reader = csv.DictReader(source_fp, delimiter=delim, fieldnames=in_fieldnames)
         num_fields = len(reader.fieldnames)
 
+        # TODO: "type" is a deprecated tag
+        protocol_string = source_definition.get('protocol') or source_definition['type']
+    
         # Construct headers for the extracted CSV file
-        if source_definition["protocol"] == "ESRI":
+        if protocol_string == "ESRI":
             # ESRI sources: just copy what the downloader gave us. (Already has OA:x and OA:y)
             out_fieldnames = list(reader.fieldnames)
         else:
@@ -867,11 +880,15 @@ def _transform_to_4326(srs):
 def row_extract_and_reproject(source_definition, source_row):
     ''' Find lat/lon in source CSV data and store it in ESPG:4326 in X/Y in the row
     '''
+    # TODO: "type" is a deprecated tag
+    format_string = source_definition["conform"].get('format') or source_definition["conform"].get('type')
+    protocol_string = source_definition.get('protocol') or source_definition['type']
+    
     # Ignore any lat/lon names for natively geographic sources.
-    ignore_conform_names = bool(source_definition['conform']['format'] != 'csv')
+    ignore_conform_names = bool(format_string != 'csv')
 
     # ESRI-derived source CSV is synthetic; we should ignore any lat/lon names.
-    ignore_conform_names |= bool(source_definition['protocol'] == 'ESRI')
+    ignore_conform_names |= bool(protocol_string == 'ESRI')
 
     # Set local variables lon_name, source_x, lat_name, source_y
     if ignore_conform_names:
@@ -1251,14 +1268,18 @@ def extract_to_source_csv(source_definition, source_path, extract_path):
     The extracted file will be in UTF-8 and will have X and Y columns corresponding
     to longitude and latitude in EPSG:4326.
     """
-    if source_definition["conform"]["format"] in ("shapefile", "shapefile-polygon", "xml", "gdb"):
+    # TODO: "type" is a deprecated tag
+    format_string = source_definition["conform"].get('format') or source_definition["conform"]['type']
+    protocol_string = source_definition.get('protocol') or source_definition['type']
+    
+    if format_string in ("shapefile", "shapefile-polygon", "xml", "gdb"):
         ogr_source_path = normalize_ogr_filename_case(source_path)
         ogr_source_to_csv(source_definition, ogr_source_path, extract_path)
-    elif source_definition["conform"]["format"] == "csv":
+    elif format_string == "csv":
         csv_source_to_csv(source_definition, source_path, extract_path)
-    elif source_definition["conform"]["format"] == "geojson":
+    elif format_string == "geojson":
         # GeoJSON sources have some awkward legacy with ESRI, see issue #34
-        if source_definition["protocol"] == "ESRI":
+        if protocol_string == "ESRI":
             _L.info("ESRI GeoJSON source found; treating it as CSV")
             csv_source_to_csv(source_definition, source_path, extract_path)
         else:
@@ -1266,7 +1287,7 @@ def extract_to_source_csv(source_definition, source_path, extract_path):
             geojson_source_path = normalize_ogr_filename_case(source_path)
             geojson_source_to_csv(geojson_source_path, extract_path)
     else:
-        raise Exception("Unsupported source format %s" % source_definition["conform"]["format"])
+        raise Exception("Unsupported source format %s" % format_string)
 
 def transform_to_out_csv(source_definition, extract_path, dest_path):
     ''' Transform an extracted source CSV to the OpenAddresses output CSV by applying conform rules.
@@ -1296,7 +1317,11 @@ def conform_cli(source_definition, source_path, dest_path):
 
     if "conform" not in source_definition:
         return 1
-    if not source_definition["conform"].get("format", None) in ["shapefile", "shapefile-polygon", "geojson", "csv", "xml", "gdb"]:
+
+    # TODO: "type" is a deprecated tag
+    format_string = source_definition["conform"].get('format') or source_definition["conform"].get('type')
+    
+    if not format_string in ["shapefile", "shapefile-polygon", "geojson", "csv", "xml", "gdb"]:
         _L.warning("Skipping file with unknown conform: %s", source_path)
         return 1
 

--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -25,13 +25,17 @@ class SourceProblem (enum.Enum):
     '''
     skip_source = 'Source says to skip'
     missing_conform = 'Source is missing a conform object'
-    unknown_conform_type = 'Unknown source conform type'
+    unknown_conform_format = 'Unknown source conform format'
+    unknown_conform_protocol = 'Unknown source conform protocol'
     download_source_failed = 'Could not download source data'
     conform_source_failed = 'Could not conform source data'
     no_coverage = 'Missing or incomplete coverage'
     no_esri_token = 'Missing required ESRI token'
     test_failed = 'An acceptance test failed'
     no_addresses_found = 'Found no addresses in source data'
+
+    # Old tag naming; replaced with "format" or "protocol"
+    unknown_conform_type = 'Unknown source conform type'
 
 def boolstr(value):
     '''
@@ -252,6 +256,12 @@ def find_source_problem(log_contents, source):
 
     if 'WARNING: Source is missing a conform object' in log_contents:
         return SourceProblem.missing_conform
+
+    if 'WARNING: Unknown source conform protocol' in log_contents:
+        return SourceProblem.unknown_conform_protocol
+
+    if 'WARNING: Unknown source conform format' in log_contents:
+        return SourceProblem.unknown_conform_format
 
     if 'WARNING: Unknown source conform type' in log_contents:
         return SourceProblem.unknown_conform_type

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -672,7 +672,7 @@ class TestOA (unittest.TestCase):
         self.assertFalse(state.skipped)
         self.assertIsNotNone(state.cache)
         # This test data does not contain a working conform object
-        self.assertIs(state.source_problem, SourceProblem.unknown_conform_type)
+        self.assertIs(state.source_problem, SourceProblem.unknown_conform_format)
         self.assertIsNone(state.processed)
         self.assertIsNone(state.preview)
         self.assertIsNone(state.slippymap)

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -1846,6 +1846,8 @@ class TestState (unittest.TestCase):
         self.assertIs(RunState({'source problem': find_source_problem('WARNING: Could not download ESRI source data: Could not retrieve layer metadata: Token Required', {})}).source_problem, SourceProblem.no_esri_token)
         self.assertIs(RunState({'source problem': find_source_problem('WARNING: Error doing conform; skipping', {})}).source_problem, SourceProblem.conform_source_failed)
         self.assertIs(RunState({'source problem': find_source_problem('WARNING: Could not download source data', {})}).source_problem, SourceProblem.download_source_failed)
+        self.assertIs(RunState({'source problem': find_source_problem('WARNING: Unknown source conform protocol', {})}).source_problem, SourceProblem.unknown_conform_protocol)
+        self.assertIs(RunState({'source problem': find_source_problem('WARNING: Unknown source conform format', {})}).source_problem, SourceProblem.unknown_conform_format)
         self.assertIs(RunState({'source problem': find_source_problem('WARNING: Unknown source conform type', {})}).source_problem, SourceProblem.unknown_conform_type)
         self.assertIs(RunState({'source problem': find_source_problem('WARNING: A source test failed', {})}).source_problem, SourceProblem.test_failed)
         self.assertIs(RunState({'source problem': find_source_problem('WARNING: Found no addresses in source data', {})}).source_problem, SourceProblem.no_addresses_found)

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -953,6 +953,28 @@ class TestOA (unittest.TestCase):
 
         self.assertEqual(len(sample_data), 6)
 
+    def test_single_utah_deprecated_type(self):
+        ''' Test complete process_one.process on data that uses file selection with mixed case (issue #104)
+        '''
+        source = join(self.src_dir, 'us-ut-deprecated-type.json')
+
+        with mock.patch('openaddr.util.request_ftp_file', new=self.response_content_ftp):
+            state_path = process_one.process(source, self.testdir, False, False, False)
+
+        with open(state_path) as file:
+            state = dict(zip(*json.load(file)))
+
+        self.assertIsNotNone(state['sample'])
+        self.assertIsNone(state['preview'])
+        self.assertIsNone(state['slippymap'])
+        self.assertIsNone(state['website'])
+        self.assertIsNone(state['license'])
+
+        with open(join(dirname(state_path), state['sample'])) as file:
+            sample_data = json.load(file)
+
+        self.assertEqual(len(sample_data), 6)
+
     def test_single_iceland(self):
         ''' Test complete process_one.process.
         '''
@@ -1172,6 +1194,49 @@ class TestOA (unittest.TestCase):
             self.assertEqual(rows[11]['STREET'], u'W 28TH DIVISION HWY')
             self.assertEqual(rows[21]['STREET'], u'W 28TH DIVISION HWY')
 
+    def test_single_pa_lancaster_deprecated_type(self):
+        ''' Test complete process_one.process on data with ESRI multiPolyline geometries.
+        '''
+        source = join(self.src_dir, 'us/pa/lancaster-deprecated-type.json')
+
+        with HTTMock(self.response_content):
+            state_path = process_one.process(source, self.testdir, False, False, False)
+
+        with open(state_path) as file:
+            state = dict(zip(*json.load(file)))
+
+        self.assertIsNotNone(state['sample'])
+        self.assertIsNone(state['preview'])
+        self.assertIsNone(state['slippymap'])
+
+        with open(join(dirname(state_path), state['sample'])) as file:
+            sample_data = json.load(file)
+
+        self.assertEqual(len(sample_data), 6)
+        self.assertIn('OA:geom', sample_data[0])
+        self.assertIn('UNITNUM', sample_data[0])
+        self.assertEqual('423', sample_data[1][0])
+        self.assertEqual(['W', ' ', '28TH DIVISION', 'HWY'], sample_data[1][1:5])
+        self.assertEqual('1', sample_data[1][6])
+        self.assertEqual('2', sample_data[2][6])
+        self.assertEqual('3', sample_data[3][6])
+        self.assertEqual('4', sample_data[4][6])
+        self.assertEqual('5', sample_data[5][6])
+
+        output_path = join(dirname(state_path), state['processed'])
+
+        with open(output_path, encoding='utf8') as input:
+            rows = list(csv.DictReader(input))
+            self.assertEqual(rows[1]['UNIT'], u'2')
+            self.assertEqual(rows[11]['UNIT'], u'11')
+            self.assertEqual(rows[21]['UNIT'], u'')
+            self.assertEqual(rows[1]['NUMBER'], u'423')
+            self.assertEqual(rows[11]['NUMBER'], u'423')
+            self.assertEqual(rows[21]['NUMBER'], u'7')
+            self.assertEqual(rows[1]['STREET'], u'W 28TH DIVISION HWY')
+            self.assertEqual(rows[11]['STREET'], u'W 28TH DIVISION HWY')
+            self.assertEqual(rows[21]['STREET'], u'W 28TH DIVISION HWY')
+
     def test_single_ua_kharkiv(self):
         ''' Test complete process_one.process on data with ESRI multiPolyline geometries.
         '''
@@ -1199,6 +1264,50 @@ class TestOA (unittest.TestCase):
         ''' Test complete process_one.process on data with ESRI multiPolyline geometries.
         '''
         source = join(self.src_dir, 'us/pa/bucks.json')
+
+        with HTTMock(self.response_content):
+            state_path = process_one.process(source, self.testdir, False, False, False)
+
+        with open(state_path) as file:
+            state = dict(zip(*json.load(file)))
+
+        self.assertIsNotNone(state['sample'])
+        self.assertIsNone(state['preview'])
+        self.assertIsNone(state['slippymap'])
+
+        with open(join(dirname(state_path), state['sample'])) as file:
+            sample_data = json.load(file)
+            row1 = dict(zip(sample_data[0], sample_data[1]))
+            row2 = dict(zip(sample_data[0], sample_data[2]))
+
+        self.assertEqual(len(sample_data), 6)
+        self.assertIn('SITUS_ADDR_NUM', sample_data[0])
+        self.assertIn('MUNI', sample_data[0])
+        self.assertEqual('', row1['SITUS_ADDR_NUM'])
+        self.assertEqual('STATE', row1['SITUS_FNAME'])
+        self.assertEqual('RD', row1['SITUS_FTYPE'])
+        self.assertEqual('', row2['SITUS_ADDR_NUM'])
+        self.assertEqual('STATE', row2['SITUS_FNAME'])
+        self.assertEqual('RD', row2['SITUS_FTYPE'])
+
+        output_path = join(dirname(state_path), state['processed'])
+
+        with open(output_path, encoding='utf8') as input:
+            rows = list(csv.DictReader(input))
+            self.assertEqual(rows[1]['UNIT'], u'')
+            self.assertEqual(rows[10]['UNIT'], u'')
+            self.assertEqual(rows[20]['UNIT'], u'')
+            self.assertEqual(rows[1]['NUMBER'], u'')
+            self.assertEqual(rows[10]['NUMBER'], u'')
+            self.assertEqual(rows[20]['NUMBER'], u'429')
+            self.assertEqual(rows[1]['STREET'], u'STATE RD')
+            self.assertEqual(rows[10]['STREET'], u'STATE RD')
+            self.assertEqual(rows[20]['STREET'], u'WALNUT AVE E')
+
+    def test_single_pa_bucks_deprecated_type(self):
+        ''' Test complete process_one.process on data with ESRI multiPolyline geometries.
+        '''
+        source = join(self.src_dir, 'us/pa/bucks-deprecated-type.json')
 
         with HTTMock(self.response_content):
             state_path = process_one.process(source, self.testdir, False, False, False)
@@ -1426,10 +1535,78 @@ class TestOA (unittest.TestCase):
             self.assertEqual(sample_datum[9], row['NUMBER'])
             self.assertEqual(sample_datum[13], row['STREET'])
 
+    def test_single_de_berlin_deprecated_type(self):
+        ''' Test complete process_one.process on data.
+        '''
+        source = join(self.src_dir, 'de/berlin-deprecated-type.json')
+
+        with HTTMock(self.response_content):
+            state_path = process_one.process(source, self.testdir, False, False, False)
+
+        with open(state_path) as file:
+            state = dict(zip(*json.load(file)))
+
+        output_path = join(dirname(state_path), state['processed'])
+
+        with open(output_path, encoding='utf8') as input:
+            rows = list(csv.DictReader(input))
+            self.assertEqual(rows[0]['NUMBER'], u'72')
+            self.assertEqual(rows[1]['NUMBER'], u'3')
+            self.assertEqual(rows[2]['NUMBER'], u'75')
+            self.assertEqual(rows[0]['STREET'], u'Otto-Braun-Stra\xdfe')
+            self.assertEqual(rows[1]['STREET'], u'Dorotheenstra\xdfe')
+            self.assertEqual(rows[2]['STREET'], u'Alte Jakobstra\xdfe')
+
+        self.assertIsNotNone(state['sample'])
+        self.assertIsNone(state['preview'])
+        self.assertIsNone(state['slippymap'])
+
+        with open(join(dirname(state_path), state['sample'])) as file:
+            sample_data = json.load(file)
+
+        self.assertEqual(len(sample_data), 6)
+
+        for (sample_datum, row) in zip(sample_data[1:], rows[0:]):
+            self.assertEqual(sample_datum[9], row['NUMBER'])
+            self.assertEqual(sample_datum[13], row['STREET'])
+
     def test_single_us_or_portland(self):
         ''' Test complete process_one.process on data.
         '''
         source = join(self.src_dir, 'us/or/portland.json')
+
+        with mock.patch('openaddr.util.request_ftp_file', new=self.response_content_ftp):
+            state_path = process_one.process(source, self.testdir, False, False, False)
+
+        with open(state_path) as file:
+            state = dict(zip(*json.load(file)))
+
+        output_path = join(dirname(state_path), state['processed'])
+
+        with open(output_path, encoding='utf8') as input:
+            rows = list(csv.DictReader(input))
+            self.assertEqual(len(rows), 12)
+            self.assertEqual(rows[2]['NUMBER'], u'1')
+            self.assertEqual(rows[3]['NUMBER'], u'10')
+            self.assertEqual(rows[-2]['NUMBER'], u'2211')
+            self.assertEqual(rows[-1]['NUMBER'], u'2211')
+            self.assertEqual(rows[2]['STREET'], u'SW RICHARDSON ST')
+            self.assertEqual(rows[3]['STREET'], u'SW PORTER ST')
+            self.assertEqual(rows[-2]['STREET'], u'SE OCHOCO ST')
+            self.assertEqual(rows[-1]['STREET'], u'SE OCHOCO ST')
+            self.assertTrue(bool(rows[2]['LAT']))
+            self.assertTrue(bool(rows[2]['LON']))
+            self.assertTrue(bool(rows[3]['LAT']))
+            self.assertTrue(bool(rows[3]['LON']))
+            self.assertFalse(bool(rows[-2]['LAT']))
+            self.assertFalse(bool(rows[-2]['LON']))
+            self.assertTrue(bool(rows[-1]['LAT']))
+            self.assertTrue(bool(rows[-1]['LON']))
+
+    def test_single_us_or_portland_deprecated_type(self):
+        ''' Test complete process_one.process on data.
+        '''
+        source = join(self.src_dir, 'us/or/portland-deprecated-type.json')
 
         with mock.patch('openaddr.util.request_ftp_file', new=self.response_content_ftp):
             state_path = process_one.process(source, self.testdir, False, False, False)
@@ -1550,6 +1727,35 @@ class TestOA (unittest.TestCase):
         ''' Test complete process_one.process on data.
         '''
         source = join(self.src_dir, 'us/nj/statewide.json')
+
+        with HTTMock(self.response_content):
+            state_path = process_one.process(source, self.testdir, False, False, False)
+
+        with open(state_path) as file:
+            state = dict(zip(*json.load(file)))
+
+        output_path = join(dirname(state_path), state['processed'])
+
+        with open(output_path, encoding='utf8') as input:
+            rows = list(csv.DictReader(input))
+            self.assertEqual(len(rows), 1045)
+            self.assertEqual(rows[0]['NUMBER'], u'7')
+            self.assertEqual(rows[0]['STREET'], u'Sagamore Avenue')
+            self.assertEqual(rows[1]['NUMBER'], u'29')
+            self.assertEqual(rows[1]['STREET'], u'Sagamore Avenue')
+            self.assertEqual(rows[2]['NUMBER'], u'47')
+            self.assertEqual(rows[2]['STREET'], u'Seneca Place')
+            self.assertAlmostEqual(float(rows[0]['LON']), -74.0012016, places=5)
+            self.assertAlmostEqual(float(rows[0]['LAT']),  40.3201199, places=5)
+            self.assertAlmostEqual(float(rows[1]['LON']), -74.0027904, places=5)
+            self.assertAlmostEqual(float(rows[1]['LAT']),  40.3203365, places=5)
+            self.assertAlmostEqual(float(rows[2]['LON']), -74.0011386, places=5)
+            self.assertAlmostEqual(float(rows[2]['LAT']),  40.3166497, places=5)
+
+    def test_single_us_nj_statewide_deprecated_type(self):
+        ''' Test complete process_one.process on data.
+        '''
+        source = join(self.src_dir, 'us/nj/statewide-deprecated-type.json')
 
         with HTTMock(self.response_content):
             state_path = process_one.process(source, self.testdir, False, False, False)

--- a/openaddr/tests/conform.py
+++ b/openaddr/tests/conform.py
@@ -325,28 +325,28 @@ class TestConformTransforms (unittest.TestCase):
 
     def test_row_extract_and_reproject(self):
         # CSV lat/lon column names
-        d = { "conform" : { "lon": "longitude", "lat": "latitude", "type": "csv" }, 'type': 'test' }
+        d = { "conform" : { "lon": "longitude", "lat": "latitude", "format": "csv" }, 'protocol': 'test' }
         r = row_extract_and_reproject(d, {"longitude": "-122.3", "latitude": "39.1"})
         self.assertEqual({Y_FIELDNAME: "39.1", X_FIELDNAME: "-122.3"}, r)
 
         # non-CSV lat/lon column names
-        d = { "conform" : { "lon": "x", "lat": "y", "type": "" }, 'type': 'test' }
+        d = { "conform" : { "lon": "x", "lat": "y", "format": "" }, 'protocol': 'test' }
         r = row_extract_and_reproject(d, {X_FIELDNAME: "-122.3", Y_FIELDNAME: "39.1" })
         self.assertEqual({X_FIELDNAME: "-122.3", Y_FIELDNAME: "39.1"}, r)
 
         # reprojection
-        d = { "conform" : { "srs": "EPSG:2913", "type": "" }, 'type': 'test' }
+        d = { "conform" : { "srs": "EPSG:2913", "format": "" }, 'protocol': 'test' }
         r = row_extract_and_reproject(d, {X_FIELDNAME: "7655634.924", Y_FIELDNAME: "668868.414"})
         self.assertAlmostEqual(-122.630842186650796, float(r[X_FIELDNAME]))
         self.assertAlmostEqual(45.481554393851063, float(r[Y_FIELDNAME]))
 
-        d = { "conform" : { "lon": "X", "lat": "Y", "srs": "EPSG:2913", "type": "" }, 'type': 'test' }
+        d = { "conform" : { "lon": "X", "lat": "Y", "srs": "EPSG:2913", "format": "" }, 'protocol': 'test' }
         r = row_extract_and_reproject(d, {X_FIELDNAME: "", Y_FIELDNAME: ""})
         self.assertEqual("", r[X_FIELDNAME])
         self.assertEqual("", r[Y_FIELDNAME])
 
         # commas in lat/lon columns (eg Iceland)
-        d = { "conform" : { "lon": "LONG_WGS84", "lat": "LAT_WGS84", "type": "csv" }, 'type': 'test' }
+        d = { "conform" : { "lon": "LONG_WGS84", "lat": "LAT_WGS84", "format": "csv" }, 'protocol': 'test' }
         r = row_extract_and_reproject(d, {"LONG_WGS84": "-21,77", "LAT_WGS84": "64,11"})
         self.assertEqual({Y_FIELDNAME: "64.11", X_FIELDNAME: "-21.77"}, r)
 
@@ -1400,7 +1400,7 @@ class TestConformCli (unittest.TestCase):
         # Test that the conform tool does something reasonable with unknown conform sources
         self.assertEqual(1, conform_cli({}, 'test', ''))
         self.assertEqual(1, conform_cli({'conform': {}}, 'test', ''))
-        self.assertEqual(1, conform_cli({'conform': {'type': 'broken'}}, 'test', ''))
+        self.assertEqual(1, conform_cli({'conform': {'format': 'broken'}}, 'test', ''))
 
     def test_lake_man(self):
         rc, dest_path = self._run_conform_on_source('lake-man', 'shp')
@@ -1660,7 +1660,7 @@ class TestConformMisc(unittest.TestCase):
         self.assertEqual(re.sub(r'he(ll)o', crr('he$1$1o'), 'hello'), 'hellllo')
 
     def test_find_shapefile_source_path(self):
-        shp_conform = {"conform": { "type": "shapefile" } }
+        shp_conform = {"conform": { "format": "shapefile" } }
         self.assertEqual("foo.shp", find_source_path(shp_conform, ["foo.shp"]))
         self.assertEqual("FOO.SHP", find_source_path(shp_conform, ["FOO.SHP"]))
         self.assertEqual("xyzzy/FOO.SHP", find_source_path(shp_conform, ["xyzzy/FOO.SHP"]))
@@ -1668,19 +1668,19 @@ class TestConformMisc(unittest.TestCase):
         self.assertEqual(None, find_source_path(shp_conform, ["nope.txt"]))
         self.assertEqual(None, find_source_path(shp_conform, ["foo.shp", "bar.shp"]))
 
-        shp_file_conform = {"conform": { "type": "shapefile", "file": "foo.shp" } }
+        shp_file_conform = {"conform": { "format": "shapefile", "file": "foo.shp" } }
         self.assertEqual("foo.shp", find_source_path(shp_file_conform, ["foo.shp"]))
         self.assertEqual("foo.shp", find_source_path(shp_file_conform, ["foo.shp", "bar.shp"]))
         self.assertEqual("xyzzy/foo.shp", find_source_path(shp_file_conform, ["xyzzy/foo.shp", "xyzzy/bar.shp"]))
 
-        shp_poly_conform = {"conform": { "type": "shapefile-polygon" } }
+        shp_poly_conform = {"conform": { "format": "shapefile-polygon" } }
         self.assertEqual("foo.shp", find_source_path(shp_poly_conform, ["foo.shp"]))
 
-        broken_conform = {"conform": { "type": "broken" }}
+        broken_conform = {"conform": { "format": "broken" }}
         self.assertEqual(None, find_source_path(broken_conform, ["foo.shp"]))
 
     def test_find_gdb_source_path(self):
-        shp_conform = {"conform": { "type": "gdb" } }
+        shp_conform = {"conform": { "format": "gdb" } }
         self.assertEqual("foo.gdb", find_source_path(shp_conform, ["foo.gdb"]))
         self.assertEqual("FOO.GDB", find_source_path(shp_conform, ["FOO.GDB"]))
         self.assertEqual("xyzzy/FOO.GDB", find_source_path(shp_conform, ["xyzzy/FOO.GDB"]))
@@ -1688,13 +1688,13 @@ class TestConformMisc(unittest.TestCase):
         self.assertEqual(None, find_source_path(shp_conform, ["nope.txt"]))
         self.assertEqual(None, find_source_path(shp_conform, ["foo.gdb", "bar.gdb"]))
 
-        shp_file_conform = {"conform": { "type": "gdb", "file": "foo.gdb" } }
+        shp_file_conform = {"conform": { "format": "gdb", "file": "foo.gdb" } }
         self.assertEqual("foo.gdb", find_source_path(shp_file_conform, ["foo.gdb"]))
         self.assertEqual("foo.gdb", find_source_path(shp_file_conform, ["foo.gdb", "bar.gdb"]))
         self.assertEqual("xyzzy/foo.gdb", find_source_path(shp_file_conform, ["xyzzy/foo.gdb", "xyzzy/bar.gdb"]))
 
     def test_find_geojson_source_path(self):
-        geojson_conform = {"type": "notESRI", "conform": {"type": "geojson"}}
+        geojson_conform = {"protocol": "notESRI", "conform": {"format": "geojson"}}
         self.assertEqual("foo.json", find_source_path(geojson_conform, ["foo.json"]))
         self.assertEqual("FOO.JSON", find_source_path(geojson_conform, ["FOO.JSON"]))
         self.assertEqual("xyzzy/FOO.JSON", find_source_path(geojson_conform, ["xyzzy/FOO.JSON"]))
@@ -1704,24 +1704,24 @@ class TestConformMisc(unittest.TestCase):
 
     def test_find_esri_source_path(self):
         # test that the legacy ESRI/GeoJSON style works
-        old_conform = {"type": "ESRI", "conform": {"type": "geojson"}}
+        old_conform = {"protocol": "ESRI", "conform": {"format": "geojson"}}
         self.assertEqual("foo.csv", find_source_path(old_conform, ["foo.csv"]))
         # test that the new ESRI/CSV style works
-        new_conform = {"type": "ESRI", "conform": {"type": "csv"}}
+        new_conform = {"protocol": "ESRI", "conform": {"format": "csv"}}
         self.assertEqual("foo.csv", find_source_path(new_conform, ["foo.csv"]))
 
     def test_find_csv_source_path(self):
-        csv_conform = {"conform": {"type": "csv"}}
+        csv_conform = {"conform": {"format": "csv"}}
         self.assertEqual("foo.csv", find_source_path(csv_conform, ["foo.csv"]))
-        csv_file_conform = {"conform": {"type": "csv", "file":"bar.txt"}}
+        csv_file_conform = {"conform": {"format": "csv", "file":"bar.txt"}}
         self.assertEqual("bar.txt", find_source_path(csv_file_conform, ["license.pdf", "bar.txt"]))
         self.assertEqual("aa/bar.txt", find_source_path(csv_file_conform, ["license.pdf", "aa/bar.txt"]))
         self.assertEqual(None, find_source_path(csv_file_conform, ["foo.txt"]))
 
     def test_find_xml_source_path(self):
-        c = {"conform": {"type": "xml"}}
+        c = {"conform": {"format": "xml"}}
         self.assertEqual("foo.gml", find_source_path(c, ["foo.gml"]))
-        c = {"conform": {"type": "xml", "file": "xyzzy/foo.gml"}}
+        c = {"conform": {"format": "xml", "file": "xyzzy/foo.gml"}}
         self.assertEqual("xyzzy/foo.gml", find_source_path(c, ["xyzzy/foo.gml", "bar.gml", "foo.gml"]))
         self.assertEqual("/tmp/foo/xyzzy/foo.gml", find_source_path(c, ["/tmp/foo/xyzzy/foo.gml"]))
 
@@ -1856,7 +1856,7 @@ class TestConformCsv(unittest.TestCase):
             return [s.decode('utf-8').strip() for s in file]
 
     def test_simple(self):
-        c = { "conform": { "type": "csv", "lat": "LATITUDE", "lon": "LONGITUDE" }, 'type': 'test' }
+        c = { "conform": { "format": "csv", "lat": "LATITUDE", "lon": "LONGITUDE" }, 'protocol': 'test' }
         d = (self._ascii_header_in.encode('ascii'),
              self._ascii_row_in.encode('ascii'))
         r = self._convert(c, d)
@@ -1864,7 +1864,7 @@ class TestConformCsv(unittest.TestCase):
         self.assertEqual(self._ascii_row_out, r[1])
 
     def test_utf8(self):
-        c = { "conform": { "type": "csv", "lat": u"\u7def\u5ea6", "lon": u"LONGITUDE" }, 'type': 'test' }
+        c = { "conform": { "format": "csv", "lat": u"\u7def\u5ea6", "lon": u"LONGITUDE" }, 'protocol': 'test' }
         d = (self._unicode_header_in.encode('utf-8'),
              self._unicode_row_in.encode('utf-8'))
         r = self._convert(c, d)
@@ -1872,19 +1872,19 @@ class TestConformCsv(unittest.TestCase):
         self.assertEqual(self._unicode_row_out, r[1])
 
     def test_csvsplit(self):
-        c = { "conform": { "csvsplit": ";", "type": "csv", "lat": "LATITUDE", "lon": "LONGITUDE" }, 'type': 'test' }
+        c = { "conform": { "csvsplit": ";", "format": "csv", "lat": "LATITUDE", "lon": "LONGITUDE" }, 'protocol': 'test' }
         d = (self._ascii_header_in.replace(',', ';').encode('ascii'),
              self._ascii_row_in.replace(',', ';').encode('ascii'))
         r = self._convert(c, d)
         self.assertEqual(self._ascii_header_out, r[0])
         self.assertEqual(self._ascii_row_out, r[1])
 
-        unicode_conform = { "conform": { "csvsplit": u";", "type": "csv", "lat": "LATITUDE", "lon": "LONGITUDE" }, 'type': 'test' }
+        unicode_conform = { "conform": { "csvsplit": u";", "format": "csv", "lat": "LATITUDE", "lon": "LONGITUDE" }, 'protocol': 'test' }
         r = self._convert(unicode_conform, d)
         self.assertEqual(self._ascii_row_out, r[1])
 
     def test_csvencoded_utf8(self):
-        c = { "conform": { "encoding": "utf-8", "type": "csv", "lat": u"\u7def\u5ea6", "lon": u"LONGITUDE" }, 'type': 'test' }
+        c = { "conform": { "encoding": "utf-8", "format": "csv", "lat": u"\u7def\u5ea6", "lon": u"LONGITUDE" }, 'protocol': 'test' }
         d = (self._unicode_header_in.encode('utf-8'),
              self._unicode_row_in.encode('utf-8'))
         r = self._convert(c, d)
@@ -1892,7 +1892,7 @@ class TestConformCsv(unittest.TestCase):
         self.assertEqual(self._unicode_row_out, r[1])
 
     def test_csvencoded_shift_jis(self):
-        c = { "conform": { "encoding": "shift-jis", "type": "csv", "lat": u"\u7def\u5ea6", "lon": u"LONGITUDE" }, 'type': 'test' }
+        c = { "conform": { "encoding": "shift-jis", "format": "csv", "lat": u"\u7def\u5ea6", "lon": u"LONGITUDE" }, 'protocol': 'test' }
         d = (u'\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d,NUMBER,\u7def\u5ea6,LONGITUDE'.encode('shift-jis'),
              u'\u6771 ST,123,39.3,-121.2'.encode('shift-jis'))
         r = self._convert(c, d)
@@ -1900,14 +1900,14 @@ class TestConformCsv(unittest.TestCase):
         self.assertEqual(r[1], u'\u6771 ST,123,-121.2,39.3')
 
     def test_headers_minus_one(self):
-        c = { "conform": { "headers": -1, "type": "csv", "lon": "COLUMN4", "lat": "COLUMN3" }, 'type': 'test' }
+        c = { "conform": { "headers": -1, "format": "csv", "lon": "COLUMN4", "lat": "COLUMN3" }, 'protocol': 'test' }
         d = (u'MAPLE ST,123,39.3,-121.2'.encode('ascii'),)
         r = self._convert(c, d)
         self.assertEqual(r[0], u'COLUMN1,COLUMN2,{X_FIELDNAME},{Y_FIELDNAME}'.format(**globals()))
         self.assertEqual(r[1], u'MAPLE ST,123,-121.2,39.3')
 
     def test_headers_and_skiplines(self):
-        c = {"conform": { "headers": 2, "skiplines": 2, "type": "csv", "lon": "LONGITUDE", "lat": "LATITUDE" }, 'type': 'test' }
+        c = {"conform": { "headers": 2, "skiplines": 2, "format": "csv", "lon": "LONGITUDE", "lat": "LATITUDE" }, 'protocol': 'test' }
         d = (u'HAHA,THIS,HEADER,IS,FAKE'.encode('ascii'),
              self._ascii_header_in.encode('ascii'),
              self._ascii_row_in.encode('ascii'))
@@ -1919,7 +1919,7 @@ class TestConformCsv(unittest.TestCase):
         # This is an example inspired by the hipsters in us-or-portland
         # Conform says lowercase but the actual header is uppercase.
         # Also the columns are named X and Y in the input
-        c = {"conform": {"lon": "x", "lat": "y", "number": "n", "street": "s", "type": "csv"}, 'type': 'test'}
+        c = {"conform": {"lon": "x", "lat": "y", "number": "n", "street": "s", "format": "csv"}, 'protocol': 'test'}
         d = (u'n,s,X,Y'.encode('ascii'),
              u'3203,SE WOODSTOCK BLVD,-122.629314,45.479425'.encode('ascii'))
         r = self._convert(c, d)
@@ -1928,7 +1928,7 @@ class TestConformCsv(unittest.TestCase):
 
     def test_srs(self):
         # This is an example inspired by the hipsters in us-or-portland
-        c = {"conform": {"lon": "x", "lat": "y", "srs": "EPSG:2913", "number": "n", "street": "s", "type": "csv"}, 'type': 'test'}
+        c = {"conform": {"lon": "x", "lat": "y", "srs": "EPSG:2913", "number": "n", "street": "s", "format": "csv"}, 'protocol': 'test'}
         d = (u'n,s,X,Y'.encode('ascii'),
              u'3203,SE WOODSTOCK BLVD,7655634.924,668868.414'.encode('ascii'))
         r = self._convert(c, d)
@@ -1937,7 +1937,7 @@ class TestConformCsv(unittest.TestCase):
 
     def test_too_many_columns(self):
         "Check that we don't barf on input with too many columns in some rows"
-        c = { "conform": { "type": "csv", "lat": "LATITUDE", "lon": "LONGITUDE" }, 'type': 'test' }
+        c = { "conform": { "format": "csv", "lat": "LATITUDE", "lon": "LONGITUDE" }, 'protocol': 'test' }
         d = (self._ascii_header_in.encode('ascii'),
              self._ascii_row_in.encode('ascii'),
              u'MAPLE ST,123,39.3,-121.2,EXTRY'.encode('ascii'))
@@ -1948,7 +1948,7 @@ class TestConformCsv(unittest.TestCase):
 
     def test_esri_csv(self):
         # Test that our ESRI-emitted CSV is converted correctly.
-        c = { "type": "ESRI", "conform": { "type": "geojson", "lat": "theseare", "lon": "ignored" } }
+        c = { "protocol": "ESRI", "conform": { "format": "geojson", "lat": "theseare", "lon": "ignored" } }
         d = (u'STREETNAME,NUMBER,OA:x,OA:y'.encode('ascii'),
              u'MAPLE ST,123,-121.2,39.3'.encode('ascii'))
         r = self._convert(c, d)
@@ -1957,7 +1957,7 @@ class TestConformCsv(unittest.TestCase):
 
     def test_esri_csv_no_lat_lon(self):
         # Test that the ESRI path works even without lat/lon tags. See issue #91
-        c = { "type": "ESRI", "conform": { "type": "geojson" } }
+        c = { "protocol": "ESRI", "conform": { "format": "geojson" } }
         d = (u'STREETNAME,NUMBER,OA:x,OA:y'.encode('ascii'),
              u'MAPLE ST,123,-121.2,39.3'.encode('ascii'))
         r = self._convert(c, d)

--- a/openaddr/tests/conforms/jp-nara.json
+++ b/openaddr/tests/conforms/jp-nara.json
@@ -1,5 +1,5 @@
 {
-    "type": "http",
+    "protocol": "http",
     "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-nara.zip",
     "website": "http://nlftp.mlit.go.jp/isj/index.html",
     "compression": "zip",
@@ -10,7 +10,7 @@
         "state": "\u5948\u826f\u770c"
     },
     "conform": {
-        "type": "csv",
+        "format": "csv",
         "lat": "\u7def\u5ea6",
         "srs": "EPSG:4612",
         "number": "auto_number",

--- a/openaddr/tests/conforms/lake-man-3740.json
+++ b/openaddr/tests/conforms/lake-man-3740.json
@@ -1,13 +1,13 @@
 {
     "data": "http://fake-web/lake-man-3740",
     "cache": "http://fake-cache/lake-man-3740.json",
-    "type": "http",
+    "protocol": "http",
     "conform": {
         "lon": "lon",
         "lat": "lat",
         "number": "number",
         "street": "street",
-        "type": "csv",
+        "format": "csv",
         "srs": "EPSG:3740"
     }
 }

--- a/openaddr/tests/conforms/lake-man-epsg26943-noprj.json
+++ b/openaddr/tests/conforms/lake-man-epsg26943-noprj.json
@@ -1,14 +1,14 @@
 {
     "data": "http://fake-web/lake-man-epsg26943.zip",
     "cache": "http://fake-cache/lake-man-epsg26943.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "NUMBER",
         "street": "STRNAME",
-        "type": "shapefile",
+        "format": "shapefile",
         "srs": "EPSG:26943"
     }
 }

--- a/openaddr/tests/conforms/lake-man-epsg26943.json
+++ b/openaddr/tests/conforms/lake-man-epsg26943.json
@@ -1,13 +1,13 @@
 {
     "data": "http://fake-web/lake-man-epsg26943.zip",
     "cache": "http://fake-cache/lake-man-epsg26943.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "NUMBER",
         "street": "STRNAME",
-        "type": "shapefile"
+        "format": "shapefile"
     }
 }

--- a/openaddr/tests/conforms/lake-man-gdb.json
+++ b/openaddr/tests/conforms/lake-man-gdb.json
@@ -1,13 +1,13 @@
 {
     "data": "http://fake-web/lake-man.gdb.zip",
     "cache": "http://fake-cache/lake-man.gdb.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "NUMBER",
         "street": "STRNAME",
-        "type": "gdb"
+        "format": "gdb"
     }
 }

--- a/openaddr/tests/conforms/lake-man-gml.json
+++ b/openaddr/tests/conforms/lake-man-gml.json
@@ -1,14 +1,14 @@
 {
     "data": "http://fake-web/lake-man.zip",
     "cache": "http://fake-cache/lake-man.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "NUMBER",
         "street": "STRNAME",
-        "type": "xml",
+        "format": "xml",
         "srs": "EPSG:4326"
     }
 }

--- a/openaddr/tests/conforms/lake-man-merge-postcode.json
+++ b/openaddr/tests/conforms/lake-man-merge-postcode.json
@@ -1,7 +1,7 @@
 {
     "data": "http://fake-web/lake-man-merge-postcode.zip",
     "cache": "http://fake-cache/lake-man-merge-postcode.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "street": [
@@ -11,7 +11,7 @@
         "lon": "X",
         "lat": "Y",
         "number": "HOUSE_NUM",
-        "type": "shapefile",
+        "format": "shapefile",
         "postcode": "ZIPCODE"
     }
 }

--- a/openaddr/tests/conforms/lake-man-merge-postcode2.json
+++ b/openaddr/tests/conforms/lake-man-merge-postcode2.json
@@ -1,7 +1,7 @@
 {
     "data": "http://fake-web/lake-man-merge-postcode2.zip",
     "cache": "http://fake-cache/lake-man-merge-postcode2.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "street": [
@@ -11,7 +11,7 @@
         "lon": "X",
         "lat": "Y",
         "number": "ST_NUM",
-        "type": "shapefile",
+        "format": "shapefile",
         "postcode": "ZIPCODE"
     }
 }

--- a/openaddr/tests/conforms/lake-man-split.json
+++ b/openaddr/tests/conforms/lake-man-split.json
@@ -1,7 +1,7 @@
 {
     "data": "http://fake-web/lake-man-split.zip",
     "cache": "http://fake-cache/lake-man-split.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
@@ -16,6 +16,6 @@
             "field": "ADD_RANGE",
             "pattern": "^(?:\\S+ )(.*)"
             },
-        "type": "shapefile"
+        "format": "shapefile"
     }
 }

--- a/openaddr/tests/conforms/lake-man-split2.json
+++ b/openaddr/tests/conforms/lake-man-split2.json
@@ -1,7 +1,7 @@
 {
     "data": "http://fake-web/lake-man-split2",
     "cache": "http://fake-cache/lake-man-split2.json",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
         "lon": "NONSENSE",
         "lat": "Y",
@@ -15,6 +15,6 @@
             "field": "MAILSTREET",
             "pattern": "^(?:\\S+ )(.*)"
             },
-        "type": "geojson"
+        "format": "geojson"
     }
 }

--- a/openaddr/tests/conforms/lake-man-utf8.json
+++ b/openaddr/tests/conforms/lake-man-utf8.json
@@ -1,14 +1,14 @@
 {
     "data": "http://fake-web/lake-man-utf8",
     "cache": "http://fake-cache/lake-man-utf8.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "number",
         "street": "street",
-        "type": "shapefile",
+        "format": "shapefile",
 	"encoding": "utf-8"
     }
 }

--- a/openaddr/tests/conforms/lake-man.json
+++ b/openaddr/tests/conforms/lake-man.json
@@ -1,13 +1,13 @@
 {
     "data": "http://fake-web/lake-man.zip",
     "cache": "http://fake-cache/lake-man.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "NUMBER",
         "street": "STRNAME",
-        "type": "shapefile"
+        "format": "shapefile"
     }
 }

--- a/openaddr/tests/parcels/sources/us/ca/berkeley.json
+++ b/openaddr/tests/parcels/sources/us/ca/berkeley.json
@@ -13,7 +13,7 @@
     "attribution": "City of Berkeley",
     "data": "http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.zip",
     "website": "http://www.ci.berkeley.ca.us/datacatalog/",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "note": "Metadata at http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.shp(1).xml",
     "conform": {
@@ -27,6 +27,6 @@
         "unit": "Unit",
         "city": "City",
         "postcode": "Zip",
-        "type": "shapefile-polygon"
+        "format": "shapefile-polygon"
     }
 }

--- a/openaddr/tests/parcels/sources/us/id/clearwater.json
+++ b/openaddr/tests/parcels/sources/us/id/clearwater.json
@@ -10,9 +10,9 @@
         "county": "Clearwater"
     },
     "data": "http://gis.clearwatercounty.org/arcgis/rest/services/County/MapServer/1",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
-        "type": "geojson",
+        "format": "geojson",
         "number": "Prop_StNum",
         "unit": "DLVRY_APT",
         "street": "prop_stree",

--- a/openaddr/tests/sources/be/wa/brussels-fr.json
+++ b/openaddr/tests/sources/be/wa/brussels-fr.json
@@ -1,5 +1,5 @@
 {
-    "type": "http",
+    "protocol": "http",
     "data": "https://s.irisnet.be/v1/AUTH_b4e6bcc3-db61-442e-8b59-e0ce9142d182/Region/UrbAdm_SHP.zip",
     "website": "http://bric.brussels/",
     "compression": "zip",
@@ -12,7 +12,7 @@
     "license": "http://bric.brussels/en/our-solutions/urbis-solutions/Licence%20Open%20data%20Fr%20v4.pdf",
     "conform": {
         "encoding": "utf-8",
-        "type": "shapefile",
+        "format": "shapefile",
         "file": "shp/UrbAdm_AdPt.shp",
         "number": "ADRN",
         "city":  "MU_NAME_FR",

--- a/openaddr/tests/sources/cz-countrywide-bad-tests.json
+++ b/openaddr/tests/sources/cz-countrywide-bad-tests.json
@@ -8,7 +8,7 @@
     },
     "website": "http://vdp.cuzk.cz/vdp/ruian/vymennyformat/vyhledej?vf.pu=S&_vf.pu=on&_vf.pu=on&vf.cr=U&vf.up=OB&vf.ds=Z&vf.vu=Z&_vf.vu=on&_vf.vu=on&_vf.vu=on&_vf.vu=on&vf.uo=O&ob.kod=531723&search=Vyhledat",
     "license": "§ 62 of Law 111/2009 Sb - http://www.zakonyprolidi.cz/cs/2009-111#p62",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "data": "https://www.dropbox.com/s/fhopgbg4vkyoobr/czech_addresses_wgs84_12092016_MASTER.zip?dl=1",
     "note": {
@@ -36,7 +36,7 @@
         "city": "alternativ",
         "postcode": "alternativ",
         "file": "czech_addresses_wgs84_12092016_MASTER.csv",
-        "type": "csv",
+        "format": "csv",
         "accuracy": 1
     },
     "test": {

--- a/openaddr/tests/sources/cz-countrywide-disabled-tests.json
+++ b/openaddr/tests/sources/cz-countrywide-disabled-tests.json
@@ -8,7 +8,7 @@
     },
     "website": "http://vdp.cuzk.cz/vdp/ruian/vymennyformat/vyhledej?vf.pu=S&_vf.pu=on&_vf.pu=on&vf.cr=U&vf.up=OB&vf.ds=Z&vf.vu=Z&_vf.vu=on&_vf.vu=on&_vf.vu=on&_vf.vu=on&vf.uo=O&ob.kod=531723&search=Vyhledat",
     "license": "§ 62 of Law 111/2009 Sb - http://www.zakonyprolidi.cz/cs/2009-111#p62",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "data": "https://www.dropbox.com/s/fhopgbg4vkyoobr/czech_addresses_wgs84_12092016_MASTER.zip?dl=1",
     "note": {
@@ -52,7 +52,7 @@
             "pattern": "(?:.*),\\s+(\\d+)"
         },
         "file": "czech_addresses_wgs84_12092016_MASTER.csv",
-        "type": "csv",
+        "format": "csv",
         "accuracy": 1
     },
     "test": {

--- a/openaddr/tests/sources/cz-countrywide-good-tests.json
+++ b/openaddr/tests/sources/cz-countrywide-good-tests.json
@@ -8,7 +8,7 @@
     },
     "website": "http://vdp.cuzk.cz/vdp/ruian/vymennyformat/vyhledej?vf.pu=S&_vf.pu=on&_vf.pu=on&vf.cr=U&vf.up=OB&vf.ds=Z&vf.vu=Z&_vf.vu=on&_vf.vu=on&_vf.vu=on&_vf.vu=on&vf.uo=O&ob.kod=531723&search=Vyhledat",
     "license": "§ 62 of Law 111/2009 Sb - http://www.zakonyprolidi.cz/cs/2009-111#p62",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "data": "https://www.dropbox.com/s/fhopgbg4vkyoobr/czech_addresses_wgs84_12092016_MASTER.zip?dl=1",
     "note": {
@@ -52,7 +52,7 @@
             "pattern": "(?:.*),\\s+(\\d+)"
         },
         "file": "czech_addresses_wgs84_12092016_MASTER.csv",
-        "type": "csv",
+        "format": "csv",
         "accuracy": 1
     },
     "test": {

--- a/openaddr/tests/sources/cz-countrywide-implied-tests.json
+++ b/openaddr/tests/sources/cz-countrywide-implied-tests.json
@@ -8,7 +8,7 @@
     },
     "website": "http://vdp.cuzk.cz/vdp/ruian/vymennyformat/vyhledej?vf.pu=S&_vf.pu=on&_vf.pu=on&vf.cr=U&vf.up=OB&vf.ds=Z&vf.vu=Z&_vf.vu=on&_vf.vu=on&_vf.vu=on&_vf.vu=on&vf.uo=O&ob.kod=531723&search=Vyhledat",
     "license": "§ 62 of Law 111/2009 Sb - http://www.zakonyprolidi.cz/cs/2009-111#p62",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "data": "https://www.dropbox.com/s/fhopgbg4vkyoobr/czech_addresses_wgs84_12092016_MASTER.zip?dl=1",
     "note": {
@@ -52,7 +52,7 @@
             "pattern": "(?:.*),\\s+(\\d+)"
         },
         "file": "czech_addresses_wgs84_12092016_MASTER.csv",
-        "type": "csv",
+        "format": "csv",
         "accuracy": 1
     },
     "test": {

--- a/openaddr/tests/sources/cz-countrywide-no-tests.json
+++ b/openaddr/tests/sources/cz-countrywide-no-tests.json
@@ -8,7 +8,7 @@
     },
     "website": "http://vdp.cuzk.cz/vdp/ruian/vymennyformat/vyhledej?vf.pu=S&_vf.pu=on&_vf.pu=on&vf.cr=U&vf.up=OB&vf.ds=Z&vf.vu=Z&_vf.vu=on&_vf.vu=on&_vf.vu=on&_vf.vu=on&vf.uo=O&ob.kod=531723&search=Vyhledat",
     "license": "§ 62 of Law 111/2009 Sb - http://www.zakonyprolidi.cz/cs/2009-111#p62",
-    "type": "http",
+    "format": "http",
     "compression": "zip",
     "data": "https://www.dropbox.com/s/fhopgbg4vkyoobr/czech_addresses_wgs84_12092016_MASTER.zip?dl=1",
     "note": {
@@ -52,7 +52,7 @@
             "pattern": "(?:.*),\\s+(\\d+)"
         },
         "file": "czech_addresses_wgs84_12092016_MASTER.csv",
-        "type": "csv",
+        "format": "csv",
         "accuracy": 1
     },
     "test": {}

--- a/openaddr/tests/sources/de/berlin-deprecated-type.json
+++ b/openaddr/tests/sources/de/berlin-deprecated-type.json
@@ -1,0 +1,34 @@
+{
+	"coverage": {
+		"country": "de",
+		"state": "berline",
+		"ISO 3166": {
+            "alpha2": "DE-BE",
+            "country": "Germany",
+            "subdivision": "Berlin"
+        }
+	},
+	"data": "http://fbarc.stadt-berlin.de/FIS_Broker_Atom/Hauskoordinaten/HKO_EPSG3068.zip",
+	"website": "http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_hauskoordinaten@senstadt&type=FEED",
+	"type": "http",
+	"compression": "zip",
+	"license": {
+		"text": "Nutzungsbestimmungen Geoportal Berlin",
+		"url": "http://www.stadtentwicklung.berlin.de/geoinformation/download/nutzIII.pdf",
+		"attribution": true,
+		"share-alike": false,
+		"attribution name": "Geoportal Berlin / Hauskoordinaten Berlin"
+	},
+	"conform": {
+		"type": "csv",
+		"srs": "EPSG:3068",
+		"encoding": "ISO-8859-1",
+		"csvsplit": ";",
+		"lat": "NNNNNNN_NNN",
+		"lon": "EEEEEEEE_EEE",
+		"city": "ONM",
+		"postcode": "PLZ",
+		"street": "STN",
+		"number": ["HNR", "ADZ"]
+	}
+}

--- a/openaddr/tests/sources/de/berlin.json
+++ b/openaddr/tests/sources/de/berlin.json
@@ -10,7 +10,7 @@
 	},
 	"data": "http://fbarc.stadt-berlin.de/FIS_Broker_Atom/Hauskoordinaten/HKO_EPSG3068.zip",
 	"website": "http://fbinter.stadt-berlin.de/fb/berlin/service.jsp?id=a_hauskoordinaten@senstadt&type=FEED",
-	"type": "http",
+	"protocol": "http",
 	"compression": "zip",
 	"license": {
 		"text": "Nutzungsbestimmungen Geoportal Berlin",
@@ -20,7 +20,7 @@
 		"attribution name": "Geoportal Berlin / Hauskoordinaten Berlin"
 	},
 	"conform": {
-		"type": "csv",
+		"format": "csv",
 		"srs": "EPSG:3068",
 		"encoding": "ISO-8859-1",
 		"csvsplit": ";",

--- a/openaddr/tests/sources/fr-paris.json
+++ b/openaddr/tests/sources/fr-paris.json
@@ -7,10 +7,10 @@
     "website": "http://adresse.data.gouv.fr/download/",
     "note": "Downloaded and cached 2015-06-18",
     "data": "http://data.openaddresses.io/cache/fr/BAN_licence_gratuite_repartage_75.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
-        "type": "csv",
+        "format": "csv",
         "csvsplit": ";",
         "number": "numero",
         "street": "nom_voie",

--- a/openaddr/tests/sources/fr/la-réunion.json
+++ b/openaddr/tests/sources/fr/la-réunion.json
@@ -7,10 +7,10 @@
     "website": "http://adresse.data.gouv.fr/download/",
     "note": "Downloaded and cached 2015-06-18",
     "data": "http://data.openaddresses.io/cache/fr/BAN_licence_gratuite_repartage_974.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
-        "type": "csv",
+        "format": "csv",
         "csvsplit": ";",
         "number": "numero",
         "street": "nom_voie",

--- a/openaddr/tests/sources/iceland.json
+++ b/openaddr/tests/sources/iceland.json
@@ -2,7 +2,7 @@
     "website": "http://www.skra.is/",
     "data": "ftp://ftp.skra.is/skra/STADFANG.dsv.zip",
     "license": "http://www.skra.is/fasteignaskra/nidurhalsthjonusta/stadfangaskra/user-licence/",
-    "type": "ftp",
+    "protocol": "ftp",
     "coverage": {
         "ISO 3166": {
             "alpha2": "IS",
@@ -13,7 +13,7 @@
     "compression": "zip",
     "conform": {
         "file": "STADFANG.dsv",
-        "type": "csv",
+        "format": "csv",
         "csvsplit": "|",
         "lon": "LONG_WGS84",
         "lat": "LAT_WGS84",

--- a/openaddr/tests/sources/it-52-statewide.json
+++ b/openaddr/tests/sources/it-52-statewide.json
@@ -15,7 +15,7 @@
         "attribution": true,
         "share-alike": true
         },
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "language": "it",
     "conform": {
@@ -24,7 +24,7 @@
         "city": "comune",
         "region": "Toscana",
         "id": "cod_civ",
-        "type": "shapefile",
+        "format": "shapefile",
         "file":"shp/civici-excerpt.shp",
         "accuracy": 1
     }

--- a/openaddr/tests/sources/jp-fukushima1.json
+++ b/openaddr/tests/sources/jp-fukushima1.json
@@ -1,5 +1,5 @@
 {
-    "type": "http",
+    "protocol": "http",
     "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-fukushima.zip",
     "website": "http://nlftp.mlit.go.jp/isj/index.html",
     "compression": "zip",
@@ -10,7 +10,7 @@
         "state": "\u798f\u5cf6\u770c"
     },
     "conform": {
-        "type": "csv",
+        "format": "csv",
         "lat": "\u7def\u5ea6",
         "srs": "EPSG:4612",
         "number": "auto_number",

--- a/openaddr/tests/sources/jp-fukushima2.json
+++ b/openaddr/tests/sources/jp-fukushima2.json
@@ -1,5 +1,5 @@
 {
-    "type": "http",
+    "protocol": "http",
     "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-fukushima.zip",
     "website": "http://nlftp.mlit.go.jp/isj/index.html",
     "compression": "zip",
@@ -14,7 +14,7 @@
         "state": "福島県"
     },
     "conform": {
-        "type": "csv",
+        "format": "csv",
         "lat": "緯度",
         "srs": "EPSG:4612",
         "number": {

--- a/openaddr/tests/sources/lake-man-gdb-nested-nodir.json
+++ b/openaddr/tests/sources/lake-man-gdb-nested-nodir.json
@@ -1,13 +1,13 @@
 {
     "data": "http://fake-web/lake-man-gdb-othername-nodir.zip",
     "cache": "http://fake-cache/lake-man-gdb-othername-nodir.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "NUMBER",
         "street": "STRNAME",
-        "type": "gdb"
+        "format": "gdb"
     }
 }

--- a/openaddr/tests/sources/lake-man-gdb-nested.json
+++ b/openaddr/tests/sources/lake-man-gdb-nested.json
@@ -1,13 +1,13 @@
 {
     "data": "http://fake-web/lake-man-gdb-othername.zip",
     "cache": "http://fake-cache/lake-man-gdb-othername.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "NUMBER",
         "street": "STRNAME",
-        "type": "gdb"
+        "format": "gdb"
     }
 }

--- a/openaddr/tests/sources/lake-man-gdb.json
+++ b/openaddr/tests/sources/lake-man-gdb.json
@@ -1,13 +1,13 @@
 {
     "data": "http://fake-web/lake-man.gdb.zip",
     "cache": "http://fake-cache/lake-man.gdb.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "NUMBER",
         "street": "STRNAME",
-        "type": "gdb"
+        "format": "gdb"
     }
 }

--- a/openaddr/tests/sources/nl/countrywide.json
+++ b/openaddr/tests/sources/nl/countrywide.json
@@ -8,7 +8,7 @@
 	},
 	"data": "https://www.dropbox.com/s/8uaqry2w657p44n/bagadres.zip?dl=1",
 	"website": "http://www.nlextract.nl",
-	"type": "http",
+	"protocol": "http",
 	"compression": "zip",
 	"conform": {
 		"lon": "lon",
@@ -23,7 +23,7 @@
 		"city": "woonplaats",
 		"district":"gemeente",
 		"region": "provincie",
-		"type": "csv",
+		"format": "csv",
 		"csvsplit": ";"
 	}
 }

--- a/openaddr/tests/sources/pl-dolnoslaskie.json
+++ b/openaddr/tests/sources/pl-dolnoslaskie.json
@@ -21,11 +21,11 @@
         "number": "pad_numer_porzadkowy",
         "lat": "Y",
         "file": "punkty_adr_v2/dolnoslaskie.gml",
-        "type": "xml",
+        "format": "xml",
         "headers": 1,
         "skiplines": 1
     },
     "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
-    "type": "http",
+    "protocol": "http",
     "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
 }

--- a/openaddr/tests/sources/pl-lodzkie.json
+++ b/openaddr/tests/sources/pl-lodzkie.json
@@ -21,11 +21,11 @@
         "number": "pad_numer_porzadkowy",
         "lat": "Y",
         "file": "punkty_adr_v2/lodzkie.gml",
-        "type": "xml",
+        "format": "xml",
         "headers": 1,
         "skiplines": 1
     },
     "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
-    "type": "http",
+    "protocol": "http",
     "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
 }

--- a/openaddr/tests/sources/ua-63-city_of_kharkiv.json
+++ b/openaddr/tests/sources/ua-63-city_of_kharkiv.json
@@ -5,9 +5,9 @@
         "city": "Kharkiv"
     },
     "data": "http://cdr.citynet.kharkov.ua/arcgis/rest/services/gis_ort_stat_general/MapServer/1",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
-        "type": "geojson",
+        "format": "geojson",
         "number": {
           "function": "join",
           "fields": ["PREFIX", "SUFIXRU"],

--- a/openaddr/tests/sources/us-ca-alameda_county-mixedcase.json
+++ b/openaddr/tests/sources/us-ca-alameda_county-mixedcase.json
@@ -12,13 +12,13 @@
     "data": "https://data.acgov.org/api/geospatial/MiXeD-cAsE?method=export&format=Original",
     "license": { "url": "http://www.acgov.org/acdata/terms.htm" },
     "year": "",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "ST_NUM",
         "street": ["FEANME", "FEATYP"],
-        "type": "shapefile"
+        "format": "shapefile"
     }
 }

--- a/openaddr/tests/sources/us-ca-alameda_county.json
+++ b/openaddr/tests/sources/us-ca-alameda_county.json
@@ -12,13 +12,13 @@
     "data": "https://data.acgov.org/api/geospatial/8e4s-7f4v?method=export&format=Original",
     "license": { "url": "http://www.acgov.org/acdata/terms.htm" },
     "year": "",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "X",
         "lat": "Y",
         "number": "ST_NUM",
         "street": ["FEANME", "FEATYP"],
-        "type": "shapefile"
+        "format": "shapefile"
     }
 }

--- a/openaddr/tests/sources/us-ca-alameda_county_v2.json
+++ b/openaddr/tests/sources/us-ca-alameda_county_v2.json
@@ -15,14 +15,14 @@
             "data": "https://data.acgov.org/api/geospatial/8e4s-7f4v?method=export&format=Original",
             "license": { "url": "http://www.acgov.org/acdata/terms.htm" },
             "year": "",
-            "type": "http",
+            "protocol": "http",
             "compression": "zip",
             "conform": {
                 "lon": "X",
                 "lat": "Y",
                 "number": "ST_NUM",
                 "street": ["FEANME", "FEATYP"],
-                "type": "shapefile"
+                "format": "shapefile"
             }
         }]
     }

--- a/openaddr/tests/sources/us-ca-berkeley-404.json
+++ b/openaddr/tests/sources/us-ca-berkeley-404.json
@@ -7,7 +7,7 @@
     },
     "data": "http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/No-Parcels.zip",
     "website": "http://www.ci.berkeley.ca.us/datacatalog/",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "note": "Metadata at http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.shp(1).xml"
 }

--- a/openaddr/tests/sources/us-ca-berkeley-apn.json
+++ b/openaddr/tests/sources/us-ca-berkeley-apn.json
@@ -13,11 +13,11 @@
             "StreetSufx",
             "Direction"
         ],
-        "type": "shapefile-polygon"
+        "format": "shapefile-polygon"
     },
     "data": "http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.zip",
     "website": "http://www.ci.berkeley.ca.us/datacatalog/",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "note": "Metadata at http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.shp(1).xml"
 }

--- a/openaddr/tests/sources/us-ca-berkeley.json
+++ b/openaddr/tests/sources/us-ca-berkeley.json
@@ -8,7 +8,7 @@
     "data": "http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.zip",
     "website": "http://www.ci.berkeley.ca.us/datacatalog/",
     "license": { },
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "note": "Metadata at http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.shp(1).xml"
 }

--- a/openaddr/tests/sources/us-ca-carson-cached.json
+++ b/openaddr/tests/sources/us-ca-carson-cached.json
@@ -9,13 +9,13 @@
     "version": "20000101",
     "data": "http://www.carsonproperty.info/ArcGIS/rest/services/basemap/MapServer/1",
     "website": "http://ci.carson.ca.us/",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
         "lon": "x",
         "lat": "y",
         "number": "SITENUMBER",
         "street": "SITESTREET",
-        "type": "geojson",
+        "format": "geojson",
         "postal_code": "sitezip"
     }
 }

--- a/openaddr/tests/sources/us-ca-carson-old-cached.json
+++ b/openaddr/tests/sources/us-ca-carson-old-cached.json
@@ -9,13 +9,13 @@
     "version": "20000101",
     "data": "http://www.carsonproperty.info/ArcGIS/rest/services/basemap/MapServer/1",
     "website": "http://ci.carson.ca.us/",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
         "lon": "x",
         "lat": "y",
         "number": "SITENUMBER",
         "street": "SITESTREET",
-        "type": "geojson",
+        "format": "geojson",
         "postal_code": "sitezip"
     }
 }

--- a/openaddr/tests/sources/us-ca-carson.json
+++ b/openaddr/tests/sources/us-ca-carson.json
@@ -6,13 +6,13 @@
     },
     "data": "http://www.carsonproperty.info/ArcGIS/rest/services/basemap/MapServer/1",
     "website": "http://ci.carson.ca.us/",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
         "lon": "x",
         "lat": "y",
         "number": "SITENUMBER",
         "street": "SITESTREET",
-        "type": "csv",
+        "format": "csv",
         "postcode": "SITEZIP",
         "city": "SITECITY"
     }

--- a/openaddr/tests/sources/us-ca-oakland-skip.json
+++ b/openaddr/tests/sources/us-ca-oakland-skip.json
@@ -9,7 +9,7 @@
     "data": "http://data.openoakland.org/sites/default/files/OakParcelsGeo2013_0.zip",
     "website": "http://data.openoakland.org/dataset/property-parcels/resource/df20b818-0d16-4da8-a9c1-a7b8b720ff49",
     "year": "2013",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
-    "conform": { "type": "broken" }
+    "conform": { "format": "broken" }
 }

--- a/openaddr/tests/sources/us-ca-oakland.json
+++ b/openaddr/tests/sources/us-ca-oakland.json
@@ -8,7 +8,7 @@
     "data": "http://data.openoakland.org/sites/default/files/OakParcelsGeo2013_0.zip",
     "website": "http://data.openoakland.org/dataset/property-parcels/resource/df20b818-0d16-4da8-a9c1-a7b8b720ff49",
     "year": "2013",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
-    "conform": { "type": "broken" }
+    "conform": { "format": "broken" }
 }

--- a/openaddr/tests/sources/us-ca-san_francisco.json
+++ b/openaddr/tests/sources/us-ca-san_francisco.json
@@ -7,7 +7,7 @@
     "data": "https://data.sfgov.org/download/kvej-w5kb/ZIPPED%20SHAPEFILE",
     "license": { "text": "" },
     "year": "",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "lon": "x",
@@ -18,6 +18,6 @@
             "pattern": "^(\\S+)"
             },
         "street": ["st_name", "st_type"],
-        "type": "shapefile"
+        "format": "shapefile"
     }
 }

--- a/openaddr/tests/sources/us-mi-grand_traverse.json
+++ b/openaddr/tests/sources/us-mi-grand_traverse.json
@@ -11,10 +11,10 @@
     },
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/trescube/f5df2e/us-mi-grand-traverse.geojson.zip",
     "note": "querying Esri source in machine results in errors, exported via pyesridump: https://s3.amazonaws.com/data.openaddresses.io/runs/159143/output.txt",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
-        "type": "geojson",
+        "format": "geojson",
         "number": "ADDNUMB",
         "street": "FULLNAME",
         "city": "VENUE",

--- a/openaddr/tests/sources/us-ny-orange.json
+++ b/openaddr/tests/sources/us-ny-orange.json
@@ -10,9 +10,9 @@
         "county":"Orange"
     },
     "data": "http://ocgis.orangecountygov.com/ArcGIS/rest/services/Dynamic/LandBase/MapServer/0",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
-        "type": "geojson",
+        "format": "geojson",
         "number": {
             "function": "prefixed_number",
             "field": "StreetAddress"

--- a/openaddr/tests/sources/us-or-curry.json
+++ b/openaddr/tests/sources/us-or-curry.json
@@ -10,10 +10,10 @@
         "county": "Curry"
     },
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/migurski/d5add2/oregon_state_addresses.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
-        "type": "gdb",
+        "format": "gdb",
         "file": "Delivery/addresses_oregon.gdb",
         "layer": "Curry",
         "number": {

--- a/openaddr/tests/sources/us-ut-deprecated-type.json
+++ b/openaddr/tests/sources/us-ut-deprecated-type.json
@@ -1,0 +1,22 @@
+{
+    "coverage": {
+        "US Census": {"geoid": "49", "state": "Utah"},
+        "country": "us",
+        "state": "ut"
+    },
+    "data": "ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/LOCATION/UnpackagedData/AddressPoints/_Statewide/AddressPoints_shp.zip",
+    "type": "ftp",
+    "compression": "zip",
+    "conform": {
+        "street": [
+            "StreetName",
+            "StreetType"
+        ],
+        "type": "shapefile",
+        "file": "AddressPoints/AddressPoints.shp",
+        "lon": "x",
+        "lat": "y",
+        "number": "AddNum",
+        "postcode": "zipcode"
+    }
+}

--- a/openaddr/tests/sources/us-ut.json
+++ b/openaddr/tests/sources/us-ut.json
@@ -5,14 +5,14 @@
         "state": "ut"
     },
     "data": "ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/LOCATION/UnpackagedData/AddressPoints/_Statewide/AddressPoints_shp.zip",
-    "type": "ftp",
+    "protocol": "ftp",
     "compression": "zip",
     "conform": {
         "street": [
             "StreetName",
             "StreetType"
         ],
-        "type": "shapefile",
+        "format": "shapefile",
         "file": "AddressPoints/AddressPoints.shp",
         "lon": "x",
         "lat": "y",

--- a/openaddr/tests/sources/us-wy-park.json
+++ b/openaddr/tests/sources/us-wy-park.json
@@ -10,9 +10,9 @@
         "county": "Park"
     },
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/nvkelso/5a5bf6/ParkCountyADDRESS_POINTS_point.zip",
-    "type": "http",
+    "protocol": "http",
     "conform": {
-        "type": "shapefile",
+        "format": "shapefile",
         "number": {
             "function": "prefixed_number",
             "field": "DLVRY_ADD"

--- a/openaddr/tests/sources/us/ks/brown_county.json
+++ b/openaddr/tests/sources/us/ks/brown_county.json
@@ -10,7 +10,7 @@
         "county": "Brown"
     },
     "conform": {
-        "type": "geojson",
+        "format": "geojson",
         "number": "add_num",
         "street": [
             "road_pre",
@@ -21,5 +21,5 @@
         "postcode": "zip"
     },
     "data": "http://72.205.198.131/ArcGIS/rest/services/Brown/Brown/MapServer/33",
-    "type": "ESRI"
+    "protocol": "ESRI"
 }

--- a/openaddr/tests/sources/us/nj/statewide-deprecated-type.json
+++ b/openaddr/tests/sources/us/nj/statewide-deprecated-type.json
@@ -1,0 +1,36 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "34",
+            "name": "Morris County",
+            "state": "New Jersey"
+        },
+        "country": "us",
+        "state": "nj"
+    },
+    "data": "https://njgin.state.nj.us/download2/Address/ADDR_POINT_NJ_fgdb.zip",
+    "website": "https://njgin.state.nj.us/NJ_NJGINExplorer/ShowMetadata.jsp?docId={EC181B3D-4D15-11E1-A2E4-0003BA2C919E}",
+    "type": "http",
+    "compression": "zip",
+    "conform": {
+        "type": "gdb",
+        "layer": "AddressPoints_NJ",
+        "number": [
+            "PRE_NUM",
+            "ADDR_NUM",
+            "SUF_NUM"
+        ],
+        "street": [
+            "PRE_DIR",
+            "PRE_TYPE",
+            "PRE_MOD",
+            "NAME",
+            "SUF_TYPE",
+            "SUF_DIR",
+            "SUF_MOD"
+        ],
+        "postcode": "ZIP_CODE",
+        "id": "AP_GUID",
+        "accuracy": 1
+    }
+}

--- a/openaddr/tests/sources/us/nj/statewide.json
+++ b/openaddr/tests/sources/us/nj/statewide.json
@@ -10,10 +10,10 @@
     },
     "data": "https://njgin.state.nj.us/download2/Address/ADDR_POINT_NJ_fgdb.zip",
     "website": "https://njgin.state.nj.us/NJ_NJGINExplorer/ShowMetadata.jsp?docId={EC181B3D-4D15-11E1-A2E4-0003BA2C919E}",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
-        "type": "gdb",
+        "format": "gdb",
         "layer": "AddressPoints_NJ",
         "number": [
             "PRE_NUM",

--- a/openaddr/tests/sources/us/nm/washington.json
+++ b/openaddr/tests/sources/us/nm/washington.json
@@ -10,9 +10,9 @@
         "county": "Washington"
     },
     "data": "http://maps.co.washington.mn.us/arcgis/rest/services/Public/Public_Parcels/MapServer/0",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
-        "type": "geojson",
+        "format": "geojson",
         "number": "BLDG_NUM",
         "street": [
             "PREFIX_DIR",

--- a/openaddr/tests/sources/us/oh/trumbull.json
+++ b/openaddr/tests/sources/us/oh/trumbull.json
@@ -10,7 +10,7 @@
         "county": "Trumbull"
     },
     "data": "http://gis3.oit.ohio.gov/LBRS/_downloads/TRU_ADDS.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
         "number": "HOUSENUM",
@@ -20,7 +20,7 @@
             "ST_TYPE",
             "ST_SUFFIX"
         ],
-        "type": "shapefile",
+        "format": "shapefile",
         "postcode": "zipcode"
     }
 }

--- a/openaddr/tests/sources/us/or/portland-deprecated-type.json
+++ b/openaddr/tests/sources/us/or/portland-deprecated-type.json
@@ -1,0 +1,30 @@
+{
+    "coverage": {
+        "country": "us",
+        "city": "Portland",
+        "state": "or"
+    },
+    "compression": "zip",
+    "conform": {
+        "number": "address_number",
+        "lon": "x",
+        "lat": "y",
+        "type": "csv",
+        "street": [
+            "str_predir_code",
+            "street_name",
+            "street_type_code",
+            "str_postdir_code"
+        ],
+        "unit": "unit_value",
+        "city": "city",
+        "district": "county",
+        "region": "state_abbrev",
+        "postcode": "zip_code",
+        "srs": "EPSG:2913"
+    },
+    "skip": false,
+    "note": "zipped csv",
+    "data": "ftp://ftp02.portlandoregon.gov/CivicApps/address.zip",
+    "type": "ftp"
+}

--- a/openaddr/tests/sources/us/or/portland.json
+++ b/openaddr/tests/sources/us/or/portland.json
@@ -9,7 +9,7 @@
         "number": "address_number",
         "lon": "x",
         "lat": "y",
-        "type": "csv",
+        "format": "csv",
         "street": [
             "str_predir_code",
             "street_name",
@@ -26,5 +26,5 @@
     "skip": false,
     "note": "zipped csv",
     "data": "ftp://ftp02.portlandoregon.gov/CivicApps/address.zip",
-    "type": "ftp"
+    "protocol": "ftp"
 }

--- a/openaddr/tests/sources/us/pa/bucks-deprecated-type.json
+++ b/openaddr/tests/sources/us/pa/bucks-deprecated-type.json
@@ -1,0 +1,27 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "42017",
+            "name": "Bucks County",
+            "state": "Pennsylvania"
+        },
+        "country": "us",
+        "state": "pa",
+        "county": "Bucks"
+    },
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/iandees/ed482f/bucks.geojson.zip",
+    "type": "http",
+    "compression": "zip",
+    "conform": {
+        "type": "geojson",
+        "number": "SITUS_ADDR_NUM",
+        "street": [
+            "SITUS_FDPRE",
+            "SITUS_FNAME",
+            "SITUS_FTYPE",
+            "SITUS_FDSUF"
+        ],
+        "city": "MUNI",
+        "accuracy": 2
+    }
+}

--- a/openaddr/tests/sources/us/pa/bucks.json
+++ b/openaddr/tests/sources/us/pa/bucks.json
@@ -10,10 +10,10 @@
         "county": "Bucks"
     },
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/iandees/ed482f/bucks.geojson.zip",
-    "type": "http",
+    "protocol": "http",
     "compression": "zip",
     "conform": {
-        "type": "geojson",
+        "format": "geojson",
         "number": "SITUS_ADDR_NUM",
         "street": [
             "SITUS_FDPRE",

--- a/openaddr/tests/sources/us/pa/lancaster-deprecated-type.json
+++ b/openaddr/tests/sources/us/pa/lancaster-deprecated-type.json
@@ -1,0 +1,26 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "42071",
+            "name": "Lancaster County",
+            "state": "Pennsylvania"
+        },
+        "country": "us",
+        "state": "pa",
+        "city": "Lancaster"
+    },
+    "data": "http://services1.arcgis.com/I6XnrlnguPDoEObn/arcgis/rest/services/AddressPoints/FeatureServer/0",
+    "type": "ESRI",
+    "conform": {
+        "type": "geojson",
+        "number": "ADRNUM",
+        "unit": "UNITNUM",
+        "street": [
+            "FDPRE",
+            "FNAME",
+            "FTYPE",
+            "FDSUF"
+        ],
+        "city": "MUNI"
+    }
+}

--- a/openaddr/tests/sources/us/pa/lancaster.json
+++ b/openaddr/tests/sources/us/pa/lancaster.json
@@ -10,9 +10,9 @@
         "city": "Lancaster"
     },
     "data": "http://services1.arcgis.com/I6XnrlnguPDoEObn/arcgis/rest/services/AddressPoints/FeatureServer/0",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
-        "type": "geojson",
+        "format": "geojson",
         "number": "ADRNUM",
         "unit": "UNITNUM",
         "street": [

--- a/openaddr/tests/sources/us/tx/city_of_waco.json
+++ b/openaddr/tests/sources/us/tx/city_of_waco.json
@@ -17,9 +17,9 @@
         "city": "Waco"
     },
     "data": "http://gis.ci.waco.tx.us/arcgis/rest/services/Parcels/MapServer/0",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
-        "type": "geojson",
+        "format": "geojson",
         "number": "situs_num",
         "street": ["situs_street_prefx", "situs_street", "situs_street_sufix"],
         "city": "situs_city",

--- a/openaddr/tests/sources/us/tx/runnels.json
+++ b/openaddr/tests/sources/us/tx/runnels.json
@@ -10,13 +10,13 @@
         "county": "Runnels"
     },
     "data": "http://services.geoportalmaps.com/arcgis/rest/services/Runnels_Services/MapServer/1",
-    "type": "ESRI",
+    "protocol": "ESRI",
     "conform": {
         "number": "ADDRESS",
         "street": "MSAGCOMPLE",
         "city": "CITY",
         "region": "ST",
         "postcode": "ZIPCODE",
-        "type": "geojson"
+        "format": "geojson"
     }
 }

--- a/openaddr/tests/sources/us/va/statewide.json
+++ b/openaddr/tests/sources/us/va/statewide.json
@@ -3,7 +3,7 @@
     "website": "http://vgin.maps.arcgis.com/home/item.html?id=100e5e12ddc14748a5ec3b8b997af13a",
     "license": "public domain",
     "compression": "zip",
-    "type": "http",
+    "protocol": "http",
     "year": 2014,
     "coverage": {
         "US Census": {
@@ -14,7 +14,7 @@
         "state": "va"
     },
     "conform": {
-        "type": "csv",
+        "format": "csv",
         "file": "VA_SiteAddress.txt",
         "lon": "LONG",
         "lat": "LAT",


### PR DESCRIPTION
We’ve used "type" tags to mean two different things for a long time: protocols like "ESRI" or "http", and file formats like "shapefile" or "csv". This change deprecates support for "type" tags.

1. This PR:
    1. [x] Add support for "format" and "protocol" tags throughout code and tests
    2. [x] Get feedback from other OA contributors to decide if this is a good change
    3. [x] Re-add support for older-style "type" tags to ensure backwards-compatibility
2. Sources repo:
    1. Update documentation with new tags
    2. Update source files with new tags
3. This repo:
    1. Remove support for older-style "type" tags

New-style source:

```JSON
{
    "coverage": {},
    "data": "http://data.openoakland.org/sites/default/files/OakParcelsGeo2013_0.zip",
    "protocol": "http",
    "compression": "zip",
    "conform": { "format": "csv" }
}
```

Corresponding old-style source:

```JSON
{
    "coverage": {},
    "data": "http://data.openoakland.org/sites/default/files/OakParcelsGeo2013_0.zip",
    "type": "http",
    "compression": "zip",
    "conform": { "type": "csv" }
}
```