### PR TITLE
Don't expose the S3 bucket URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ More information about Machine’s output can be seen by following the Details l
 Machine also runs its own weekly batch process to generate the downloadable
 files, maps, and other resources available via [results.openaddresses.io](https://results.openaddresses.io).
 
-![OpenAddresses worldwide coverage map](https://s3.amazonaws.com/data.openaddresses.io/render-world.png)
+![OpenAddresses worldwide coverage map](https://data.openaddresses.io/render-world.png)
 
 Development
 -----------

--- a/openaddr/ci/templates/dashboard.html
+++ b/openaddr/ci/templates/dashboard.html
@@ -22,7 +22,7 @@ td, th { border: none }
 tr:nth-child(2n+1) td { background-color: #f8f8f8 }
 tr:nth-child(2n+2) td { background-color: #ffffff }
 
-</style> 
+</style>
 {% endblock head %}
 
 {% block main %}
@@ -207,7 +207,7 @@ function addLostTable(data) {
 
 // Main script. Load the data and graph it.
 
-d3.json('https://s3.amazonaws.com/data.openaddresses.io/machine-stats.json', function(error, data) {
+d3.json('https://data.openaddresses.io/machine-stats.json', function(error, data) {
     var timeseries = data['timeseries'];
     var dateRange = d3.extent(timeseries, function(d) { return d.ts; });
 

--- a/openaddr/ci/templates/index.html
+++ b/openaddr/ci/templates/index.html
@@ -25,7 +25,7 @@
     #downloads tr td { vertical-align: top }
 
     #downloads tr th, #downloads tr td.explanation { font-size: 65% }
-    
+
     #downloads tr:nth-child(2n+1) td { background-color: #f8f8f8 }
     #downloads tr:nth-child(2n+2) td { background-color: #ffffff }
 
@@ -34,7 +34,7 @@
         background-color: white;
         border-color: #bcb7df;
     }
-    
+
    /*
     * Progressively show additional sample data columns.
     * Always show the explanation cells.
@@ -67,7 +67,7 @@
             display: table-cell
         }
     }
-    
+
     p#all-runs { text-align: center }
     p#all-runs a
     {
@@ -76,7 +76,7 @@
         border-radius: 3px;
         padding: .2em 1em;
     }
-    
+
 </style>
 <table id="downloads">
     <tr>
@@ -151,11 +151,11 @@
     </tr>
 </table>
 <p>
-    <button onclick="choosemap('https://s3.amazonaws.com/{{ s3_bucket }}/render-world.png')">Show World</button>
-    <button onclick="choosemap('https://s3.amazonaws.com/{{ s3_bucket }}/render-usa.png')">Show United States</button>
-    <button onclick="choosemap('https://s3.amazonaws.com/{{ s3_bucket }}/render-europe.png')">Show Europe</button>
+    <button onclick="choosemap('https://data.openaddresses.io/render-world.png')">Show World</button>
+    <button onclick="choosemap('https://data.openaddresses.io/render-usa.png')">Show United States</button>
+    <button onclick="choosemap('https://data.openaddresses.io/render-europe.png')">Show Europe</button>
 </p>
-<p><img src="https://s3.amazonaws.com/{{ s3_bucket }}/render-world.png" width="100%" id="render-img"></p>
+<p><img src="https://data.openaddresses.io/render-world.png" width="100%" id="render-img"></p>
 <p>
     The latest summary can always be found at
     <a href="http://results.openaddresses.io">results.openaddresses.io</a>.<br>

--- a/openaddr/ci/templates/job.html
+++ b/openaddr/ci/templates/job.html
@@ -13,7 +13,7 @@
     {% else %}
         {% set status_phrase = 'is in progress' %}
     {% endif %}
-    
+
     This job {{ status_phrase }}:
 </p>
 
@@ -36,22 +36,22 @@
         </td>
         <td>
         {% if file_runstate and file_runstate.output %}
-            <a href="{{ file_runstate.output }}">log</a>
+            <a href="{{ file_runstate.output|nice_domain }}">log</a>
         {% endif %}
         </td>
         <td>
         {% if file_runstate and file_runstate.sample %}
-            <a href="{{ file_runstate.sample }}">sample</a>
+            <a href="{{ file_runstate.sample|nice_domain }}">sample</a>
         {% endif %}
         </td>
         <td>
         {% if file_runstate and file_runstate.processed %}
-            <a href="{{ file_runstate.processed }}">data</a>
+            <a href="{{ file_runstate.processed|nice_domain }}">data</a>
         {% endif %}
         </td>
         <td>
         {% if file_runstate and file_runstate.preview %}
-            <a href="{{ file_runstate.preview }}">image preview</a>
+            <a href="{{ file_runstate.preview|nice_domain }}">image preview</a>
         {% endif %}
         </td>
         {% if dotmaps_base_url %}

--- a/openaddr/ci/templates/runs-table.html
+++ b/openaddr/ci/templates/runs-table.html
@@ -1,7 +1,7 @@
 <style lang="text/css">
 
     #runs { border-collapse: collapse }
-    
+
     #runs tr th,
     #runs tr td.type,
     #runs tr td.cached,
@@ -11,14 +11,14 @@
     {
         font-size: 65%;
     }
-    
+
     #runs tr th, #runs tr td
     {
         text-align: left;
         padding: 3px 10px;
         border: none;
     }
-    
+
     #runs tr td>a
     {
         display: block;
@@ -26,7 +26,7 @@
         padding: 3px 10px;
         text-decoration: underline;
     }
-    
+
     #runs tr td.problems>a,
     #runs tr td.sample>a
     {
@@ -34,12 +34,12 @@
         margin: 0;
         padding: 0;
     }
-    
+
     #runs tr td.name>a
     {
         text-decoration: none;
     }
-    
+
     #runs tr:nth-child(4n-2) td, #runs tr:nth-child(4n-1) td { background-color: #f8f8f8 }
     #runs tr:nth-child(4n+0) td, #runs tr:nth-child(4n+1) td { background-color: #ffffff }
 
@@ -55,7 +55,7 @@
         line-height: 1.5em;
         padding: 1px 10px;
     }
-    
+
    /*
     * Progressively show additional sample data columns.
     */
@@ -95,7 +95,7 @@
             display: table-cell
         }
     }
-    
+
     @media (min-width: 640px)
     {
         #runs tr.init th.cached,
@@ -106,7 +106,7 @@
             display: table-cell
         }
     }
-    
+
     @media (min-width: 960px)
     {
         #runs tr.init th.type,
@@ -128,7 +128,7 @@
         var row = document.getElementById(row_id),
             link = document.getElementById(link_id),
             style = getComputedStyle(row);
-    
+
         if(row && style.display == 'none') {
             row.style.display = 'table-row';
             button.innerHTML = 'Hide <span class="words">sample data</span>';
@@ -141,13 +141,13 @@
 
         return false;
     }
-    
+
     function populatesample(link)
     {
         var anchors = link.getElementsByTagName('a'),
             neighbor = link.nextSibling,
             parent = link.parentNode;
-    
+
         var request = new XMLHttpRequest();
         request.open('GET', anchors[0].href, true);
 
@@ -156,10 +156,10 @@
             // Success!
             var stuff = document.createElement('div');
             stuff.innerHTML = request.responseText;
-        
+
             parent.removeChild(link);
             parent.insertBefore(stuff.firstChild, neighbor);
-        
+
           } else {
             // We reached our target server, but it returned an error
             link.innerHTML = 'Failed to load.';
@@ -171,18 +171,18 @@
         };
 
         link.innerHTML = '(Loading)';
-        request.send();            
+        request.send();
     }
-    
+
     function choosemap(src)
     {
         var img = document.getElementById('render-img');
-        
+
         if(img)
         {
             img.src = src;
         }
-        
+
         return false;
     }
 
@@ -212,7 +212,7 @@
         </td>
         <td class="cached">
           {% if state.cache %}
-            <a href="{{ state.cache }}">{{ state.cache_date }}</a>
+            <a href="{{ state.cache|nice_domain }}">{{ state.cache_date }}</a>
           {% elif state.cache_date %}
             <strike>{{ state.cache_date }}</strike>
           {% else %}
@@ -221,7 +221,7 @@
         </td>
         <td class="processed">
           {% if state.processed %}
-            <a href="{{ state.processed }}">zip</a>
+            <a href="{{ state.processed|nice_domain }}">zip</a>
           {% else %}
             –
           {% endif %}
@@ -238,9 +238,9 @@
             <a href="{{ state.href }}">Source</a> has
             <a href="https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#coverage-object">incomplete coverage</a>
           {% elif state['source problem'] %}
-            {{ state['source problem'] }} ( <a href="{{ state.output }}">log</a> )
+            {{ state['source problem'] }} ( <a href="{{ state.output|nice_domain }}">log</a> )
           {% elif not (state.conform and state.cache and state.sample) %}
-            Unknown problem ( <a href="{{ state.output }}">log</a> )
+            Unknown problem ( <a href="{{ state.output|nice_domain }}">log</a> )
           {% else %}
             &nbsp;
           {% endif %}
@@ -249,7 +249,7 @@
           {% if state.sample and state.run_id %}
             <button onclick="return showhide(this, '{{ state.shortname|element_id }}-sample-data', '{{ state.shortname|element_id }}-sample-link')">Show <span class="words">sample data</span></button>
           {% else %}
-            No sample data {% if state.output %}( <a href="{{ state.output }}">log</a> ){% endif %}
+            No sample data {% if state.output %}( <a href="{{ state.output|nice_domain }}">log</a> ){% endif %}
           {% endif %}
         </td>
       </tr>
@@ -258,7 +258,7 @@
           {% if suggest_conform %}
             <p>
               Possible <a href="https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#conform-object">conform object</a>
-              for <a href="{{ state.cache }}">{{ state.shortname }}</a>:
+              for <a href="{{ state.cache|nice_domain }}">{{ state.shortname }}</a>:
             </p>
 <pre>"conform": {
   "type": {{ state['conform type']|tojson }},
@@ -270,7 +270,7 @@
           {% endif %}
           {% if state.sample and state.run_id %}
             <p>
-              Sample data for first rows of <a href="{{ state.cache }}">{{ state.shortname }}</a>:
+              Sample data for first rows of <a href="{{ state.cache|nice_domain }}">{{ state.shortname }}</a>:
             </p>
             <p id="{{ state.shortname|element_id }}-sample-link">
                 <a href="{{ url_for('webhooks.app_get_run_sample', run_id=state.run_id) }}">{{ state.shortname }} sample</a>

--- a/openaddr/ci/templates/source.html
+++ b/openaddr/ci/templates/source.html
@@ -5,19 +5,19 @@
 <style lang="text/css">
 
     #source { border-collapse: collapse }
-    
+
     #source tr th
     {
         font-size: 65%;
     }
-    
+
     #source tr th, #source tr td
     {
         text-align: left;
         padding: 3px 10px;
         border: none;
     }
-    
+
     /*
     #source tr td>a
     {
@@ -27,7 +27,7 @@
         text-decoration: underline;
     }
     */
-    
+
     #source tr td small>a,
     #source tr td.sample>a
     {
@@ -35,12 +35,12 @@
         margin: 0;
         padding: 0;
     }
-    
+
     #source tr td.name>a
     {
         text-decoration: none;
     }
-    
+
     #source tr:nth-child(2n+0) td { background-color: #f8f8f8 }
     #source tr:nth-child(2n+1) td { background-color: #ffffff }
 
@@ -56,7 +56,7 @@
         line-height: 1.5em;
         padding: 1px 10px;
     }
-    
+
    /*
     * Progressively show additional sample data columns.
     */
@@ -96,7 +96,7 @@
             display: table-cell
         }
     }
-    
+
     @media (min-width: 640px)
     {
         #source tr th.cached,
@@ -105,7 +105,7 @@
             display: table-cell
         }
     }
-    
+
     @media (min-width: 960px)
     {
         #source tr th.source,
@@ -123,7 +123,7 @@
 
 {% if run.state.processed %}
 <p>
-    <a href="{{ run.state.processed }}">
+    <a href="{{ run.state.processed | nice_url }}">
     {{ run.state.address_count|nice_integer }} addresses
     downloaded {{ run.datetime_tz.strftime('%b %d %Y') }}
     </a>
@@ -161,30 +161,30 @@
             {{ run.state.address_count|nice_integer }}
           {% elif run.state.source_problem %}
             <small>{{ run.state.source_problem }}
-            ( <a href="{{ run.state.output }}">log</a> )</small>
+            ( <a href="{{ run.state.output | nice_url }}">log</a> )</small>
           {% else %}
             <small>Unknown problem
-            ( <a href="{{ run.state.output }}">log</a> )</small>
+            ( <a href="{{ run.state.output | nice_url }}">log</a> )</small>
           {% endif %}
         </td>
         <td class="datetimelog">
-        <a href="{{ run.state.output }}">{{ run.datetime_tz.strftime('%Y-%m-%d') }}</a>
+        <a href="{{ run.state.output | nice_url }}">{{ run.datetime_tz.strftime('%Y-%m-%d') }}</a>
         </td>
         <td class="processed">
         {% if run.state.process_hash %}
-            <a href="{{ run.state.processed }}"><tt>{{ run.state.process_hash[:7] }}</tt></a>
+            <a href="{{ run.state.processed | nice_url }}"><tt>{{ run.state.process_hash[:7] }}</tt></a>
             <small>({{ run.state.process_time.split('.')[0] }})</small>
         {% elif run.state.processed %}
-            <a href="{{ run.state.processed }}">zip</a>
+            <a href="{{ run.state.processed | nice_url }}">zip</a>
             <small>({{ run.state.process_time.split('.')[0] }})</small>
         {% endif %}
         </td>
         <td class="cached">
         {% if run.state.fingerprint %}
-            <a href="{{ run.state.cache }}"><tt>{{ run.state.fingerprint[:7] }}</tt></a>
+            <a href="{{ run.state.cache | nice_url }}"><tt>{{ run.state.fingerprint[:7] }}</tt></a>
             <small>({{ run.state.cache_time.split('.')[0] }})</small>
         {% elif run.state.cache %}
-            <a href="{{ run.state.cache }}">cache</a>
+            <a href="{{ run.state.cache | nice_url }}">cache</a>
             <small>({{ run.state.cache_time.split('.')[0] }})</small>
         {% endif %}
         </td>

--- a/openaddr/ci/templates/source.html
+++ b/openaddr/ci/templates/source.html
@@ -123,7 +123,7 @@
 
 {% if run.state.processed %}
 <p>
-    <a href="{{ run.state.processed | nice_url }}">
+    <a href="{{ run.state.processed|nice_domain }}">
     {{ run.state.address_count|nice_integer }} addresses
     downloaded {{ run.datetime_tz.strftime('%b %d %Y') }}
     </a>
@@ -161,30 +161,30 @@
             {{ run.state.address_count|nice_integer }}
           {% elif run.state.source_problem %}
             <small>{{ run.state.source_problem }}
-            ( <a href="{{ run.state.output | nice_url }}">log</a> )</small>
+            ( <a href="{{ run.state.output|nice_domain }}">log</a> )</small>
           {% else %}
             <small>Unknown problem
-            ( <a href="{{ run.state.output | nice_url }}">log</a> )</small>
+            ( <a href="{{ run.state.output|nice_domain }}">log</a> )</small>
           {% endif %}
         </td>
         <td class="datetimelog">
-        <a href="{{ run.state.output | nice_url }}">{{ run.datetime_tz.strftime('%Y-%m-%d') }}</a>
+        <a href="{{ run.state.output|nice_domain }}">{{ run.datetime_tz.strftime('%Y-%m-%d') }}</a>
         </td>
         <td class="processed">
         {% if run.state.process_hash %}
-            <a href="{{ run.state.processed | nice_url }}"><tt>{{ run.state.process_hash[:7] }}</tt></a>
+            <a href="{{ run.state.processed|nice_domain }}"><tt>{{ run.state.process_hash[:7] }}</tt></a>
             <small>({{ run.state.process_time.split('.')[0] }})</small>
         {% elif run.state.processed %}
-            <a href="{{ run.state.processed | nice_url }}">zip</a>
+            <a href="{{ run.state.processed|nice_domain }}">zip</a>
             <small>({{ run.state.process_time.split('.')[0] }})</small>
         {% endif %}
         </td>
         <td class="cached">
         {% if run.state.fingerprint %}
-            <a href="{{ run.state.cache | nice_url }}"><tt>{{ run.state.fingerprint[:7] }}</tt></a>
+            <a href="{{ run.state.cache|nice_domain }}"><tt>{{ run.state.fingerprint[:7] }}</tt></a>
             <small>({{ run.state.cache_time.split('.')[0] }})</small>
         {% elif run.state.cache %}
-            <a href="{{ run.state.cache | nice_url }}">cache</a>
+            <a href="{{ run.state.cache|nice_domain }}">cache</a>
             <small>({{ run.state.cache_time.split('.')[0] }})</small>
         {% endif %}
         </td>

--- a/openaddr/ci/webcommon.py
+++ b/openaddr/ci/webcommon.py
@@ -33,7 +33,7 @@ def monitor_execution_time(route_function):
         ns = os.environ.get('AWS_CLOUDWATCH_NS')
     except:
         cw = False
-    
+
     @wraps(route_function)
     def decorated_function(*args, **kwargs):
         start_time = time.time()
@@ -59,12 +59,12 @@ def nice_domain(url):
     _ = None
 
     if parsed.hostname == u'data.openaddresses.io':
-        return urlunparse((u'http', parsed.hostname, parsed.path, _, _, _))
+        return urlunparse((u'https', parsed.hostname, parsed.path, _, _, _))
 
     if parsed.hostname == u's3.amazonaws.com' and parsed.path.startswith(u'/data.openaddresses.io/'):
-        return urlunparse((u'http', u'data.openaddresses.io', parsed.path[22:], _, _, _))
+        return urlunparse((u'https', u'data.openaddresses.io', parsed.path[22:], _, _, _))
 
     if parsed.hostname == u'data.openaddresses.io.s3.amazonaws.com':
-        return urlunparse((u'http', u'data.openaddresses.io', parsed.path, _, _, _))
+        return urlunparse((u'https', u'data.openaddresses.io', parsed.path, _, _, _))
 
     return url

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -432,6 +432,7 @@ def apply_webhooks_blueprint(app):
         app.jinja_env.filters['nice_timedelta'] = nice_timedelta
         app.jinja_env.filters['breakstate'] = break_state
         app.jinja_env.filters['nice_size'] = nice_size
+        app.jinja_env.filters['nice_domain'] = nice_domain
 
         app.jinja_env.filters['slippymap_preview_url'] = slippymap_preview_url
 

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -889,9 +889,9 @@ class TestAPI (unittest.TestCase):
         self.assertEqual(index['tileindex_url'], 'http://localhost/tiles/{lon}/{lat}.zip')
         self.assertEqual(index['latest_set_url'], 'http://localhost/sets/2.json')
 
-        self.assertEqual(colls['global']['']['url'], 'http://data.openaddresses.io/openaddr-collected-global.zip')
-        self.assertEqual(colls['global']['sa']['url'], 'http://data.openaddresses.io/openaddr-collected-global-sa.zip')
-        self.assertEqual(colls['us_west']['']['url'], 'http://data.openaddresses.io/openaddr-collected-us_west.zip')
+        self.assertEqual(colls['global']['']['url'], 'https://data.openaddresses.io/openaddr-collected-global.zip')
+        self.assertEqual(colls['global']['sa']['url'], 'https://data.openaddresses.io/openaddr-collected-global-sa.zip')
+        self.assertEqual(colls['us_west']['']['url'], 'https://data.openaddresses.io/openaddr-collected-us_west.zip')
         self.assertEqual(colls['global']['']['content_length'], 1234)
         self.assertEqual(colls['global']['sa']['content_length'], 2345)
         self.assertEqual(colls['us_west']['']['content_length'], 3456)
@@ -901,10 +901,10 @@ class TestAPI (unittest.TestCase):
         self.assertNotIn('sa', colls['us_west'])
         self.assertNotIn('europe', colls)
 
-        self.assertEqual(index['render_world_url'], 'http://data.openaddresses.io/render-world.png')
-        self.assertEqual(index['render_europe_url'], 'http://data.openaddresses.io/render-europe.png')
-        self.assertEqual(index['render_usa_url'], 'http://data.openaddresses.io/render-usa.png')
-        self.assertEqual(index['render_geojson_url'], 'http://data.openaddresses.io/render-world.geojson')
+        self.assertEqual(index['render_world_url'], 'https://data.openaddresses.io/render-world.png')
+        self.assertEqual(index['render_europe_url'], 'https://data.openaddresses.io/render-europe.png')
+        self.assertEqual(index['render_usa_url'], 'https://data.openaddresses.io/render-usa.png')
+        self.assertEqual(index['render_geojson_url'], 'https://data.openaddresses.io/render-world.geojson')
 
     def test_latest_licenses(self):
         '''

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -1012,10 +1012,10 @@ class TestAPI (unittest.TestCase):
         self.assertIn('datetime_start', data)
         self.assertIn('datetime_end', data)
 
-        self.assertEqual(data['render_world_url'], 'http://data.openaddresses.io/--/world.png')
-        self.assertEqual(data['render_europe_url'], 'http://data.openaddresses.io/--/europe.png')
-        self.assertEqual(data['render_usa_url'], 'http://data.openaddresses.io/--/usa.png')
-        self.assertEqual(data['render_geojson_url'], 'http://data.openaddresses.io/--/world.geojson')
+        self.assertEqual(data['render_world_url'], 'https://data.openaddresses.io/--/world.png')
+        self.assertEqual(data['render_europe_url'], 'https://data.openaddresses.io/--/europe.png')
+        self.assertEqual(data['render_usa_url'], 'https://data.openaddresses.io/--/usa.png')
+        self.assertEqual(data['render_geojson_url'], 'https://data.openaddresses.io/--/world.geojson')
 
     def test_tile_redirects(self):
         '''

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2273,15 +2273,15 @@ class TestHook (unittest.TestCase):
 
         got1 = self.client.get('/latest/run/a1.zip')
         self.assertEqual(got1.status_code, 302)
-        self.assertEqual(got1.headers.get('Location'), 'http://data.openaddresses.io/runs/1/a1.zip')
+        self.assertEqual(got1.headers.get('Location'), 'https://data.openaddresses.io/runs/1/a1.zip')
 
         got2 = self.client.get('/latest/run/a2.zip')
         self.assertEqual(got2.status_code, 302)
-        self.assertEqual(got2.headers.get('Location'), 'http://data.openaddresses.io/runs/2/a2.zip')
+        self.assertEqual(got2.headers.get('Location'), 'https://data.openaddresses.io/runs/2/a2.zip')
 
         got3 = self.client.get('/latest/run/a3.zip')
         self.assertEqual(got3.status_code, 302)
-        self.assertEqual(got3.headers.get('Location'), 'http://data.openaddresses.io/runs/3/a3.zip')
+        self.assertEqual(got3.headers.get('Location'), 'https://data.openaddresses.io/runs/3/a3.zip')
 
         got4 = self.client.get('/latest/run/a4.zip')
         self.assertEqual(got4.status_code, 302)


### PR DESCRIPTION
This passes most of the URLs on results.openaddresses.io through a filter to clean up any URLs that refer to S3 directly so that they can be served via the CDN at data.openaddresses.io instead.