### PR TITLE
Handle bucket-in-domain and bucket-in-path forms of S3 URL

### DIFF
--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -247,9 +247,16 @@ def download_processed_file(url):
     handle, filename = mkstemp(prefix='processed-', suffix=ext)
     close(handle)
 
-    if urlparts.hostname == 's3.amazonaws.com':
+    if urlparts.hostname.endswith('s3.amazonaws.com'):
         # Use boto directly if it's an S3 URL
-        bucket, key = urlparts.path[1:].split('/', 1)
+        if urlparts.hostname == 's3.amazonaws.com':
+            # Bucket and key are in the path part of the URL
+            bucket, key = urlparts.path[1:].split('/', 1)
+        else:
+            # Bucket is part of the domain, path is the key
+            bucket = urlparts.hostname[:-17]
+            key = urlparts.path[1:]
+
         s3 = S3(None, None, bucket)
         k = s3.get_key(key)
         k.get_contents_to_filename(filename)

--- a/openaddr/tests/__init__.py
+++ b/openaddr/tests/__init__.py
@@ -1947,22 +1947,6 @@ class TestPackage (unittest.TestCase):
             self.assertEqual(local_processed_result2.run_state.processed, state3['processed'])
             self.assertEqual(local_processed_result2.run_state.license, state3['license'])
 
-    def response_content(self, url, request):
-        '''
-        '''
-        MHP = request.method, url.hostname, url.path
-
-        if MHP == ('GET', 's3.amazonaws.com', '/openaddresses/us-oh-clinton.csv'):
-            return response(200, b'...', headers={'Last-Modified': 'Wed, 30 Apr 2014 17:42:10 GMT'})
-
-        if MHP == ('GET', 'data.openaddresses.io.s3.amazonaws.com', '/runs/11170/ca-ab-strathcona-county.zip'):
-            return response(200, b'...', headers={'Last-Modified': 'Tue, 18 Aug 2015 07:10:32 GMT'})
-
-        if MHP == ('GET', 'data.openaddresses.io.s3.amazonaws.com', '/runs/13616/fr/vaucluse.zip'):
-            return response(200, b'...', headers={'Last-Modified': 'Wed, 19 Aug 2015 10:35:44 GMT'})
-
-        raise ValueError(url.geturl())
-
     def test_download_processed_file_csv(self):
         with mock.patch('openaddr.S3') as s3:
             fake_s3 = mock.MagicMock()
@@ -1978,7 +1962,13 @@ class TestPackage (unittest.TestCase):
         remove(filename)
 
     def test_download_processed_file_zip(self):
-        with HTTMock(self.response_content):
+        with mock.patch('openaddr.S3') as s3:
+            fake_s3 = mock.MagicMock()
+            fake_key = mock.MagicMock()
+            fake_key.get_contents_to_filename.return_value = None
+            fake_key.last_modified = "Tue, 18 Aug 2015 07:10:32 GMT"
+            fake_s3.get_key.return_value = fake_key
+            s3.return_value = fake_s3
             filename = download_processed_file('http://data.openaddresses.io.s3.amazonaws.com/runs/11170/ca-ab-strathcona-county.zip')
 
         self.assertEqual(splitext(filename)[1], '.zip')
@@ -1986,7 +1976,13 @@ class TestPackage (unittest.TestCase):
         remove(filename)
 
     def test_download_processed_file_nested_zip(self):
-        with HTTMock(self.response_content):
+        with mock.patch('openaddr.S3') as s3:
+            fake_s3 = mock.MagicMock()
+            fake_key = mock.MagicMock()
+            fake_key.get_contents_to_filename.return_value = None
+            fake_key.last_modified = "Wed, 19 Aug 2015 10:35:44 GMT"
+            fake_s3.get_key.return_value = fake_key
+            s3.return_value = fake_s3
             filename = download_processed_file('http://data.openaddresses.io.s3.amazonaws.com/runs/13616/fr/vaucluse.zip')
 
         self.assertEqual(splitext(filename)[1], '.zip')


### PR DESCRIPTION
This is to handle 403's after I removed support for `public-read` ACLs on the `data.openaddresses.io` bucket today.