### PR TITLE
Tell tippecanoe to drop densest points as needed

### DIFF
--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -44,9 +44,16 @@ def call_tippecanoe(mbtiles_filename, include_properties=True):
     '''
     base_zoom = 15
 
-    cmd = 'tippecanoe', '--drop-rate', '2', '--layer', 'openaddresses', \
-          '--name', 'OpenAddresses {}'.format(str(date.today())), '--force', \
-          '--temporary-directory', gettempdir(), '--output', mbtiles_filename
+    cmd = (
+        'tippecanoe',
+        '--drop-rate', '2',
+        '--layer', 'openaddresses',
+        '--name', 'OpenAddresses {}'.format(str(date.today())),
+        '--force',
+        '--drop-densest-as-needed',
+        '--temporary-directory', gettempdir(),
+        '--output', mbtiles_filename,
+    )
 
     if include_properties:
         full_cmd = cmd + (

--- a/openaddr/tests/dotmap.py
+++ b/openaddr/tests/dotmap.py
@@ -83,8 +83,8 @@ class TestDotmap (unittest.TestCase):
 
         self.assertEqual('tippecanoe', cmd1[0])
         self.assertEqual('tippecanoe', cmd2[0])
-        self.assertEqual(('--output', 'oa.mbtiles'), cmd1[10:12])
-        self.assertEqual(('--output', 'oa.mbtiles'), cmd2[10:12])
+        self.assertEqual(('--output', 'oa.mbtiles'), cmd1[11:13])
+        self.assertEqual(('--output', 'oa.mbtiles'), cmd2[11:13])
         self.assertIn('OpenAddresses {}'.format(str(date.today())), cmd1)
         self.assertIn('OpenAddresses {}'.format(str(date.today())), cmd2)
 


### PR DESCRIPTION
For https://github.com/openaddresses/openaddresses.io/issues/77 

Looking at [the logs](https://s3.console.aws.amazon.com/s3/object/data.openaddresses.io/logs/2019-10-01-15-01-openaddr-update-dotmap/cloud-init-output.log.gz?region=us-east-1&tab=overview), the dotmap build was failing because tippecanoe couldn't successfully write out all the features at our chosen base zoom level of 15:

```
tile 15/16593/11212 has 201699 features, >200000    
Try using -B (and --drop-lines or --drop-polygons if needed) to set a higher base zoom level.
...
*** NOTE TILES ONLY COMPLETE THROUGH ZOOM 14 ***
...
Traceback (most recent call last):
  File "/usr/local/bin/openaddr-update-dotmap", line 11, in <module>
    load_entry_point('OpenAddresses-Machine==7.2.13', 'console_scripts', 'openaddr-update-dotmap')()
  File "/usr/local/lib/python3.5/dist-packages/openaddr/dotmap.py", line 273, in main
    raise RuntimeError('High-zoom Tippecanoe command returned {}'.format(status_hi))
RuntimeError: High-zoom Tippecanoe command returned 1
```

It seems weird that that tile would have so many features in it, so I'm telling tippecanoe to just drop the super dense points so that it will at least finish.