### PR TITLE
Possibly simplify the completed runs query?

### DIFF
--- a/openaddr/ci/objects.py
+++ b/openaddr/ci/objects.py
@@ -518,13 +518,10 @@ def read_completed_runs_to_date(db, starting_set_id):
         return None
 
     # Get IDs for latest successful source runs of any run in the requested set.
-    db.execute('''SELECT MAX(id), source_path FROM runs
-                  WHERE source_path IN (
-                      -- Get all source paths for successful runs in this set.
-                      SELECT source_path FROM runs
-                      WHERE set_id = %s
-                    )
-                    -- Get only successful, merged runs.
+    db.execute('''SELECT MAX(id), source_path
+                  FROM runs
+                  WHERE
+                    set_id = %s
                     AND status = true
                     AND (is_merged = true OR is_merged IS NULL)
                   GROUP BY source_path''',
@@ -533,13 +530,10 @@ def read_completed_runs_to_date(db, starting_set_id):
     run_path_ids = {path: run_id for (run_id, path) in db.fetchall()}
 
     # Get IDs for latest unsuccessful source runs of any run in the requested set.
-    db.execute('''SELECT MAX(id), source_path FROM runs
-                  WHERE source_path IN (
-                      -- Get all source paths for failed runs in this set.
-                      SELECT source_path FROM runs
-                      WHERE set_id = %s
-                    )
-                    -- Get only unsuccessful, merged runs.
+    db.execute('''SELECT MAX(id), source_path
+                  FROM runs
+                  WHERE
+                    set_id = %s
                     AND status = false
                     AND (is_merged = true OR is_merged IS NULL)
                   GROUP BY source_path''',
@@ -571,19 +565,19 @@ def mark_runs_for_index_page(db, runs):
     ''' Update runs.for_index_page boolean column from list of provided runs.
     '''
     run_ids = tuple([run.id for run in runs])
-    
+
     db.execute('''
         UPDATE runs SET for_index_page = false
         WHERE for_index_page
           AND id NOT IN %s
         ''', (run_ids, ))
-    
+
     db.execute('''
         UPDATE runs SET for_index_page = true
         WHERE NOT for_index_page
           AND id IN %s
         ''', (run_ids, ))
-    
+
 def read_latest_run(db, source_path):
     '''
     '''

--- a/openaddr/dotmap.py
+++ b/openaddr/dotmap.py
@@ -248,6 +248,7 @@ def main():
     with connect_db(args.database_url) as conn:
         with db_cursor(conn) as db:
             set = read_latest_set(db, args.owner, args.repository)
+            _L.info("Got latest set %s", set.id)
             runs = read_completed_runs_to_date(db, set.id)
             _L.info("Using set %s with %d runs.", set.id, len(runs))
 

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -738,25 +738,19 @@ class TestObjects (unittest.TestCase):
             = exec1[1][:], exec2[1][:], exec3[1][:]
 
         self.assertEqual(e1_query,
-               '''SELECT MAX(id), source_path FROM runs
-                  WHERE source_path IN (
-                      -- Get all source paths for successful runs in this set.
-                      SELECT source_path FROM runs
-                      WHERE set_id = %s
-                    )
-                    -- Get only successful, merged runs.
+               '''SELECT MAX(id), source_path
+                  FROM runs
+                  WHERE
+                    set_id = %s
                     AND status = true
                     AND (is_merged = true OR is_merged IS NULL)
                   GROUP BY source_path''')
 
         self.assertEqual(e2_query,
-               '''SELECT MAX(id), source_path FROM runs
-                  WHERE source_path IN (
-                      -- Get all source paths for failed runs in this set.
-                      SELECT source_path FROM runs
-                      WHERE set_id = %s
-                    )
-                    -- Get only unsuccessful, merged runs.
+               '''SELECT MAX(id), source_path
+                  FROM runs
+                  WHERE
+                    set_id = %s
                     AND status = false
                     AND (is_merged = true OR is_merged IS NULL)
                   GROUP BY source_path''')


### PR DESCRIPTION
These queries were causing the dotmap to never finish (https://github.com/openaddresses/openaddresses.io/issues/77#issuecomment-540818005), so I tried to make them simpler while doing the same thing.

From my cursory testing it seems that this returns the expected result. I was never able to get the original query to finish, so I can't be certain that it's returning the exact same result. The number of rows returned by the two queries seems to make sense and looking at the run IDs returned by each seem to make sense.