### PR TITLE
Moving support for slippy dotmaps in CI previews to machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - checkout
       - run: .circleci/prepare-docker-images.sh
-      
+
       # Perform tests, but don't keep images around
       - run: docker-compose up -d && sleep 15
-      - run: docker-compose run machine python3 /usr/local/src/openaddr/test.py
+      - run: docker-compose run machine python3 /usr/local/src/openaddr/test.py --logall
 
   # Package Docker images and upload to S3 for use in production.
   Package:
@@ -44,7 +44,7 @@ jobs:
       - run: docker tag openaddr/machine:`cat /tmp/P/MAJOR` openaddr/machine:`cat /tmp/P/FULL`
       - run: docker save openaddr/machine:`cat /tmp/P/FULL` | gzip -c --fast > /tmp/images/openaddr-machine-`cat /tmp/P/FULL`.tar.gz
       - run: aws s3 cp --quiet --recursive --acl public-read /tmp/images/ s3://data.openaddresses.io/docker/
-  
+
   # Deploy new version of Machine to EC2 and Lambda
   Deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Perform tests, but don't keep images around
       - run: docker-compose up -d && sleep 15
-      - run: docker-compose run machine python3 /usr/local/src/openaddr/test.py --logall
+      - run: docker-compose run machine python3 /usr/local/src/openaddr/test.py
 
   # Package Docker images and upload to S3 for use in production.
   Package:

--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -2,19 +2,16 @@ from __future__ import absolute_import, division, print_function
 import logging; _L = logging.getLogger('openaddr')
 
 from tempfile import mkdtemp, mkstemp
-from os.path import realpath, join, basename, splitext, exists, dirname, abspath, relpath
+from os.path import realpath, join, splitext, exists, dirname, abspath, relpath
 from shutil import copy, move, rmtree
 from os import close, utime, remove
-from urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 from datetime import datetime, date
 from calendar import timegm
-import json
 import requests
 
-from osgeo import ogr
 from boto.s3.connection import S3Connection
 from dateutil.parser import parse
-from .sample import sample_geojson
 
 from .cache import (
     CacheResult,

--- a/openaddr/__init__.py
+++ b/openaddr/__init__.py
@@ -5,7 +5,7 @@ from tempfile import mkdtemp, mkstemp
 from os.path import realpath, join, splitext, exists, dirname, abspath, relpath
 from shutil import copy, move, rmtree
 from os import close, utime, remove
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from datetime import datetime, date
 from calendar import timegm
 import requests

--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -13,7 +13,7 @@ import simplejson as json
 from os import mkdir
 from hashlib import md5
 from os.path import join, basename, exists, abspath, splitext
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from subprocess import check_output
 from tempfile import mkstemp
 from hashlib import sha1

--- a/openaddr/cache.py
+++ b/openaddr/cache.py
@@ -4,7 +4,6 @@ import logging; _L = logging.getLogger('openaddr.cache')
 import os
 import errno
 import math
-import socket
 import mimetypes
 import shutil
 import re
@@ -14,7 +13,7 @@ import simplejson as json
 from os import mkdir
 from hashlib import md5
 from os.path import join, basename, exists, abspath, splitext
-from urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 from subprocess import check_output
 from tempfile import mkstemp
 from hashlib import sha1

--- a/openaddr/ci/__init__.py
+++ b/openaddr/ci/__init__.py
@@ -52,7 +52,6 @@ def load_config():
                 GITHUB_OAUTH_CALLBACK=os.environ.get('GITHUB_CALLBACK'),
                 MEMCACHE_SERVER=os.environ.get('MEMCACHE_SERVER'),
                 DATABASE_URL=os.environ['DATABASE_URL'],
-                DOTMAPS_BASE_URL=os.environ.get('DOTMAPS_BASE_URL'),
                 AWS_S3_BUCKET=os.environ.get('AWS_S3_BUCKET', 'data.openaddresses.io'),
                 WEBHOOK_SECRETS=webhook_secrets)
 

--- a/openaddr/ci/templates/dotmap-index.html
+++ b/openaddr/ci/templates/dotmap-index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Run {{ run_id }}</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="https://www.nextzen.org/js/nextzen.css">
+    <script src="https://www.nextzen.org/js/nextzen.min.js"></script>
+    <style>
+      #map {
+        height: 100%;
+        width: 100%;
+        position: absolute;
+      }
+      #address {
+        top: 1em;
+        left: 1em;
+        padding: .5em;
+        background-color: rgba(255, 255, 255, .95);
+        border-radius: 3px;
+        border: 1px solid black;
+        position: absolute;
+        z-index: 999;
+        display: none;
+        font-family: monospace;
+        font-size: 9pt;
+      }
+      html, body { margin: 0; padding: 0 }
+  </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <div id="address">
+        <table>
+            <tr><td>Number</td><td id="address-number">Yo</td></tr>
+            <tr><td>Street</td><td id="address-street">Yo</td></tr>
+            <tr><td>Unit</td><td id="address-unit">Yo</td></tr>
+            <tr><td>City</td><td id="address-city">Yo</td></tr>
+            <tr><td>Region</td><td id="address-region">Yo</td></tr>
+            <tr><td>Postcode</td><td id="address-postcode">Yo</td></tr>
+            <tr><td>Hash</td><td id="address-hash">Yo</td></tr>
+            <tr><td>Source</td><td id="address-source_path">Yo</td></tr>
+        </table>
+    </div>
+    <script>
+
+      function onLoaded(event)
+      {
+        event.tangramLayer.setSelectionEvents({ hover: onHover, click: onClick });
+      }
+
+      function onHover(selection)
+      {
+        var fields = ['number', 'street', 'unit', 'city', 'region', 'postcode', 'hash', 'source_path'],
+            label = document.getElementById('address'),
+            map = document.getElementById('map'),
+            key, i, props = {};
+
+        if(selection.feature)
+        {
+            for(key in selection.feature.properties)
+            {
+                props[key.toLowerCase()] = selection.feature.properties[key];
+            }
+
+            if('number' in props && 'street' in props)
+            {
+                for(i in fields)
+                {
+                    key = fields[i];
+                    document.getElementById('address-' + key).innerText = (props[key] || '');
+                }
+
+                map.style.cursor = 'pointer';
+                label.style.display = 'block';
+                label.style.left = (selection.pixel.x - 20) + 'px';
+                label.style.top = (selection.pixel.y - label.clientHeight - 10) + 'px';
+
+                return;
+            }
+        }
+
+        map.style.cursor = '';
+        label.style.display = 'none';
+      }
+
+      function onClick(selection)
+      {
+      }
+
+      L.Nextzen.apiKey = '2fbIR01VTFuSyPuvdkBSfQ';
+      var map = L.Nextzen.map('map', {
+        center: [{{lat}}, {{lon}}],
+        zoom: {{zoom}},
+        scene: "{{ scene_url|escape }}",
+        tangramOptions: {
+          apiKey: L.Nextzen.apiKey,
+        }
+      });
+
+      // Move zoom control to the top right corner of the map
+      map.zoomControl.setPosition('topright');
+
+      // URL hash
+      L.Nextzen.hash({map: map});
+
+      // Set up interactivity
+      map.on('tangramloaded', onLoaded);
+
+    </script>
+  </body>
+</html>

--- a/openaddr/ci/templates/dotmap-scene.yaml
+++ b/openaddr/ci/templates/dotmap-scene.yaml
@@ -1,0 +1,47 @@
+import: https://www.nextzen.org/carto/refill-style/12/refill-style.zip
+
+sources:
+    _dots:
+        type: MVT
+        url: "{{ tile_url|escape }}"
+        max_zoom: 14
+
+styles:
+    # Set up style aliases so that overlapping points can be drawn.
+    # https://mapzen.com/documentation/tangram/styles/#styles
+    _kirby_whites:
+        base: points
+    _kirby_outlines:
+        base: points
+
+layers:
+    _dots:
+        # order - https://mapzen.com/documentation/cartography/api-reference/#overlay
+        # collide - https://mapzen.com/documentation/tangram/draw/#collide
+        data: { source: _dots, layer: dots }
+        draw:
+            # Blue dot fills.
+            points:
+                order: global.sdk_order_over_everything_but_text_1
+                collide: false
+                color: "#25bffc"
+                size: [[10, 2px], [11, 2px], [12, 3px], [13, 4px], [14, 5px], [15, 6px]]
+        _dot_whites:
+            # White dot outlines, also used as a mouse hit area.
+            # interactive - https://mapzen.com/documentation/tangram/draw/#interactive
+            filter: { $zoom: { min: 15 } }
+            draw:
+                _kirby_whites:
+                    order: global.sdk_order_over_everything_but_text_2
+                    interactive: true
+                    collide: false
+                    color: "#fff"
+                    size: 12px
+        _dot_outlines:
+            filter: { $zoom: { min: 17 } }
+            draw:
+                _kirby_outlines:
+                    order: global.sdk_order_over_everything_but_text_3
+                    collide: false
+                    color: "#ccc"
+                    size: 14px

--- a/openaddr/ci/templates/job.html
+++ b/openaddr/ci/templates/job.html
@@ -54,13 +54,11 @@
             <a href="{{ file_runstate.preview|nice_domain }}">image preview</a>
         {% endif %}
         </td>
-        {% if dotmaps_base_url %}
-            <td>
-            {% if file_runstate and file_runstate.slippymap %}
-                <a href="{{ file_runstate|slippymap_preview_url }}">slippy map preview</a>
-            {% endif %}
-            </td>
+        <td>
+        {% if file_runstate and file_runstate.slippymap %}
+            <a href="{{ file_runstate|slippymap_preview_url }}">slippy map preview</a>
         {% endif %}
+        </td>
     </tr>
 
 {% endfor %}

--- a/openaddr/ci/web.py
+++ b/openaddr/ci/web.py
@@ -5,6 +5,7 @@ from .webauth import apply_webauth_blueprint
 from .webhooks import apply_webhooks_blueprint
 from .webapi import apply_webapi_blueprint
 from .webcoverage import apply_coverage_blueprint
+from .webdotmap import apply_dotmap_blueprint
 from . import load_config
 
 app = Flask(__name__)
@@ -12,6 +13,7 @@ app.config.update(load_config())
 apply_webauth_blueprint(app)
 apply_webhooks_blueprint(app)
 apply_webapi_blueprint(app)
+apply_dotmap_blueprint(app)
 apply_coverage_blueprint(app)
 
 # Look at X-Forwarded-* request headers when behind a proxy.

--- a/openaddr/ci/webdotmap.py
+++ b/openaddr/ci/webdotmap.py
@@ -1,0 +1,219 @@
+import apsw
+import boto3
+import os
+import json
+from flask import Blueprint, Response, abort, current_app, render_template, url_for
+
+from . import setup_logger
+from .webcommon import log_application_errors, flask_log_level
+from .webhooks import get_memcache_client
+
+dots = Blueprint('dots', __name__)
+
+
+# https://stackoverflow.com/questions/56776974/sqlite3-connect-to-a-database-in-cloud-s3
+class S3VFS(apsw.VFS):
+    def __init__(self, vfsname="s3", basevfs="", cache=None):
+        self.vfsname = vfsname
+        self.basevfs = basevfs
+        self.cache = cache
+        apsw.VFS.__init__(self, self.vfsname, self.basevfs)
+
+    def xOpen(self, name, flags):
+        return S3VFSFile(self.basevfs, name, flags, self.cache)
+
+
+class S3VFSFile():
+    def __init__(self, inheritfromvfsname, filename, flags, cache):
+        self.s3 = boto3.client('s3')
+        self.cache = cache
+        self.bucket = filename.uri_parameter("bucket")
+        self.key = filename.filename().lstrip("/")
+
+    def _cache_key(self, amount, offset):
+        return '{bucket}/{key}/{amount}/{offset}'.format(
+            bucket=self.bucket,
+            key=self.key,
+            amount=amount,
+            offset=offset,
+        )
+
+    def xRead(self, amount, offset):
+        data = None
+        if self.cache:
+            cache_key = self._cache_key(amount, offset)
+            data = self.cache.get(cache_key)
+
+        if data is None:
+            response = self.s3.get_object(Bucket=self.bucket, Key=self.key, Range='bytes={}-{}'.format(offset, offset + amount))
+            data = response['Body'].read()
+
+            if self.cache:
+                self.cache.set(cache_key, data)
+
+        return data
+
+    def xFileSize(self):
+        length = None
+        if self.cache:
+            cache_key = '{bucket}/{key}/size'.format(bucket=self.bucket, key=self.key)
+            length = self.cache.get(cache_key)
+
+        if length is None:
+            response = self.s3.head_object(Bucket=self.bucket, Key=self.key)
+            length = response['ContentLength']
+
+            if self.cache:
+                self.cache.set(cache_key, length)
+
+        return length
+
+    def xClose(self):
+        pass
+
+    def xFileControl(self, op, ptr):
+        return False
+
+
+def get_mbtiles_connection(bucket, key, cache):
+    '''
+    '''
+    s3vfs = S3VFS(cache=cache)
+    return apsw.Connection(
+        'file:/{key}?bucket={bucket}&immutable=1'.format(bucket=bucket, key=key),
+        flags=apsw.SQLITE_OPEN_READONLY | apsw.SQLITE_OPEN_URI,
+        vfs=s3vfs.vfsname,
+    )
+
+
+def get_mbtiles_metadata(bucket, key, cache):
+    '''
+    '''
+    if cache:
+        cache_key = '{bucket}/{key}/metadata'.format(bucket=bucket, key=key)
+        cached = cache.get(cache_key)
+        if cached:
+            return cached
+
+    connection = get_mbtiles_connection(bucket, key, cache)
+    cur = connection.cursor()
+
+    res = cur.execute('''SELECT name, value FROM metadata
+                        WHERE name IN ('center', 'json')''')
+
+    data = dict(res.fetchall())
+    lon, lat, zoom = map(float, data.get('center', '0,0,0').split(','))
+
+    more = json.loads(data.get('json', '{}'))
+    fields = list(more.get('vector_layers', [])[0].get('fields', {}).keys())
+
+    cur.close()
+
+    metadata_tuple = (zoom, lat, lon, fields)
+    if cache:
+        cache.set(cache_key, metadata_tuple)
+
+    return metadata_tuple
+
+
+def get_mbtiles_tile(bucket, key, row, col, zoom, cache):
+    '''
+    '''
+    if cache:
+        cache_key = '{bucket}/{key}/{zoom}/{row}/{col}'.format(bucket=bucket, key=key, zoom=zoom, row=row, col=col)
+        cached = cache.get(cache_key)
+        if cached:
+            return cached
+
+    connection = get_mbtiles_connection(bucket, key, cache)
+    cur = connection.cursor()
+
+    flipped_row = (2**zoom) - 1 - row
+
+    res = cur.execute('''SELECT tile_data FROM tiles
+                         WHERE zoom_level=? AND tile_column=? AND tile_row=?''', (zoom, col, flipped_row))
+
+    data = res.fetchone()
+
+    cur.close()
+
+    if cache:
+        cache.set(cache_key, data)
+
+    return data
+
+
+@dots.route('/runs/<int:run_id>/dotmap/index.html')
+@log_application_errors
+def dotmap_preview(run_id):
+    '''
+    '''
+    if not run_id:
+        abort(404)
+
+    try:
+        bucket = "data.openaddresses.io"
+        key = "runs/{run_id}/slippymap.mbtiles".format(run_id=run_id)
+        mc = get_memcache_client(current_app.config)
+        zoom, lat, lon, fields = get_mbtiles_metadata(bucket, key, mc)
+    except ValueError:
+        abort(500)
+
+    return render_template(
+        'dotmap-index.html',
+        run_id=run_id,
+        zoom=zoom,
+        lat=lat,
+        lon=lon,
+        fields=fields,
+        scene_url=url_for('dots.get_scene', run_id=run_id)
+    )
+
+
+@dots.route('/runs/<run_id>/dotmap/scene.yaml')
+@log_application_errors
+def get_scene(run_id):
+    if not run_id:
+        abort(404)
+
+    tile_args = dict(run_id=run_id, zoom=123, col=456, row=789)
+    tile_url = url_for('dots.get_one_tile', **tile_args).replace('123/456/789', '{z}/{x}/{y}')
+
+    return Response(
+        render_template('dotmap-scene.yaml', tile_url=tile_url),
+        headers={'Content-Type': 'application/x-yaml'},
+    )
+
+
+@dots.route('/runs/<run_id>/dotmap/tiles/<int:zoom>/<int:col>/<int:row>.mvt')
+@log_application_errors
+def get_one_tile(run_id, zoom, col, row):
+    '''
+    '''
+    if not run_id:
+        abort(404)
+
+    bucket = "data.openaddresses.io"
+    key = "runs/{run_id}/slippymap.mbtiles".format(run_id=run_id)
+    mc = get_memcache_client(current_app.config)
+    body = get_mbtiles_tile(bucket, key, row, col, zoom, mc)
+
+    if not body:
+        abort(404)
+
+    headers = {
+        'Content-Type': 'application/vnd.mapbox-vector-tile',
+        'Content-Encoding': 'gzip',
+    }
+
+    return Response(body, headers=headers)
+
+
+def apply_dotmap_blueprint(app):
+    '''
+    '''
+    app.register_blueprint(dots)
+
+    @app.before_first_request
+    def app_prepare():
+        setup_logger(os.environ.get('AWS_SNS_ARN'), None, flask_log_level(app.config))

--- a/openaddr/ci/webdotmap.py
+++ b/openaddr/ci/webdotmap.py
@@ -212,6 +212,12 @@ def get_one_tile(run_id, zoom, col, row):
 def apply_dotmap_blueprint(app):
     '''
     '''
+    @dots.after_request
+    def cache_everything(response):
+        response.cache_control.max_age = 31556952  # 1 year
+        response.cache_control.public = True
+        return response
+
     app.register_blueprint(dots)
 
     @app.before_first_request

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -420,6 +420,7 @@ def nice_size(size):
 def slippymap_preview_url(runstate):
     '''
     '''
+    print(runstate)
     if runstate.run_id:
         run_id = str(runstate.run_id)
 

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -420,14 +420,13 @@ def nice_size(size):
 def slippymap_preview_url(runstate):
     '''
     '''
-    print(runstate)
     if runstate.run_id:
-        run_id = str(runstate.run_id)
+        run_id = runstate.run_id
 
     elif runstate.slippymap:
         # Old hack-ass way to get the run ID
         parsed_url = urlparse(runstate.slippymap)
-        run_id = os.path.basename(os.path.dirname(parsed_url.path))
+        run_id = int(os.path.basename(os.path.dirname(parsed_url.path)))
 
     else:
         raise ValueError()

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -11,6 +11,7 @@ from dateutil.tz import tzutc
 from csv import DictWriter
 import json, os, base64
 import hashlib, hmac, time
+import traceback
 
 import memcache, requests, psycopg2
 from jinja2 import Environment, FileSystemLoader
@@ -420,18 +421,22 @@ def nice_size(size):
 def slippymap_preview_url(runstate):
     '''
     '''
-    if runstate.run_id:
-        run_id = runstate.run_id
+    try:
+        if runstate.run_id:
+            run_id = runstate.run_id
 
-    elif runstate.slippymap:
-        # Old hack-ass way to get the run ID
-        parsed_url = urlparse(runstate.slippymap)
-        run_id = int(os.path.basename(os.path.dirname(parsed_url.path)))
+        elif runstate.slippymap:
+            # Old hack-ass way to get the run ID
+            parsed_url = urlparse(runstate.slippymap)
+            run_id = int(os.path.basename(os.path.dirname(parsed_url.path)))
 
-    else:
-        raise ValueError()
+        else:
+            raise ValueError()
 
-    return url_for('dots.dotmap_preview', run_id=run_id)
+        return url_for('dots.dotmap_preview', run_id=run_id)
+    except Exception as e:
+        traceback.print_exc()
+        raise
 
 def apply_webhooks_blueprint(app):
     '''

--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -213,8 +213,7 @@ def app_get_job(job_id):
     job = dict(status=job.status, task_files=ordered_files, file_states=job.states,
                file_results=job.file_results, github_status_url=job.github_status_url)
 
-    return render_template('job.html', job=job,
-                           dotmaps_base_url=current_app.config['DOTMAPS_BASE_URL'])
+    return render_template('job.html', job=job)
 
 @webhooks.route('/sets/', methods=['GET'])
 @log_application_errors
@@ -432,7 +431,7 @@ def slippymap_preview_url(runstate):
     else:
         raise ValueError()
 
-    return urljoin(current_app.config['DOTMAPS_BASE_URL'], run_id)
+    return url_for('dots.dotmap_preview', run_id=run_id)
 
 def apply_webhooks_blueprint(app):
     '''

--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -6,16 +6,13 @@ import logging; _L = logging.getLogger('openaddr.conform')
 import os
 import errno
 import tempfile
-import itertools
 import mimetypes
 import json
 import copy
-import sys
 import csv
 import re
 
 from zipfile import ZipFile
-from argparse import ArgumentParser
 from locale import getpreferredencoding
 from os.path import splitext
 from hashlib import sha1
@@ -335,7 +332,7 @@ class ExcerptDataTask(object):
             data_path = ExcerptDataTask._sample_geojson_file(data_path)
 
         format_string = conform.get('format')
-    
+
         # GDAL has issues with weird input CSV data, so use Python instead.
         if format_string == 'csv':
             return ExcerptDataTask._excerpt_csv_file(data_path, encoding, csvsplit)
@@ -380,7 +377,7 @@ class ExcerptDataTask(object):
     @staticmethod
     def _get_known_paths(source_paths, workdir, conform, known_types):
         format_string = conform.get('format')
-    
+
         if format_string != 'csv' or 'file' not in conform:
             paths = [source_path for source_path in source_paths
                      if os.path.splitext(source_path)[1].lower() in known_types]
@@ -482,7 +479,7 @@ def find_source_path(source_definition, source_paths):
 
     format_string = conform.get('format')
     protocol_string = source_definition.get('protocol')
-    
+
     if format_string in ("shapefile", "shapefile-polygon"):
         # TODO this code is too complicated; see XML variant below for simpler option
         # Shapefiles are named *.shp
@@ -800,7 +797,7 @@ def csv_source_to_csv(source_definition, source_path, dest_path):
         num_fields = len(reader.fieldnames)
 
         protocol_string = source_definition['protocol']
-    
+
         # Construct headers for the extracted CSV file
         if protocol_string == "ESRI":
             # ESRI sources: just copy what the downloader gave us. (Already has OA:x and OA:y)
@@ -878,7 +875,7 @@ def row_extract_and_reproject(source_definition, source_row):
     '''
     format_string = source_definition["conform"].get('format')
     protocol_string = source_definition['protocol']
-    
+
     # Ignore any lat/lon names for natively geographic sources.
     ignore_conform_names = bool(format_string != 'csv')
 
@@ -1265,7 +1262,7 @@ def extract_to_source_csv(source_definition, source_path, extract_path):
     """
     format_string = source_definition["conform"]['format']
     protocol_string = source_definition['protocol']
-    
+
     if format_string in ("shapefile", "shapefile-polygon", "xml", "gdb"):
         ogr_source_path = normalize_ogr_filename_case(source_path)
         ogr_source_to_csv(source_definition, ogr_source_path, extract_path)
@@ -1313,7 +1310,7 @@ def conform_cli(source_definition, source_path, dest_path):
         return 1
 
     format_string = source_definition["conform"].get('format')
-    
+
     if not format_string in ["shapefile", "shapefile-polygon", "geojson", "csv", "xml", "gdb"]:
         _L.warning("Skipping file with unknown conform: %s", source_path)
         return 1

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -1240,7 +1240,6 @@ class TestHook (unittest.TestCase):
         os.environ['WEBHOOK_SECRETS'] = 'hello,world'
         os.environ['AWS_ACCESS_KEY_ID'] = '12345'
         os.environ['AWS_SECRET_ACCESS_KEY'] = '67890'
-        os.environ['DOTMAPS_BASE_URL'] = 'https://dotmaps.example.com/yo/'
 
         self.app = Flask(__name__)
         self.app.config.update(load_config(), MINIMUM_LOGLEVEL=logging.CRITICAL)

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2285,19 +2285,20 @@ class TestHook (unittest.TestCase):
 
         got2 = self.client.get('/jobs/abc')
         body2 = got2.data.decode('utf8')
+        print(body2)
         self.assertEqual(got2.status_code, 200)
 
         self.assertIn('http://example.com/998/log.txt', body2)
         self.assertIn('http://example.com/998/sample.json', body2)
         self.assertIn('http://example.com/998/stuff.zip', body2)
         self.assertIn('http://example.com/998/preview.png', body2)
-        self.assertIn('https://dotmaps.example.com/yo/998', body2)
+        self.assertIn('/998/dotmaps/index.html', body2)
 
         self.assertIn('http://example.com/999/log.txt', body2)
         self.assertIn('http://example.com/999/sample.json', body2)
         self.assertIn('http://example.com/999/stuff.zip', body2)
         self.assertIn('http://example.com/999/preview.png', body2)
-        self.assertIn('https://dotmaps.example.com/yo/999', body2)
+        self.assertIn('/998/dotmaps/index.html', body2)
 
 class TestRuns (unittest.TestCase):
 

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -58,6 +58,7 @@ from ..ci.tileindex import (
 from ..jobs import JOB_TIMEOUT
 from ..ci.work import make_source_filename, assemble_runstate, MAGIC_OK_MESSAGE
 from ..ci.webhooks import apply_webhooks_blueprint
+from ..ci.webdotmap import apply_dotmap_blueprint
 from ..ci.webapi import apply_webapi_blueprint
 from .. import LocalProcessedResult
 from . import FakeS3
@@ -1244,6 +1245,7 @@ class TestHook (unittest.TestCase):
         self.app = Flask(__name__)
         self.app.config.update(load_config(), MINIMUM_LOGLEVEL=logging.CRITICAL)
         apply_webhooks_blueprint(self.app)
+        apply_dotmap_blueprint(self.app)
         webcoverage.apply_coverage_blueprint(self.app)
 
         recreate_db.recreate(self.app.config['DATABASE_URL'])

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2285,7 +2285,6 @@ class TestHook (unittest.TestCase):
 
         got2 = self.client.get('/jobs/abc')
         body2 = got2.data.decode('utf8')
-        print(body2)
         self.assertEqual(got2.status_code, 200)
 
         self.assertIn('http://example.com/998/log.txt', body2)

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -2293,13 +2293,13 @@ class TestHook (unittest.TestCase):
         self.assertIn('http://example.com/998/sample.json', body2)
         self.assertIn('http://example.com/998/stuff.zip', body2)
         self.assertIn('http://example.com/998/preview.png', body2)
-        self.assertIn('/998/dotmaps/index.html', body2)
+        self.assertIn('/runs/998/dotmap/index.html', body2)
 
         self.assertIn('http://example.com/999/log.txt', body2)
         self.assertIn('http://example.com/999/sample.json', body2)
         self.assertIn('http://example.com/999/stuff.zip', body2)
         self.assertIn('http://example.com/999/preview.png', body2)
-        self.assertIn('/998/dotmaps/index.html', body2)
+        self.assertIn('/runs/999/dotmap/index.html', body2)
 
 class TestRuns (unittest.TestCase):
 

--- a/openaddr/util/__init__.py
+++ b/openaddr/util/__init__.py
@@ -6,11 +6,14 @@ from os.path import join, basename, splitext, dirname, exists
 from operator import attrgetter
 from tempfile import mkstemp
 from os import close, getpid
-import glob, collections
-import ftplib, httmock
-import io, zipfile
-import json, time
-import shlex, re
+import glob
+import collections
+import ftplib
+import httmock
+import io
+import zipfile
+import time
+import re
 
 RESOURCE_LOG_INTERVAL = timedelta(seconds=30)
 RESOURCE_LOG_FORMAT = 'Resource usage: {{ user: {user:.0f}%, system: {system:.0f}%, ' \

--- a/setup.py
+++ b/setup.py
@@ -70,11 +70,11 @@ setup(
         # http://flask-cors.corydolphin.com
         'Flask-Cors == 3.0.8',
 
-        # https://www.palletsproject.com/projects/werkzeug/
-        'Werkzeug == 0.15.6',
+        # https://www.palletsprojects.com/p/werkzeug/
+        'Werkzeug == 0.16.0',
 
         # http://gunicorn.org
-        'gunicorn == 19.9.0',
+        'gunicorn == 19.10.0',
 
         # http://www.voidspace.org.uk/python/mock/
         'mock == 3.0.5',
@@ -86,7 +86,7 @@ setup(
         'pq == 1.8.1',
 
         # http://initd.org/psycopg/
-        'psycopg2 == 2.8.3',
+        'psycopg2-binary == 2.8.4',
 
         # http://docs.python-requests.org/en/master/
         'requests == 2.22.0',
@@ -95,14 +95,18 @@ setup(
         'httmock == 1.3.0',
 
         # https://boto3.readthedocs.org
-        'boto3 == 1.9.180',
+        'boto3 == 1.11.5',
 
         # https://github.com/openaddresses/pyesridump
         'esridump == 1.6.0',
 
         # Used in openaddr.parcels
-        'Shapely == 1.5.17',
-        'Fiona == 1.7.0.post2',
+        'Shapely == 1.7b1',
+        'Fiona == 1.8.13',
+
+        # Used in dotmaps preview to support S3-backed SQLite mbtiles
+        # https://rogerbinns.github.io/apsw/
+        'apsw == 3.9.2.post1',
 
         # http://pythonhosted.org/itsdangerous/
         'itsdangerous == 1.1.0',


### PR DESCRIPTION
This uses a Python SQLite library called apsw that supports virtual filesystems. It also implements an S3-backed filesystem that makes calls to the CI-built mbtiles files.

Since the S3-backed filesystem is making a ton of calls out to S3 (it's reading 1KB blocks at a time basically), I used the memcache client to help alleviate some of the S3 calls. I'd still like to figure out how to grab bigger chunks of the S3 file and warm the cache more, but this is "good enough" for now. There's also memcache caching for the tiles themselves and I also tell the browser to cache the responses for a year to try reducing calls in the first place.