### PR TITLE
Handle the case where none of the runs are processed

### DIFF
--- a/openaddr/ci/webhooks.py
+++ b/openaddr/ci/webhooks.py
@@ -120,7 +120,10 @@ def app_index():
 
     if runs:
         good_runs = [run for run in runs if (run.state or {}).get('processed')]
-        last_modified = sorted(good_runs, key=attrgetter('datetime_tz'))[-1].datetime_tz
+
+        # It's possible for none of the reults to be processed
+        if good_runs:
+            last_modified = sorted(good_runs, key=attrgetter('datetime_tz'))[-1].datetime_tz
 
     mc = get_memcache_client(current_app.config)
     summary_data = summarize_runs(mc, good_runs, last_modified, set and set.owner,


### PR DESCRIPTION
This is a bug that resulted from switching over to the V2 schema. The workers couldn't process the sources, but inserted entries into the database with `processed` left null. This caused the `good_runs` list to be empty and to get an exception on these lines.

e.g.

```python
Traceback (most recent call last):
 File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 2446, in wsgi_app
   response = self.full_dispatch_request()
 File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1951, in full_dispatch_request
   rv = self.handle_user_exception(e)
 File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1820, in handle_user_exception
   reraise(exc_type, exc_value, tb)
 File "/usr/local/lib/python3.5/dist-packages/flask/_compat.py", line 39, in reraise
   raise value
 File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1949, in full_dispatch_request
   rv = self.dispatch_request()
 File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1935, in dispatch_request
   return self.view_functions[rule.endpoint](**req.view_args)
 File "/usr/local/lib/python3.5/dist-packages/openaddr/ci/webcommon.py", line 19, in decorated_function
   return route_function(*args, **kwargs)
 File "/usr/local/lib/python3.5/dist-packages/openaddr/ci/webcommon.py", line 40, in decorated_function
   result = route_function(*args, **kwargs)
 File "/usr/local/lib/python3.5/dist-packages/openaddr/ci/webhooks.py", line 123, in app_index
   last_modified = sorted(good_runs, key=attrgetter('datetime_tz'))[-1].datetime_tz
IndexError: list index out of range
```