### PR TITLE
Basic support for v2 sources in machine

### DIFF
--- a/openaddr/ci/work.py
+++ b/openaddr/ci/work.py
@@ -106,6 +106,10 @@ def do_work(s3, run_id, source_name, job_contents_b64, render_preview, output_di
     else:
         cmd += ('--skip-preview', )
 
+    # For now, assume 'addresses' layer for V2 sources
+    cmd += ('--layer', 'addresses')
+    cmd += ('--layersource', 'primary')
+
     try:
         known_error, cmd_status = False, 0
         timeout_seconds = JOB_TIMEOUT.seconds + JOB_TIMEOUT.days * 86400

--- a/openaddr/process_one.py
+++ b/openaddr/process_one.py
@@ -88,15 +88,10 @@ def process(source, destination, layer, layersource, do_preview, mapbox_key=None
                     layer = 'addresses'
                     layersource = 'primary'
 
-                if type(layer) is not str:
-                    layer = ''
-                if type(layersource) is not str:
-                    layersource = ''
-
-                if len(layer) == 0:
+                if not layer:
                     _L.error('explicit --layer arg is required for v2 sources')
                     raise ValueError('explicit --layer arg is required for v2 sources')
-                elif len(layersource) == 0:
+                if not layersource:
                     _L.error('explicit --layersource arg is required for v2 sources')
                     raise ValueError('explicit --layersource arg is required for v2 sources')
 

--- a/openaddr/tests/ci.py
+++ b/openaddr/tests/ci.py
@@ -3072,7 +3072,9 @@ class TestWorker (unittest.TestCase):
             os.path.join(self.output_dir, u'work/so--exalté.txt'),
             os.path.join(self.output_dir, 'work/out'),
             '--render-preview',
-            '--mapbox-key', 'mapbox-XXXX'
+            '--mapbox-key', 'mapbox-XXXX',
+            '--layer', 'addresses',
+            '--layersource', 'primary',
             ))
 
         self.assertEqual(check_output.mock_calls[-1][2]['timeout'],
@@ -3130,7 +3132,9 @@ class TestWorker (unittest.TestCase):
             os.path.join(self.output_dir, 'work/logfile.txt'),
             os.path.join(self.output_dir, 'work/angry.txt'),
             os.path.join(self.output_dir, 'work/out'),
-            '--skip-preview'
+            '--skip-preview',
+            '--layer', 'addresses',
+            '--layersource', 'primary',
             ))
 
         self.assertEqual(check_output.mock_calls[-1][2]['timeout'],
@@ -3176,7 +3180,9 @@ class TestWorker (unittest.TestCase):
             os.path.join(self.output_dir, u'work/so--exalté.txt'),
             os.path.join(self.output_dir, 'work/out'),
             '--render-preview',
-            '--mapbox-key', 'mapbox-XXXX'
+            '--mapbox-key', 'mapbox-XXXX',
+            '--layer', 'addresses',
+            '--layersource', 'primary',
             ))
 
         self.assertEqual(check_output.mock_calls[-1][2]['timeout'],


### PR DESCRIPTION
Machine already supported V2 sources since #691, but it only made assumptions about the V2 `layer` and `layersource` it should use when the sources were still V1. When we switched sources to V2 schema in https://github.com/openaddresses/openaddresses/pull/5165, `process-one` stopped making the assumption for layer and layersource and started failing instead.

This PR changes the logic for the CI worker to default to layer `addresses` and layersource `primary`.