### PR TITLE
Changed mistaken key value for get function

### DIFF
--- a/openaddr/conform.py
+++ b/openaddr/conform.py
@@ -966,7 +966,7 @@ def row_function(sd, row, key, fxn):
         row = row_fxn_chain(sd, row, key, fxn)
     elif function == "first_non_empty":
         row = row_fxn_first_non_empty(sd, row, key, fxn)
-    elif function == "get_from_array_string":
+    elif function == "get":
         row = row_fxn_get_from_array_string(sd, row, key, fxn)
 
     return row


### PR DESCRIPTION
According to the documentation 

https://github.com/openaddresses/openaddresses/blob/master/ATTRIBUTE_FUNCTIONS.md

we should use "get" function name. I hope it's going to work this time...