### PR TITLE
Add Deployed Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Scripts for running OpenAddresses on a complete data set and publishing
 the results. Uses [OpenAddresses](https://github.com/openaddresses/openaddresses)
 data sources to work.
 
+
+
 Status
 ------
 
@@ -34,6 +36,6 @@ files, maps, and other resources available via [results.openaddresses.io](https:
 Development
 -----------
 
-[Documentation for Machine internals](docs/README.md) can help point you in the
-right direction for development. Follow the [installation instructions](docs/install.md)
+[Documentation for Machine internals](https://docs.contour.so/openaddresses/machine) can help point you in the
+right direction for development. Follow the [installation instructions](https://docs.contour.so/openaddresses/machine/manual-2oq7vh5jlns0000000000)
 to use and modify Machine code locally.


### PR DESCRIPTION
Hi,

I found the documentation a little difficult to navigate, so I deployed a version that is more easily editable and readable. I'm not sure how helpful it is, but you can check out the docs [here](https://docs.contour.so/openaddresses/machine).

Hopefully it's useful and that it helps people understand how to use machine better 😸

Please feel free to let me know what you think! And you can make edits to what's already there by dragging the sidebar or clicking edit.