### PR TITLE
Attempt a workaround for a Ubuntu Python packaging bug

### DIFF
--- a/Dockerfile-prereqs
+++ b/Dockerfile-prereqs
@@ -16,6 +16,10 @@ RUN apt-get update -y && \
         gdal-bin=2.1.3+dfsg-1~xenial2 libgdal-dev=2.1.3+dfsg-1~xenial2 && \
     apt-get install -y git build-essential libsqlite3-dev protobuf-compiler libprotobuf-dev
 
+# Workaround for https://github.com/pypa/setuptools/issues/2541
+ENV PYTHONWARNINGS=ignore:DEPRECATION
+RUN pip3 install --upgrade 'pip<21' 'setuptools<51'
+
 # Download and install Tippecanoe.
 RUN git clone -b 1.34.3 https://github.com/mapbox/tippecanoe.git /tmp/tippecanoe && \
     cd /tmp/tippecanoe && \


### PR DESCRIPTION
The CI build is failing because of a SyntaxError. I tracked it down to https://github.com/pypa/setuptools/issues/2541. This is an attempt to use one of the workarounds mentioned there.